### PR TITLE
Added load balancer to API server

### DIFF
--- a/README.md
+++ b/README.md
@@ -90,13 +90,20 @@ docker tag <ID of image you just built> <URI of puller-flickr-dev repository in 
 docker push <URI of puller-flicker-dev repository in ECR>
 ```
 
-and again for the next image
+and again for the next images
 
 ```
 docker build -f ../../src/ingester-database/Dockerfile ../../src
 docker images
 docker tag <ID of image you just built> <URI of ingester-database-dev repository in ECR: use AWS console to find>
 docker push <URI of ingester-database-dev repository in ECR>
+```
+
+```
+docker build -f ../../src/api-server/Dockerfile ../../src
+docker images
+docker tag <ID of image you just built> <URI of api-server-dev repository in ECR: use AWS console to find>
+docker push <URI of api-server-dev repository in ECR>
 ```
 
 TODO:
@@ -108,3 +115,4 @@ TODO:
 - Add tests
 - Lock python lib version numbers (see https://docs.docker.com/samples/library/python/#pythonversion-alpine to lock python version)
 - Maybe add a container running nginx to serve static files
+- Have dev load balancer only be accessable from the local machine, and have the prod load balancer only listen on https

--- a/src/api-server/api-server.py
+++ b/src/api-server/api-server.py
@@ -52,6 +52,10 @@ application = Flask(__name__)
 def hello():
     return "Hello World!"
 
+@application.route("/healthcheck")
+def health_check():
+    return "OK"
+
 if __name__ == '__main__':
     # Note that running Flask like this results in the output saying "lazy loading" and I'm not sure what that means.
     # If we run it the way specified in the documentation `FLASK_APP=./api-server.py flask run` then it doesn't say this.

--- a/terraform/dev/main.tf
+++ b/terraform/dev/main.tf
@@ -108,10 +108,17 @@ module "api_server" {
 
     environment             = "dev"
     region                  = "${var.region}"
+
     vpc_id                  = "${module.vpc.vpc_id}"
+    vpc_public_subnet_ids   = "${module.vpc.vpc_public_subnet_ids}"
+    vpc_cidr                = "${module.vpc.vpc_cidr_block}"
 
     load_balancer_port      = 4444
     api_server_port         = 4445
+
+    load_balancer_days_to_keep_access_logs = 1
+    load_balancer_access_logs_bucket = "api-server-access-logs-dev"
+    load_balancer_access_logs_prefix = "api-server-lb-dev"
 
     local_machine_cidr      = "${var.local_machine_cidr}"
 

--- a/terraform/modules/api-server/load-balancer.tf
+++ b/terraform/modules/api-server/load-balancer.tf
@@ -1,0 +1,133 @@
+resource "aws_lb" "api_server" {
+    name               = "api-server-lb-${var.environment}"
+    internal           = false
+    load_balancer_type = "application"
+    security_groups    = ["${aws_security_group.load_balancer.id}"]
+    subnets            = ["${var.vpc_public_subnet_ids}"]
+    idle_timeout       = 60
+    ip_address_type    = "ipv4"
+
+    #access_logs {
+    #    bucket  = "${aws_s3_bucket.load_balancer_access_logs.bucket}"
+    #    prefix  = "${var.load_balancer_access_logs_prefix}"
+    #    enabled = true
+    #}
+
+    tags = {
+        Environment = "${var.environment}"
+    }
+}
+
+resource "aws_lb_target_group" "load_balancer" {
+    name                    = "api-server-lb-tg-${var.environment}"
+    port                    = "${var.api_server_port}"
+    protocol                = "HTTP"
+    vpc_id                  = "${var.vpc_id}"
+    deregistration_delay    = 300
+    slow_start              = 0
+
+    health_check {
+        interval            = 30
+        path                = "/healthcheck"
+        port                = "${var.api_server_port}"
+        protocol            = "HTTP"
+        timeout             = 6
+        healthy_threshold   = 3
+        unhealthy_threshold = 3
+        matcher             = "200-299"
+    }
+}
+
+resource "aws_lb_listener" "load_balancer" {  
+    load_balancer_arn = "${aws_lb.api_server.arn}"  
+    port              = "${var.load_balancer_port}"  
+    protocol          = "HTTP"
+  
+    default_action {    
+        target_group_arn = "${aws_lb_target_group.load_balancer.arn}"
+        type             = "forward"  
+    }
+}
+
+resource "aws_security_group" "load_balancer" {
+    name        = "security-group-load-balancer-${var.environment}"
+    description = "Allow access from our local machine to our load balancer"
+    vpc_id      = "${var.vpc_id}"
+
+    ingress {
+        from_port   = "${var.load_balancer_port}"
+        to_port     = "${var.load_balancer_port}"
+        protocol    = "tcp"
+        cidr_blocks = [
+            "${var.local_machine_cidr}"
+        ]
+    }
+
+    egress {
+        # allow all traffic to private SN
+        from_port = "0"
+        to_port = "0"
+        protocol = "-1"
+        cidr_blocks = [
+            "0.0.0.0/0"
+        ]
+    }
+
+    tags { 
+        Name = "security-group-load-balancer-${var.environment}"
+    }
+}
+/*
+resource "aws_kms_key" "load_balancer_access_logs" {
+    description             = "Used to encrypt the load balancer access logs"
+    key_usage               = "ENCRYPT_DECRYPT"
+    enable_key_rotation     = true
+    deletion_window_in_days = 7
+}
+
+resource "aws_s3_bucket" "load_balancer_access_logs" {
+    bucket = "${var.load_balancer_access_logs_bucket}"
+    acl    = "private"
+    policy = "${data.aws_iam_policy_document.access_logs_bucket.json}"
+
+    lifecycle_rule {
+        id      = "log"
+        enabled = true
+
+        prefix = "*"
+
+        expiration {
+            days = "${var.load_balancer_days_to_keep_access_logs}"
+        }
+    }
+
+    server_side_encryption_configuration {
+        rule {
+            apply_server_side_encryption_by_default {
+                kms_master_key_id = "${aws_kms_key.load_balancer_access_logs.arn}"
+                sse_algorithm     = "aws:kms"
+            }
+        }
+    }
+}
+
+# Setup bucket policy so load balancer can write to it.
+# Taken from https://github.com/terraform-aws-modules/terraform-aws-alb/issues/61
+
+data "aws_caller_identity" "load_balancer" {}
+
+data "aws_elb_service_account" "main" {}
+
+data "aws_iam_policy_document" "access_logs_bucket" {
+    statement {
+        sid       = "AllowToPutLoadBalancerLogsToS3Bucket"
+        actions   = ["s3:PutObject"]
+        resources = ["arn:aws:s3:::${var.load_balancer_access_logs_bucket}/${var.load_balancer_access_logs_prefix}/AWSLogs/${data.aws_caller_identity.load_balancer.account_id}/*"]
+
+        principals {
+            type        = "AWS"
+            identifiers = ["arn:aws:iam::${data.aws_elb_service_account.main.id}:root"]
+        }
+    }
+}
+*/

--- a/terraform/modules/api-server/load-balancer.tf
+++ b/terraform/modules/api-server/load-balancer.tf
@@ -128,12 +128,12 @@ resource "aws_s3_bucket" "load_balancer_access_logs" {
         }
     }
 
-    #server_side_encryption_configuration {
-    #    rule {
-    #        apply_server_side_encryption_by_default {
-    #            kms_master_key_id = "${aws_kms_key.load_balancer_access_logs.arn}"
-    #            sse_algorithm     = "aws:kms"
-    #        }
-    #    }
-    #}
+    server_side_encryption_configuration {
+        rule {
+            apply_server_side_encryption_by_default {
+                kms_master_key_id = "${aws_kms_key.load_balancer_access_logs.arn}"
+                sse_algorithm     = "aws:kms"
+            }
+        }
+    }
 }

--- a/terraform/modules/api-server/load-balancer.tf
+++ b/terraform/modules/api-server/load-balancer.tf
@@ -137,3 +137,12 @@ resource "aws_s3_bucket" "load_balancer_access_logs" {
         }
     }
 }
+
+resource "aws_s3_bucket_public_access_block" "load_balancer_access_logs" {
+    bucket = "${aws_s3_bucket.load_balancer_access_logs.id}"
+
+    block_public_acls         = true
+    block_public_policy       = true
+    ignore_public_acls        = true
+    restrict_public_buckets   = true
+}

--- a/terraform/modules/api-server/load-balancer.tf
+++ b/terraform/modules/api-server/load-balancer.tf
@@ -118,7 +118,7 @@ resource "aws_s3_bucket" "load_balancer_access_logs" {
     EOF
 
     lifecycle_rule {
-        id      = "log"
+        id      = "expire-logs-after-N-days"
         enabled = true
 
         prefix = "*"

--- a/terraform/modules/api-server/security-group.tf
+++ b/terraform/modules/api-server/security-group.tf
@@ -1,6 +1,6 @@
 resource "aws_security_group" "api_server" {
     name = "security-group-api-server-${var.environment}"
-    description = "Allow access from our local machine to the port we are listening on"
+    description = "Allow access from our local machine and VPC (i.e. the load balancer) to the port we are listening on"
     vpc_id = "${var.vpc_id}"
 
     ingress {
@@ -9,6 +9,15 @@ resource "aws_security_group" "api_server" {
         protocol = "tcp"
         cidr_blocks = [
             "${var.local_machine_cidr}"
+        ]
+    }
+
+    ingress {
+        from_port = "${var.api_server_port}"
+        to_port = "${var.api_server_port}"
+        protocol = "tcp"
+        cidr_blocks = [
+            "${var.vpc_cidr}"
         ]
     }
 

--- a/terraform/modules/api-server/task-definition.tf
+++ b/terraform/modules/api-server/task-definition.tf
@@ -13,16 +13,9 @@ module "task_definition" {
     instances_role_name         = "${var.ecs_instances_role_name}"
     instances_extra_policy_arn  = "${aws_iam_policy.ecs-instance-api-server-extra-policy.arn}"
     port_mappings               = "${data.template_file.port_mappings.rendered}"
-    create_load_balancer        = true
+    has_load_balancer           = true
     load_balancer_container_port = "${var.api_server_port}"
-    load_balancer_target_group_arn = "${aws_lb_target_group.target_group.arn}"
-}
-
-resource "aws_lb_target_group" "target_group" {
-    name     = "api-server-lb-tg-${var.environment}"
-    port     = "${var.load_balancer_port}"
-    protocol = "HTTP"
-    vpc_id   = "${var.vpc_id}"
+    load_balancer_target_group_arn = "${aws_lb_target_group.load_balancer.arn}"
 }
 
 data "aws_caller_identity" "api-server" {

--- a/terraform/modules/api-server/task-definition.tf
+++ b/terraform/modules/api-server/task-definition.tf
@@ -13,6 +13,16 @@ module "task_definition" {
     instances_role_name         = "${var.ecs_instances_role_name}"
     instances_extra_policy_arn  = "${aws_iam_policy.ecs-instance-api-server-extra-policy.arn}"
     port_mappings               = "${data.template_file.port_mappings.rendered}"
+    create_load_balancer        = true
+    load_balancer_container_port = "${var.api_server_port}"
+    load_balancer_target_group_arn = "${aws_lb_target_group.target_group.arn}"
+}
+
+resource "aws_lb_target_group" "target_group" {
+    name     = "api-server-lb-tg-${var.environment}"
+    port     = "${var.load_balancer_port}"
+    protocol = "HTTP"
+    vpc_id   = "${var.vpc_id}"
 }
 
 data "aws_caller_identity" "api-server" {

--- a/terraform/modules/api-server/variables.tf
+++ b/terraform/modules/api-server/variables.tf
@@ -6,6 +6,8 @@ variable "mysql_database_username" {}
 variable "mysql_database_password" {}
 variable "mysql_database_name" {}
 variable "vpc_id" {}
+variable "vpc_public_subnet_ids" { type = "list" }
+variable "vpc_cidr" {}
 variable "ecs_instances_desired_count" {}
 variable "ecs_instances_memory" {}
 variable "ecs_instances_cpu" {}
@@ -13,6 +15,9 @@ variable "ecs_cluster_id" {}
 variable "ecs_instances_log_configuration" {}
 variable "ecs_instances_role_name" {}
 variable "ecs_days_to_keep_images" {}
+variable "local_machine_cidr" {}
 variable "api_server_port" {}
 variable "load_balancer_port" {}
-variable "local_machine_cidr" {}
+variable "load_balancer_days_to_keep_access_logs" {}
+variable "load_balancer_access_logs_bucket" {}
+variable "load_balancer_access_logs_prefix" {}

--- a/terraform/modules/ingester-database/task-definition.tf
+++ b/terraform/modules/ingester-database/task-definition.tf
@@ -13,7 +13,7 @@ module "task_definition" {
     instances_role_name         = "${var.ecs_instances_role_name}"
     instances_extra_policy_arn  = "${aws_iam_policy.ecs-instance-ingester-database-extra-policy.arn}"
     port_mappings               = ""
-    create_load_balancer        = false
+    has_load_balancer           = false
     load_balancer_container_port = -1
     load_balancer_target_group_arn = ""
 }

--- a/terraform/modules/ingester-database/task-definition.tf
+++ b/terraform/modules/ingester-database/task-definition.tf
@@ -13,6 +13,9 @@ module "task_definition" {
     instances_role_name         = "${var.ecs_instances_role_name}"
     instances_extra_policy_arn  = "${aws_iam_policy.ecs-instance-ingester-database-extra-policy.arn}"
     port_mappings               = ""
+    create_load_balancer        = false
+    load_balancer_container_port = -1
+    load_balancer_target_group_arn = ""
 }
 
 data "aws_caller_identity" "ingester_database" {

--- a/terraform/modules/mysql/mysql.tf
+++ b/terraform/modules/mysql/mysql.tf
@@ -25,7 +25,7 @@ resource "aws_db_instance" "mysql_database" {
     storage_type                    = "${var.storage_type}"
 
     storage_encrypted               = "${var.storage_encrypted}"
-    kms_key_id                      = "${var.storage_encrypted == true ? "${aws_kms_key.mysql_encryption.arn}" : ""}"
+    kms_key_id                      = "${var.storage_encrypted ? "${aws_kms_key.mysql_encryption.arn}" : ""}" # Luckily we're able to use "" here to denote an empty field. Support for a null value is coming in terraform 0.12: https://github.com/hashicorp/terraform/issues/14037
 
     engine                          = "mysql"
     engine_version                  = "8.0"

--- a/terraform/modules/puller-flickr/task-definition.tf
+++ b/terraform/modules/puller-flickr/task-definition.tf
@@ -13,7 +13,7 @@ module "task_definition" {
     instances_role_name         = "${var.ecs_instances_role_name}"
     instances_extra_policy_arn  = "${aws_iam_policy.ecs-instance-puller-flickr-extra-policy.arn}"
     port_mappings               = ""
-    create_load_balancer        = false
+    has_load_balancer           = false
     load_balancer_container_port = -1
     load_balancer_target_group_arn = ""
 }

--- a/terraform/modules/puller-flickr/task-definition.tf
+++ b/terraform/modules/puller-flickr/task-definition.tf
@@ -13,6 +13,9 @@ module "task_definition" {
     instances_role_name         = "${var.ecs_instances_role_name}"
     instances_extra_policy_arn  = "${aws_iam_policy.ecs-instance-puller-flickr-extra-policy.arn}"
     port_mappings               = ""
+    create_load_balancer        = false
+    load_balancer_container_port = -1
+    load_balancer_target_group_arn = ""
 }
 
 data "aws_caller_identity" "puller_flickr" {

--- a/terraform/modules/task-definition/task-definition.tf
+++ b/terraform/modules/task-definition/task-definition.tf
@@ -49,7 +49,7 @@ resource "aws_iam_role_policy_attachment" "attach-extra-policy" {
 # Dynamic blocks are coming in terraform 0.12: https://github.com/hashicorp/terraform/issues/7034
 
 resource "aws_ecs_service" "ecs_service_no_load_balancer" {
-    count           = "${var.create_load_balancer ? 0 : 1}"
+    count           = "${var.has_load_balancer ? 0 : 1}"
 
     name            = "${var.name}"
     cluster         = "${var.cluster_id}"
@@ -64,7 +64,7 @@ resource "aws_ecs_service" "ecs_service_no_load_balancer" {
 }
 
 resource "aws_ecs_service" "ecs_service_with_load_balancer" {
-    count           = "${var.create_load_balancer ? 1 : 0}"
+    count           = "${var.has_load_balancer ? 1 : 0}"
 
     name            = "${var.name}"
     cluster         = "${var.cluster_id}"

--- a/terraform/modules/task-definition/task-definition.tf
+++ b/terraform/modules/task-definition/task-definition.tf
@@ -38,7 +38,19 @@ DEFINITION
     #}
 }
 
-resource "aws_ecs_service" "ecs_service" {
+# Add extra permissions to the instances in the cluster to support the actions puller-flickr needs to take
+resource "aws_iam_role_policy_attachment" "attach-extra-policy" {
+    role       = "${var.instances_role_name}"
+    policy_arn = "${var.instances_extra_policy_arn}"
+}
+
+# terraform 0.11 doesn't have support for dynamic blocks yet, and we need to use a block to describe our optional load balancer.
+# So instead we'll have to copy & paste our resource and use the count field to pick one or the other to be created.
+# Dynamic blocks are coming in terraform 0.12: https://github.com/hashicorp/terraform/issues/7034
+
+resource "aws_ecs_service" "ecs_service_no_load_balancer" {
+    count           = "${var.create_load_balancer ? 0 : 1}"
+
     name            = "${var.name}"
     cluster         = "${var.cluster_id}"
     task_definition = "${aws_ecs_task_definition.task_definition.family}:${max("${aws_ecs_task_definition.task_definition.revision}", "${data.aws_ecs_task_definition.task_definition.revision}")}"
@@ -51,9 +63,26 @@ resource "aws_ecs_service" "ecs_service" {
     #}
 }
 
-# Add extra permissions to the instances in the cluster to support the actions puller-flickr needs to take
-resource "aws_iam_role_policy_attachment" "attach-extra-policy" {
-    role       = "${var.instances_role_name}"
-    policy_arn = "${var.instances_extra_policy_arn}"
+resource "aws_ecs_service" "ecs_service_with_load_balancer" {
+    count           = "${var.create_load_balancer ? 1 : 0}"
+
+    name            = "${var.name}"
+    cluster         = "${var.cluster_id}"
+    task_definition = "${aws_ecs_task_definition.task_definition.family}:${max("${aws_ecs_task_definition.task_definition.revision}", "${data.aws_ecs_task_definition.task_definition.revision}")}"
+    desired_count   = "${var.instances_desired_count}"
+
+    load_balancer {
+        target_group_arn = "${var.load_balancer_target_group_arn}"
+        container_name   = "${var.name}"
+        container_port   = "${var.load_balancer_container_port}"
+    }
+
+    # Consider putting this in if we see this stuff getting rebuilt every run when we don't want to. 
+    # Note then that there will be an extra step when we change the task definition: https://github.com/terraform-providers/terraform-provider-aws/issues/1274
+    #lifecycle {
+    #    ignore_changes = ["task_definition"] # the same here, do nothing if it was already installed
+    #}
 }
+
+
 

--- a/terraform/modules/task-definition/variables.tf
+++ b/terraform/modules/task-definition/variables.tf
@@ -10,3 +10,6 @@ variable "instances_role_name" {}
 variable "instances_extra_policy_arn" {}
 variable "container_repository_url" {}
 variable "port_mappings" {}
+variable "create_load_balancer" {}
+variable "load_balancer_container_port" {}
+variable "load_balancer_target_group_arn" {}

--- a/terraform/modules/task-definition/variables.tf
+++ b/terraform/modules/task-definition/variables.tf
@@ -10,6 +10,6 @@ variable "instances_role_name" {}
 variable "instances_extra_policy_arn" {}
 variable "container_repository_url" {}
 variable "port_mappings" {}
-variable "create_load_balancer" {}
+variable "has_load_balancer" {}
 variable "load_balancer_container_port" {}
 variable "load_balancer_target_group_arn" {}


### PR DESCRIPTION
- Added in application load balancer. It listens on port 4444, and forwards traffic to port 4445
- Added health check endpoint to API server
- Added s3 bucket for lb access logs
- Refactored ECS service module to allow for a load balancer or not when creating a new service 
- Added permission for load balancer to be able to talk to EC2 instances