### PR TITLE
It's alive

### DIFF
--- a/terraform/dev/main.tf
+++ b/terraform/dev/main.tf
@@ -17,6 +17,7 @@ module "puller-flickr" {
     ecs_cluster_min_size = 2
     ecs_cluster_max_size = 2
     ecs_instances_desired_count = 2
-    ecs_instances_memory = 500
+    ecs_instances_memory = 256
     ecs_instances_cpu = 1
+    ecs_instances_log_retention_days = 7
 }

--- a/terraform/modules/elastic-container-service/cluster.tf
+++ b/terraform/modules/elastic-container-service/cluster.tf
@@ -11,7 +11,7 @@ resource "aws_launch_configuration" "ecs-launch-configuration" {
 
     root_block_device {
         volume_type = "standard"
-        volume_size = 100
+        volume_size = 30
         delete_on_termination = true
     }
 

--- a/terraform/modules/elastic-container-service/instance-role.tf
+++ b/terraform/modules/elastic-container-service/instance-role.tf
@@ -6,7 +6,9 @@ resource "aws_iam_role" "ecs-instance-role" {
 
 data "aws_iam_policy_document" "ecs-instance-policy" {
     statement {
-        actions = ["sts:AssumeRole"]
+        actions = [
+            "sts:AssumeRole"
+        ]
 
         principals {
             type        = "Service"

--- a/terraform/modules/elastic-container-service/variables.tf
+++ b/terraform/modules/elastic-container-service/variables.tf
@@ -10,3 +10,4 @@ variable "local_machine_public_key" {}
 variable "instances_desired_count" {}
 variable "instances_memory" {}
 variable "instances_cpu" {}
+variable "instances_log_retention_days" {}

--- a/terraform/modules/puller-flickr/elastic-container-service.tf
+++ b/terraform/modules/puller-flickr/elastic-container-service.tf
@@ -17,4 +17,5 @@ module "elastic-container-service" {
     instances_desired_count = "${var.ecs_instances_desired_count}"
     instances_memory = "${var.ecs_instances_memory}"
     instances_cpu = "${var.ecs_instances_cpu}"
+    instances_log_retention_days = "${var.ecs_instances_log_retention_days}"
 }

--- a/terraform/modules/puller-flickr/variables.tf
+++ b/terraform/modules/puller-flickr/variables.tf
@@ -13,3 +13,4 @@ variable "local_machine_public_key" {}
 variable "ecs_instances_desired_count" {}
 variable "ecs_instances_memory" {}
 variable "ecs_instances_cpu" {}
+variable "ecs_instances_log_retention_days" {}


### PR DESCRIPTION
Got puller-flickr running on ECS:
- Adjusted memory limit to fit within t2.micro container
- Reduced size of EBS volume to minimum for ECS image
- Pointed to correct ERC repository
- Added support for CloudWatch logs