### PR TITLE
Have puller-flickr read its config from the AWS Parameter Store

### DIFF
--- a/README.md
+++ b/README.md
@@ -71,21 +71,22 @@ Install the AWS CLI: https://docs.aws.amazon.com/cli/latest/userguide/install-bu
 
 Copy `terraform/aws_credentials` to `~/.aws/credentials`
 
+Log into your docker repository:
+
+```
+eval "$(aws ecr get-login --no-include-email --region us-west-2)"
+```
+
+Then build and push your image:
+
 ```
 docker build ../../puller-flickr
-docker tag puller-flickr <URI of puller-flickr-dev repository in ECR: use AWS console to find>
-aws ecr get-login --region us-west-2
-```
-
-Copy the output of the last command to log into the ECR repository (it may need some minor modification if you get an error message such as `unknown shorthand flag: 'e' in -e`)
-
-```
+docker images
+docker tag <ID of image you just built> <URI of puller-flickr-dev repository in ECR: use AWS console to find>
 docker push <URI of puller-flicker-dev repository in ECR>
 ```
 
 TODO:
 
-- Move config over to AWS Parameter Store
-- Autofill the elasticache endpoint/port into the appropriate parameter
 - Have ECS running in > 1 availability zone (see examples in the links in the README in the elastic-container-service module)
 - Make a build pipeline

--- a/README.md
+++ b/README.md
@@ -32,8 +32,6 @@ First we need to create the infrastructure that the various parts of the system 
 brew install terraform
 ```
 
-
-
 ### Create an AWS account
 
 Go to https://aws.amazon.com/ and click on "Create an AWS Account"
@@ -46,6 +44,8 @@ Copy the file `terraform/aws_credentials.example` to `terraform/aws_credentials`
 Copy the file `terraform/terraform.tfvars.example` to `terraform/terraform.tfvars` 
 - Enter the CIDR of your local machine/network
 - Copy your ssh public key (contained in `~/.ssh/id_rsa.pub`. If that file doesn't exist, run `ssh-keygen -t rsa` to generate it)
+- Fill in your Flickr API key and secret: https://www.flickr.com/services/apps/create/apply
+- Fill in your numerical Flickr user ID. You may need to get your numerical ID from: http://idgettr.com/
 
 ### Run terraform
 

--- a/puller-flickr/Dockerfile
+++ b/puller-flickr/Dockerfile
@@ -1,9 +1,8 @@
 FROM python:3
 ADD puller-flickr.py /
 ADD flickrapiwrapper.py /
-ADD config/config.ini /config/
-ADD config/secrets.ini /config/
 RUN pip install flickrapi
 RUN pip install python-memcached
 RUN pip install django
-CMD [ "python", "./puller-flickr.py", "-o test.html" ]
+RUN pip install boto3
+CMD [ "python", "./puller-flickr.py", "-d" ]

--- a/puller-flickr/config/config.ini
+++ b/puller-flickr/config/config.ini
@@ -6,12 +6,9 @@ flickr.api.retries=3
 flickr.api.favorites.maxpercall=500
 flickr.api.favorites.maxtoget=1000
 
-results.numphotos=50
-results.numneighbours=10
-
 memcached.location=puller-flickr-dev.j94z7t.cfg.usw2.cache.amazonaws.com:11211
 memcached.ttl=7200 
 
-[prod]
+[dev]
 
 flickr.api.key=236d0914f5c9cb19088e332fc33685b8

--- a/puller-flickr/config/secrets.ini.example
+++ b/puller-flickr/config/secrets.ini.example
@@ -2,6 +2,6 @@
 
 flickr.api.secret=
 
-[prod]
+[dev]
 
 flickr.api.secret=

--- a/puller-flickr/puller-flickr.py
+++ b/puller-flickr/puller-flickr.py
@@ -2,23 +2,16 @@
 
 import configparser
 from flickrapiwrapper import FlickrApiWrapper
-import math
 import argparse
 import logging
-
-ENVIRONMENT = "prod"
-
-def get_neighbor_score(total_favorites, common_favorites):
-    # Took this formula from https://www.flickr.com/groups/709526@N23/discuss/72157604460161681/72157604455830572
-    return 150 * math.sqrt(common_favorites / (total_favorites + 250))
+import os
+import boto3
 
 # Read in commandline arguments
 
-parser = argparse.ArgumentParser(description="Recommend Flickr photos based on your favorites")
+parser = argparse.ArgumentParser(description="Pull favorites data from Flickr and send it to Kafka")
 
 parser.add_argument("-d", "--debug", action="store_true", dest="debug", default=False, help="Display debug information")
-required_arguments = parser.add_argument_group('required arguments')
-required_arguments.add_argument("-o", "--output-file", dest="output_filename", type=str, help="HTML file to output", required=True)
 
 args = parser.parse_args()
 
@@ -28,120 +21,53 @@ if args.debug:
 
 logging.basicConfig(format='%(levelname)s: %(message)s', level=log_level)
 
-# Read in config
+# Get our config
 
-config = configparser.ConfigParser()
+flickr_api_key                      = None
+flickr_api_secret                   = None
+flickr_api_retries                  = None
+flickr_api_max_favorites_per_call   = None
+flickr_api_max_favorites_to_get     = None
+flickr_user_id                      = None
+memcached_location                  = None
+memcached_ttl                       = None
 
-config.read("config/config.ini")
-config.read("config/secrets.ini")
+if not "ENVIRONMENT" in os.environ:
+    logging.info("Did not find ENVIRONMENT environment variable, running in development mode and loading config from config files.")
 
-flickr_api_key                      = config.get(ENVIRONMENT, "flickr.api.key")
-flickr_api_secret                   = config.get(ENVIRONMENT, "flickr.api.secret")
-flickr_api_retries                  = config.getint(ENVIRONMENT, "flickr.api.retries") 
-flickr_api_max_favorites_per_call   = config.getint(ENVIRONMENT, "flickr.api.favorites.maxpercall")
-flickr_api_max_favorites_to_get     = config.getint(ENVIRONMENT, "flickr.api.favorites.maxtoget")
-flickr_user_id                      = config.get(ENVIRONMENT, "flickr.user.id")
-num_photo_results                   = config.getint(ENVIRONMENT, "results.numphotos")
-num_neighbour_results               = config.getint(ENVIRONMENT, "results.numneighbours")
-memcached_location                  = config.get(ENVIRONMENT, "memcached.location")
-memcached_ttl                       = config.getint(ENVIRONMENT, "memcached.ttl")
+    CONFIG_FILE_ENVIRONMENT = "dev"
 
-flickrapi = FlickrApiWrapper(flickr_api_key, flickr_api_secret, memcached_location, memcached_ttl, flickr_api_retries)
+    config = configparser.ConfigParser()
 
-# To locate photos that the user may find interesting, we first build a set of "neighbors" to this user.
-# A "neighbor" is someone who took a photo that the user favorited.
-# We will then assign a score to each of these neighbors, and use those scores to assign scores to their favorite photos.
-# The highest-scored of these photos will be shown to the original user.
+    config.read("config/config.ini")
+    config.read("config/secrets.ini")
 
-logging.info("Getting my favourites")
+    flickr_api_key                      = config.get(CONFIG_FILE_ENVIRONMENT, "flickr.api.key")
+    flickr_api_secret                   = config.get(CONFIG_FILE_ENVIRONMENT, "flickr.api.secret")
+    flickr_api_retries                  = config.getint(CONFIG_FILE_ENVIRONMENT, "flickr.api.retries") 
+    flickr_api_max_favorites_per_call   = config.getint(CONFIG_FILE_ENVIRONMENT, "flickr.api.favorites.maxpercall")
+    flickr_api_max_favorites_to_get     = config.getint(CONFIG_FILE_ENVIRONMENT, "flickr.api.favorites.maxtoget")
+    flickr_user_id                      = config.get(CONFIG_FILE_ENVIRONMENT, "flickr.user.id")
+    memcached_location                  = config.get(CONFIG_FILE_ENVIRONMENT, "memcached.location")
+    memcached_ttl                       = config.getint(CONFIG_FILE_ENVIRONMENT, "memcached.ttl")
 
-my_favorites = flickrapi.get_favorites(flickr_user_id, flickr_api_max_favorites_per_call, flickr_api_max_favorites_to_get)
-my_favorite_ids = set()
-all_neighbor_favorite_photo_ids = {}
+else:
+    ENVIRONMENT = os.environ.get('ENVIRONMENT')
 
-my_neighbors = {}
+    logging.info("Found ENVIRONMENT environment variable containing '%s': assuming we're running in AWS and getting our parameters from the AWS Parameter Store" % (ENVIRONMENT))
 
-for photo in my_favorites:
-    logging.debug("Found favourite photo ", photo)
-    my_favorite_ids.add(photo['id'])
-    if photo['owner'] not in my_neighbors:
-        my_neighbors[photo['owner']] = { 'user_id': photo['owner'] }
+    ssm = boto3.client('ssm')
 
-logging.debug("Found neighbors: ", my_neighbors)
+    flickr_api_key                      = ssm.get_parameter(Name='/%s/puller-flickr/flickr-api-key'                         % ENVIRONMENT)['Parameter']['Value']
+    flickr_api_secret                   = ssm.get_parameter(Name='/%s/puller-flickr/flickr-secret-key'                      % ENVIRONMENT, WithDecryption=True)['Parameter']['Value']
+    flickr_api_retries                  = int(ssm.get_parameter(Name='/%s/puller-flickr/flickr-api-retries'                 % ENVIRONMENT)['Parameter']['Value'])
+    flickr_api_max_favorites_per_call   = int(ssm.get_parameter(Name='/%s/puller-flickr/flickr-api-favorites-max-per-call'  % ENVIRONMENT)['Parameter']['Value'])
+    flickr_api_max_favorites_to_get     = int(ssm.get_parameter(Name='/%s/puller-flickr/flickr-api-favorites-max-to-get'    % ENVIRONMENT)['Parameter']['Value'])
+    flickr_user_id                      = ssm.get_parameter(Name='/%s/puller-flickr/flickr-user-id'                         % ENVIRONMENT)['Parameter']['Value']
+    memcached_location                  = ssm.get_parameter(Name='/%s/puller-flickr/memcached-location'                     % ENVIRONMENT)['Parameter']['Value']
+    memcached_ttl                       = int(ssm.get_parameter(Name='/%s/puller-flickr/memcached-ttl'                      % ENVIRONMENT)['Parameter']['Value'])
 
-# To calculate the score of each neighbour we need to know its favourites
-
-for neighbor_id in my_neighbors:
-
-    my_neighbors[neighbor_id]['favorite_ids'] = set()
-
-    logging.info("Getting favorites of neighbor %s" % (my_neighbors[neighbor_id]['user_id']))
-
-    neighbor_favorites = flickrapi.get_favorites(my_neighbors[neighbor_id]['user_id'], flickr_api_max_favorites_per_call, flickr_api_max_favorites_to_get)
-
-    for photo in neighbor_favorites:
-        logging.debug("Found neighbor favourite photo ", photo)
-
-        my_neighbors[neighbor_id]['favorite_ids'].add(photo['id'])
-        all_neighbor_favorite_photo_ids[photo['id']] = { 'score': 0, 'image_url': photo.get('url_l', photo.get('url_m', '')), 'id': photo['id'], 'user': photo['owner'] }
-
-# Now we can get the total number of favorites for each neighbor, as well as the number of favorites in common with us
-
-for neighbor_id in my_neighbors:
-    my_neighbors[neighbor_id]['total_favorites']    = len(my_neighbors[neighbor_id]['favorite_ids'])   
-    my_neighbors[neighbor_id]['common_favorites']   = len(my_neighbors[neighbor_id]['favorite_ids'] & my_favorite_ids)
-    my_neighbors[neighbor_id]['score']              = get_neighbor_score(my_neighbors[neighbor_id]['total_favorites'], my_neighbors[neighbor_id]['common_favorites'])
-    logging.info("Neighbor %s has %d total favorites and %d in common with me for a score of %f" % (neighbor_id, my_neighbors[neighbor_id]['total_favorites'], my_neighbors[neighbor_id]['common_favorites'], my_neighbors[neighbor_id]['score']))
-
-# And last we can go through all of our neighbors' favorites and score them
-# The score of a photo is the sum of the scores of all the neighbors who favorited it.
-# Taken from https://www.flickr.com/groups/709526@N23/discuss/72157604460161681/72157604455830572
-
-for photoId in all_neighbor_favorite_photo_ids:
-    score = 0
-    if photoId not in my_favorite_ids: # Don't recommend photos to me that I already like
-        for neighbor_id in my_neighbors:
-            if photoId in my_neighbors[neighbor_id]['favorite_ids']:
-                score += my_neighbors[neighbor_id]['score']
-    all_neighbor_favorite_photo_ids[photoId]['score'] = score
-
-sorted_neighbor_favorite_photo_ids = sorted(all_neighbor_favorite_photo_ids.items(), key=lambda x: x[1]['score'], reverse=True)
-
-# The result is a list of tuples where the first element is the photo ID, and the second element is a dictionary of score and url
-
-# Similarly, we sort our neighbors themselves by their score
-
-sorted_neighbors = sorted(my_neighbors.items(), key=lambda x: x[1]['score'], reverse=True)
-
-# Get some info about each of our top users
-
-for neighbor in sorted_neighbors[0:num_neighbour_results]:
-    neighbor_info = flickrapi.get_person_info(neighbor[1]['user_id'])
-    neighbor[1]['name'] = neighbor_info['person']['username']['_content']
-    neighbor[1]['photostream_url'] = neighbor_info['person']['photosurl']['_content']
-    neighbor[1]['favorites_url'] = '%sfavorites' % neighbor[1]['photostream_url']
-    
-    # Construct a link to their buddy icon according to these rules: https://www.flickr.com/services/api/misc.buddyicons.html
-    neighbor[1]['buddy_icon'] = 'https://www.flickr.com/images/buddyicon.gif'
-
-    icon_server = int(neighbor_info['person']['iconserver'])
-    if icon_server > 0:
-        neighbor[1]['buddy_icon'] = 'http://farm%d.staticflickr.com/%d/buddyicons/%s.jpg' % (neighbor_info['person']['iconfarm'], icon_server, neighbor_info['person']['nsid'])
-    
-# Write out our final file
-
-f = open(args.output_filename, "w+")
-
-f.write("<h1>Photos you may like</h1>\n")
-
-for photo in sorted_neighbor_favorite_photo_ids[0:num_photo_results]:
-    f.write("<a href=https://www.flickr.com/photos/%s/%s/><img src=%s/></a><br/>\n" % (photo[1]['user'], photo[1]['id'], photo[1]['image_url']))
-
-f.write("<h1>Other users you may like</h1>\n")
-
-for neighbor in sorted_neighbors[0:num_neighbour_results]:
-    f.write("<img src=%s/>%s - <a href=%s>Photos</a> - <a href=%s>Favorites</a><br/>\n" % (neighbor[1]['buddy_icon'], neighbor[1]['name'], neighbor[1]['photostream_url'], neighbor[1]['favorites_url']))
-
-f.close()
-
-logging.info("Finished writing output file %s" % (args.output_filename))
+    logging.info("Found flickr api key %s" % (flickr_api_key))
+    logging.info("Found flickr api secret %s" % (flickr_api_secret))
+    logging.info("Found memcached location %s" % (memcached_location))
+    logging.info("Found memcached ttl %d" % (memcached_ttl))

--- a/terraform/dev/main.tf
+++ b/terraform/dev/main.tf
@@ -14,10 +14,10 @@ module "puller-flickr" {
     local_machine_public_key = "${var.local_machine_public_key}"
 
     ecs_instance_type = "t2.micro"
-    ecs_cluster_desired_size = 2
-    ecs_cluster_min_size = 2
+    ecs_cluster_desired_size = 1
+    ecs_cluster_min_size = 1
     ecs_cluster_max_size = 2
-    ecs_instances_desired_count = 2
+    ecs_instances_desired_count = 1
     ecs_instances_memory = 256
     ecs_instances_cpu = 1
     ecs_instances_log_retention_days = 7

--- a/terraform/dev/main.tf
+++ b/terraform/dev/main.tf
@@ -8,6 +8,7 @@ module "puller-flickr" {
     memcached_node_type = "cache.t2.micro"
     memcached_num_cache_nodes = 2
     memcached_az_mode = "cross-az"
+    memcached_ttl = 7200
 
     local_machine_cidr = "${var.local_machine_cidr}"
     local_machine_public_key = "${var.local_machine_public_key}"
@@ -20,4 +21,11 @@ module "puller-flickr" {
     ecs_instances_memory = 256
     ecs_instances_cpu = 1
     ecs_instances_log_retention_days = 7
+
+    flickr_api_key = "${var.flickr_api_key}"
+    flickr_secret_key = "${var.flickr_secret_key}"
+    flickr_user_id = "${var.flickr_user_id}"
+    flickr_api_retries = 3
+    flickr_api_favorites_max_per_call = 500
+    flickr_api_favorites_max_to_get = 1000
 }

--- a/terraform/dev/variables.tf
+++ b/terraform/dev/variables.tf
@@ -3,3 +3,6 @@ variable "availability_zone" { default = "us-west-2a"}
 variable "environment" { default = "dev" }
 variable "local_machine_cidr" {}
 variable "local_machine_public_key" {}
+variable "flickr_api_key" {}
+variable "flickr_secret_key" {}
+variable "flickr_user_id" {}

--- a/terraform/modules/elastic-container-service/instance-role.tf
+++ b/terraform/modules/elastic-container-service/instance-role.tf
@@ -22,6 +22,12 @@ resource "aws_iam_role_policy_attachment" "ecs-instance-role-attachment" {
     policy_arn = "arn:aws:iam::aws:policy/service-role/AmazonEC2ContainerServiceforEC2Role"
 }
 
+# An extra policy specifically for the container that we're running: the extra stuff that this specific container needs to be able to do
+resource "aws_iam_role_policy_attachment" "attach-extra-policy" {
+    role       = "${aws_iam_role.ecs-instance-role.name}"
+    policy_arn = "${var.instances_extra_policy_arn}"
+}
+
 resource "aws_iam_instance_profile" "ecs-instance-profile" {
     name = "ecs-instance-profile-${var.cluster_name}"
     path = "/"

--- a/terraform/modules/elastic-container-service/task-definition.tf
+++ b/terraform/modules/elastic-container-service/task-definition.tf
@@ -3,7 +3,7 @@ data "aws_ecs_task_definition" "my_task" {
     task_definition = "${aws_ecs_task_definition.my_task.family}"
 }
 
-data "aws_caller_identity" "current" {
+data "aws_caller_identity" "ecs_task_definition" {
   
 }
 
@@ -21,7 +21,7 @@ resource "aws_kms_key" "logs" {
       "Sid" : "Enable IAM User Permissions",
       "Effect" : "Allow",
       "Principal" : {
-        "AWS" : "arn:aws:iam::${data.aws_caller_identity.current.account_id}:root"
+        "AWS" : "arn:aws:iam::${data.aws_caller_identity.ecs_task_definition.account_id}:root"
       },
       "Action" : "kms:*",
       "Resource" : "*"
@@ -61,10 +61,14 @@ resource "aws_ecs_task_definition" "my_task" {
 [
   {
     "name": "${var.cluster_name}",
-    "image": "${data.aws_caller_identity.current.account_id}.dkr.ecr.${var.region}.amazonaws.com/${var.cluster_name}:latest",
+    "image": "${data.aws_caller_identity.ecs_task_definition.account_id}.dkr.ecr.${var.region}.amazonaws.com/${var.cluster_name}:latest",
     "essential": true,
     "memory": ${var.instances_memory},
     "cpu": ${var.instances_cpu},
+    "environment": [
+      { "name": "ENVIRONMENT", "value": "${var.environment}" },
+      { "name": "AWS_DEFAULT_REGION", "value": "${var.region}" }
+    ],
     "logConfiguration": {
       "logDriver": "awslogs",
       "options": {

--- a/terraform/modules/elastic-container-service/task-definition.tf
+++ b/terraform/modules/elastic-container-service/task-definition.tf
@@ -7,9 +7,46 @@ data "aws_caller_identity" "current" {
   
 }
 
+# NOTE: See https://docs.aws.amazon.com/AmazonCloudWatch/latest/logs/encrypt-log-data-kms.html
+resource "aws_kms_key" "logs" {
+    description             = "Used to encrypt/decrypt logs"
+    key_usage               = "ENCRYPT_DECRYPT"
+    enable_key_rotation     = true
+    deletion_window_in_days = 30
+    policy              = <<POLICY
+{
+  "Version" : "2012-10-17",
+  "Id" : "key-default-1",
+  "Statement" : [ {
+      "Sid" : "Enable IAM User Permissions",
+      "Effect" : "Allow",
+      "Principal" : {
+        "AWS" : "arn:aws:iam::${data.aws_caller_identity.current.account_id}:root"
+      },
+      "Action" : "kms:*",
+      "Resource" : "*"
+    },
+    {
+      "Effect": "Allow",
+      "Principal": { "Service": "logs.${var.region}.amazonaws.com" },
+      "Action": [ 
+        "kms:Encrypt*",
+        "kms:Decrypt*",
+        "kms:ReEncrypt*",
+        "kms:GenerateDataKey*",
+        "kms:Describe*"
+      ],
+      "Resource": "*"
+    }  
+  ]
+}
+    POLICY
+}
+
 resource "aws_cloudwatch_log_group" "log_group" {
-  name = "${var.cluster_name}"
-  retention_in_days = "${var.instances_log_retention_days}"
+    name                = "${var.cluster_name}"
+    retention_in_days   = "${var.instances_log_retention_days}"
+    kms_key_id          = "${aws_kms_key.logs.arn}"
 }
 
 # NOTE: to debug issues with this JSON, try targetting this specific resource when running terraform. 
@@ -41,7 +78,7 @@ resource "aws_ecs_task_definition" "my_task" {
 ]
 DEFINITION
 
-    # Considering putting this in if we see this stuff getting rebuilt every run when we don't want to. 
+    # Consider putting this in if we see this stuff getting rebuilt every run when we don't want to. 
     # Note then that there will be an extra step when we change the task definition: https://github.com/terraform-providers/terraform-provider-aws/issues/1274
     #lifecycle {
     #    ignore_changes = [
@@ -56,7 +93,7 @@ resource "aws_ecs_service" "ecs-service" {
     task_definition = "${aws_ecs_task_definition.my_task.family}:${max("${aws_ecs_task_definition.my_task.revision}", "${data.aws_ecs_task_definition.my_task.revision}")}"
     desired_count   = "${var.instances_desired_count}"
 
-    # Considering putting this in if we see this stuff getting rebuilt every run when we don't want to. 
+    # Consider putting this in if we see this stuff getting rebuilt every run when we don't want to. 
     # Note then that there will be an extra step when we change the task definition: https://github.com/terraform-providers/terraform-provider-aws/issues/1274
     #lifecycle {
     #    ignore_changes = ["task_definition"] # the same here, do nothing if it was already installed

--- a/terraform/modules/elastic-container-service/variables.tf
+++ b/terraform/modules/elastic-container-service/variables.tf
@@ -1,5 +1,6 @@
 variable "cluster_name" {}
 variable "region" {}
+variable "environment" {}
 variable "availability_zone" {}
 variable "local_machine_cidr" {}
 variable "instance_type" {}
@@ -11,3 +12,4 @@ variable "instances_desired_count" {}
 variable "instances_memory" {}
 variable "instances_cpu" {}
 variable "instances_log_retention_days" {}
+variable "instances_extra_policy_arn" {}

--- a/terraform/modules/puller-flickr/parameter-store.tf
+++ b/terraform/modules/puller-flickr/parameter-store.tf
@@ -1,0 +1,63 @@
+resource "aws_kms_key" "parameter_secrets" {
+    description             = "Used to encrypt/decrypt secrets in the Parameter Store"
+    key_usage               = "ENCRYPT_DECRYPT"
+    enable_key_rotation     = true
+    deletion_window_in_days = 7
+}
+
+resource "aws_ssm_parameter" "flickr_user_id" {
+    name        = "/${var.environment}/puller-flickr/flickr-user-id"
+    description = "Numerical user ID of the user for whom we're recommending photos"
+    type        = "String"
+    value       = "${var.flickr_user_id}"
+}
+
+resource "aws_ssm_parameter" "flickr_api_key" {
+    name        = "/${var.environment}/puller-flickr/flickr-api-key"
+    description = "Flickr API key"
+    type        = "String"
+    value       = "${var.flickr_api_key}"
+}
+
+resource "aws_ssm_parameter" "flickr_secret_key" {
+    name        = "/${var.environment}/puller-flickr/flickr-secret-key"
+    description = "Flickr API secret key"
+    type        = "SecureString"
+    key_id      = "${aws_kms_key.parameter_secrets.id}"
+    value       = "${var.flickr_secret_key}"
+}
+
+resource "aws_ssm_parameter" "flickr_api_retries" {
+    name        = "/${var.environment}/puller-flickr/flickr-api-retries"
+    description = "Max number of times to retry a Flickr API call"
+    type        = "String"
+    value       = "${var.flickr_api_retries}"
+}
+
+resource "aws_ssm_parameter" "flickr_api_favorites_max_per_call" {
+    name        = "/${var.environment}/puller-flickr/flickr-api-favorites-max-per-call"
+    description = "Max number of favorites to get per API call"
+    type        = "String"
+    value       = "${var.flickr_api_favorites_max_per_call}"
+}
+
+resource "aws_ssm_parameter" "flickr_api_favorites_max_to_get" {
+    name        = "/${var.environment}/puller-flickr/flickr-api-favorites-max-to-get"
+    description = "Max number of favorites to get in total"
+    type        = "String"
+    value       = "${var.flickr_api_favorites_max_to_get}"
+}
+
+resource "aws_ssm_parameter" "memcached_ttl" {
+    name        = "/${var.environment}/puller-flickr/memcached-ttl"
+    description = "TTL in seconds of Flickr API calls put into memcached"
+    type        = "String"
+    value       = "${var.memcached_ttl}"
+}
+
+resource "aws_ssm_parameter" "memcached_location" {
+    name        = "/${var.environment}/puller-flickr/memcached-location"
+    description = "Endpoint of the memcached cluster that we cache Flickr API calls to"
+    type        = "String"
+    value       = "${aws_elasticache_cluster.memcached.cluster_address}:${aws_elasticache_cluster.memcached.port}"
+}

--- a/terraform/modules/puller-flickr/variables.tf
+++ b/terraform/modules/puller-flickr/variables.tf
@@ -4,6 +4,7 @@ variable "availability_zone" {}
 variable "memcached_node_type" {}
 variable "memcached_num_cache_nodes" {}
 variable "memcached_az_mode" {}
+variable "memcached_ttl" {}
 variable "local_machine_cidr" {}
 variable "ecs_instance_type" {}
 variable "ecs_cluster_desired_size" {}
@@ -14,3 +15,9 @@ variable "ecs_instances_desired_count" {}
 variable "ecs_instances_memory" {}
 variable "ecs_instances_cpu" {}
 variable "ecs_instances_log_retention_days" {}
+variable "flickr_api_key" {}
+variable "flickr_secret_key" {}
+variable "flickr_user_id" {}
+variable "flickr_api_retries" {}
+variable "flickr_api_favorites_max_per_call" {}
+variable "flickr_api_favorites_max_to_get" {}

--- a/terraform/terraform.tfvars.example
+++ b/terraform/terraform.tfvars.example
@@ -3,3 +3,7 @@ local_machine_cidr = "A.B.C.D/32"
 
 # Replace this with the public key for your local machine, to allow it to log into EC2 instances
 local_machine_public_key = "ssh-rsa blahblahblah a@b.com"
+
+flickr_api_key = ""
+flickr_secret_key = "" 
+flickr_user_id = ""


### PR DESCRIPTION
- Added config to the AWS Parameter Store
- Add an `ENVIRONMENT` env var to instances to indicate whether to read dev/prod parameters, and whether running in dev more or on AWS
- Add in `AWS_DEFAULT_REGION` env var to instances to say which region to read their parameters from
- Can add an application-specific policy to ECS instances
- puller-flickr reads its config from the AWS Parameter store
- Reduce resources used by ECS because I'm running up against the free tier limits
- Encrypt logs