### PR TITLE
Added basic recommendations endpoint

### DIFF
--- a/README.md
+++ b/README.md
@@ -117,3 +117,4 @@ TODO:
 - Maybe add a container running nginx to serve static files, or can ALB route to S3 to serve static files?
 - Have dev load balancer only be accessable from the local machine, and have the prod load balancer only listen on https
 - Encrypt SQS messages in prod
+- Add connection pool manager for talking to DB from API server

--- a/src/api-server/Dockerfile
+++ b/src/api-server/Dockerfile
@@ -7,7 +7,7 @@ ADD common/confighelper.py /common/
 RUN pip install flask
 RUN pip install flask_api
 RUN pip install gunicorn
-RUN pip install mysql-connector-python
+RUN pip install pymysql
 RUN pip install boto3
 EXPOSE 4445
 WORKDIR /api-server/

--- a/src/api-server/Dockerfile
+++ b/src/api-server/Dockerfile
@@ -4,6 +4,7 @@ ADD api-server/favorite.py /api-server/
 ADD api-server/favoritesstoredatabase.py /api-server/
 ADD api-server/favoritesstoreexception.py /api-server/
 ADD api-server/recommendations.py /api-server/
+ADD api-server/output.py /api-server/
 ADD common/confighelper.py /common/
 RUN pip install flask
 RUN pip install flask_api

--- a/src/api-server/Dockerfile
+++ b/src/api-server/Dockerfile
@@ -1,7 +1,11 @@
 FROM python:3-alpine
 ADD api-server/api-server.py /api-server/
+ADD api-server/favorite.py /api-server/
+ADD api-server/favoritesstoredatabase.py /api-server/
+ADD api-server/favoritesstoreexception.py /api-server/
 ADD common/confighelper.py /common/
 RUN pip install flask
+RUN pip install flask_api
 RUN pip install gunicorn
 RUN pip install mysql-connector-python
 RUN pip install boto3

--- a/src/api-server/Dockerfile
+++ b/src/api-server/Dockerfile
@@ -3,6 +3,7 @@ ADD api-server/api-server.py /api-server/
 ADD api-server/favorite.py /api-server/
 ADD api-server/favoritesstoredatabase.py /api-server/
 ADD api-server/favoritesstoreexception.py /api-server/
+ADD api-server/recommendations.py /api-server/
 ADD common/confighelper.py /common/
 RUN pip install flask
 RUN pip install flask_api

--- a/src/api-server/api-server.py
+++ b/src/api-server/api-server.py
@@ -12,6 +12,7 @@ from confighelper import ConfigHelper
 from favorite import Favorite
 from favoritesstoredatabase import FavoritesStoreDatabase
 from favoritesstoreexception import FavoritesStoreException
+from recommendations import Recommendations
 
 #
 # Read in commandline arguments
@@ -81,6 +82,8 @@ def get_recommendations(user_id=None):
         return "User not specified", status.HTTP_400_BAD_REQUEST
 
     all_favorites = favorites_store.get_my_favorites_and_neighbors_favorites(user_id)
+
+    Recommendations.get_recommendations(user_id, all_favorites)
 
     return "Got back %d favorites" % len(all_favorites)
 

--- a/src/api-server/api-server.py
+++ b/src/api-server/api-server.py
@@ -7,12 +7,14 @@ import argparse
 import logging
 import atexit
 from flask import Flask
+from flask import request
 from flask_api import status
 from confighelper import ConfigHelper
 from favorite import Favorite
 from favoritesstoredatabase import FavoritesStoreDatabase
 from favoritesstoreexception import FavoritesStoreException
 from recommendations import Recommendations
+from output import Output
 
 #
 # Read in commandline arguments
@@ -44,6 +46,7 @@ database_name               = config_helper.get("database-name")
 database_fetch_batch_size   = config_helper.getInt("database-fetch-batch-size")
 server_host                 = config_helper.get("server-host")
 server_port                 = config_helper.getInt("server-port")
+default_num_photo_recommendations = config_helper.getInt('default-num-photo-recommendations')
 
 #
 # Set up our data store
@@ -81,11 +84,15 @@ def get_recommendations(user_id=None):
     if user_id is None:
         return "User not specified", status.HTTP_400_BAD_REQUEST
 
+    num_photos = int(request.args.get('num-photos', default_num_photo_recommendations))
+
     all_favorites = favorites_store.get_my_favorites_and_neighbors_favorites(user_id)
 
-    Recommendations.get_recommendations(user_id, all_favorites)
+    recommendations = Recommendations.get_recommendations(user_id, all_favorites, num_photos)
 
-    return "Got back %d favorites" % len(all_favorites)
+    output = Output.get_output(recommendations)
+
+    return output
 
 if __name__ == '__main__':
     # Note that running Flask like this results in the output saying "lazy loading" and I'm not sure what that means.

--- a/src/api-server/api-server.py
+++ b/src/api-server/api-server.py
@@ -5,8 +5,13 @@ sys.path.insert(0, '../common')
 
 import argparse
 import logging
+import atexit
 from flask import Flask
+from flask_api import status
 from confighelper import ConfigHelper
+from favorite import Favorite
+from favoritesstoredatabase import FavoritesStoreDatabase
+from favoritesstoreexception import FavoritesStoreException
 
 #
 # Read in commandline arguments
@@ -30,31 +35,54 @@ logging.basicConfig(format='%(levelname)s: %(message)s', level=log_level)
 
 config_helper = ConfigHelper.get_config_helper(default_env_name="dev", aws_parameter_prefix="api-server")
 
-database_username   = config_helper.get("database-username")
-database_password   = config_helper.get("database-password", is_secret=True)
-database_host       = config_helper.get("database-host")
-database_port       = config_helper.getInt("database-port")
-database_name       = config_helper.get("database-name")
-server_host         = config_helper.get("server-host")
-server_port         = config_helper.getInt("server-port")
+database_username           = config_helper.get("database-username")
+database_password           = config_helper.get("database-password", is_secret=True)
+database_host               = config_helper.get("database-host")
+database_port               = config_helper.getInt("database-port")
+database_name               = config_helper.get("database-name")
+database_fetch_batch_size   = config_helper.getInt("database-fetch-batch-size")
+server_host                 = config_helper.get("server-host")
+server_port                 = config_helper.getInt("server-port")
+
+#
+# Set up our data store
+#
+
+favorites_store = FavoritesStoreDatabase(
+    database_username=database_username, 
+    database_password=database_password, 
+    database_host=database_host, 
+    database_port=database_port, 
+    database_name=database_name, 
+    fetch_batch_size=database_fetch_batch_size)
+
+def cleanup_data_store():
+    favorites_store.shutdown()
+
+atexit.register(cleanup_data_store)
 
 #
 # Run our API server
 #
 # Note that the Flask built-in server is not sufficient for production. In production we run under gunicorn instead, and
-# we run behind nginx. See: 
+# we run behind an AWS Application Load Balancer. See: 
 #   https://medium.com/@kmmanoj/deploying-a-scalable-flask-app-using-gunicorn-and-nginx-in-docker-part-1-3344f13c9649
 #
 
 application = Flask(__name__)
 
-@application.route("/")
-def hello():
-    return "Hello World!"
-
 @application.route("/healthcheck")
 def health_check():
-    return "OK"
+    return "OK", status.HTTP_200_OK
+
+@application.route("/users/<user_id>/recommendations")
+def get_recommendations(user_id=None):
+    if user_id is None:
+        return "User not specified", status.HTTP_400_BAD_REQUEST
+
+    all_favorites = favorites_store.get_my_favorites_and_neighbors_favorites(user_id)
+
+    return "Got back %d favorites" % len(all_favorites)
 
 if __name__ == '__main__':
     # Note that running Flask like this results in the output saying "lazy loading" and I'm not sure what that means.

--- a/src/api-server/config/config.ini
+++ b/src/api-server/config/config.ini
@@ -4,7 +4,7 @@ database-username=favorites_dev
 database-host=favorites-dev.c3iwtdwtednb.us-west-2.rds.amazonaws.com
 database-port=3306
 database-name=favorites
-database-fetch-batch-size=1000
+database-fetch-batch-size=10000
 
 server-host=127.0.0.1
 server-port=4445

--- a/src/api-server/config/config.ini
+++ b/src/api-server/config/config.ini
@@ -4,6 +4,7 @@ database-username=favorites_dev
 database-host=favorites-dev.c3iwtdwtednb.us-west-2.rds.amazonaws.com
 database-port=3306
 database-name=favorites
+database-fetch-batch-size=1000
 
 server-host=127.0.0.1
 server-port=4445

--- a/src/api-server/config/config.ini
+++ b/src/api-server/config/config.ini
@@ -9,4 +9,6 @@ database-fetch-batch-size=10000
 server-host=127.0.0.1
 server-port=4445
 
+default-num-photo-recommendations=10
+
 [dev]

--- a/src/api-server/favorite.py
+++ b/src/api-server/favorite.py
@@ -1,0 +1,28 @@
+class Favorite:
+
+    '''
+    A favorite (or equivalent) photo read from the data store
+    '''
+
+    def __init__(self, id, image_id, image_url, image_owner, favorited_by):
+        self.id             = id
+        self.image_id       = image_id
+        self.image_url      = image_url
+        self.image_owner    = image_owner
+        self.favorited_by   = favorited_by  
+   
+    def get_id(self):
+        return self.id
+
+    def get_image_id(self):
+        return self.image_id
+
+    def get_image_url(self):
+        return self.image_url
+
+    def get_image_owner(self):
+        return self.image_owner
+
+    def get_favorited_by(self):
+        return self.favorited_by
+        

--- a/src/api-server/favoritesstoredatabase.py
+++ b/src/api-server/favoritesstoredatabase.py
@@ -1,4 +1,5 @@
 import mysql.connector
+import logging
 from favorite import Favorite
 from favoritesstoreexception import FavoritesStoreException
 
@@ -13,7 +14,11 @@ class FavoritesStoreDatabase:
         # Using a nonbuffered cursor here results in the same row being returned over and over at the end of the results. 
         # Using a buffered cursor behaves as expected. Is this a bug in mysql or the driver?
         # The problem is that a buffered cursor retrieves all of the results at once, and our result set can be large.
-        cursor = self.cnx.cursor(buffered=True) 
+        #
+        # Solutions tried: upgrading python, upgrading the mysql-connector-python package, downgrading the database from MySQL 8.0 to 5.7
+        # Couldn't find anything with various google searches.
+        # Consider trying a different package to connect to MySQL
+        cursor = self.cnx.cursor(buffered=False) 
 
         print("Trying to get rows for user '%s'" % user_id)
 
@@ -32,7 +37,7 @@ class FavoritesStoreDatabase:
             favorites = []
 
             for row in self._iter_row(cursor):
-                print("Got a row!", row)
+                logging.debug("Got a row!", row)
                 favorites.append(Favorite(id=row[0], image_id=row[1], image_url=row[2], image_owner=row[3], favorited_by=row[4]))
 
             return favorites
@@ -47,7 +52,7 @@ class FavoritesStoreDatabase:
     def _iter_row(self, cursor):
         while True:
             rows = cursor.fetchmany(self.fetch_batch_size)
-            print("Just fetched %d rows", len(rows))
+            logging.debug("Just fetched %d rows" % len(rows))
             if not rows:
                 break
             for row in rows:

--- a/src/api-server/favoritesstoredatabase.py
+++ b/src/api-server/favoritesstoredatabase.py
@@ -6,6 +6,10 @@ from favoritesstoreexception import FavoritesStoreException
 
 class FavoritesStoreDatabase:
 
+    '''
+    This class interfaces with a MySQL database to retrieve a list of my favorites and the favorites of my neighbors
+    '''
+
     def __init__(self, database_username, database_password, database_host, database_port, database_name, fetch_batch_size):
         
         # Note that pymysql.cursors.SSCursor is an unbuffered cursor, meaning that it only retrieves rows as it needs them, rather than all at once.
@@ -35,7 +39,7 @@ class FavoritesStoreDatabase:
 
         cursor = self.cnx.cursor() 
 
-        print("Trying to get rows for user '%s'" % user_id)
+        logging.debug("Trying to get rows for user '%s'" % user_id)
 
         try:
             cursor.execute("""
@@ -53,7 +57,7 @@ class FavoritesStoreDatabase:
 
             for row in self._iter_row(cursor):
                 logging.debug("Got a row!", row)
-                favorites.append(Favorite(id=row[0], image_id=row[1], image_url=row[2], image_owner=row[3], favorited_by=row[4]))
+                favorites.append(Favorite(id=row[0], image_id=row[1], image_owner=row[2], image_url=row[3], favorited_by=row[4]))
 
             return favorites
 

--- a/src/api-server/favoritesstoredatabase.py
+++ b/src/api-server/favoritesstoredatabase.py
@@ -1,0 +1,53 @@
+import mysql.connector
+from favorite import Favorite
+from favoritesstoreexception import FavoritesStoreException
+
+class FavoritesStoreDatabase:
+
+    def __init__(self, database_username, database_password, database_host, database_port, database_name, fetch_batch_size):
+        self.cnx                = mysql.connector.connect(user=database_username, password=database_password, host=database_host, port=database_port, database=database_name)
+        self.fetch_batch_size   = fetch_batch_size
+
+    def get_my_favorites_and_neighbors_favorites(self, user_id):
+
+        cursor = self.cnx.cursor()
+
+        print("Trying to get rows")
+
+        try:
+            cursor.execute("""
+                select 
+                    id, image_id, image_owner, image_url, favorited_by 
+                from 
+                    favorites 
+                where 
+                    favorited_by="%s" 
+                or 
+                    favorited_by in (select distinct image_owner from favorites where favorited_by="%s");
+            """, (user_id, user_id))
+     
+            favorites = []
+
+            for row in self._iter_row(cursor):
+                print("Got a row!")
+                favorites.append(Favorite(id=row[0], image_id=row[1], image_url=row[2], image_owner=row[3], favorited_by=row[4]))
+
+            return favorites
+
+        except Exception as e:
+            raise FavoritesStoreException from e
+
+        finally:
+            cursor.close()
+
+ 
+    def _iter_row(self, cursor):
+        while True:
+            rows = cursor.fetchmany(self.fetch_batch_size)
+            if not rows:
+                break
+            for row in rows:
+                yield row
+
+    def shutdown(self):
+        self.cnx.close()

--- a/src/api-server/favoritesstoreexception.py
+++ b/src/api-server/favoritesstoreexception.py
@@ -1,0 +1,7 @@
+class FavoritesStoreException(Exception):
+
+    '''
+    Raised when unable to retrieve data from a favorites store
+    '''
+
+    pass

--- a/src/api-server/output.py
+++ b/src/api-server/output.py
@@ -1,0 +1,13 @@
+class Output:
+
+    @staticmethod
+    def get_output(photo_recommendations):
+
+        output = ""
+
+        output += "<h1>Photos you may like</h1>\n"
+
+        for photo in photo_recommendations:
+            output += f"<a href=https://www.flickr.com/photos/{photo['image_owner']}/{photo['photo_id']}/><img src={photo['image_url']}/></a><br/>\n"
+
+        return output

--- a/src/api-server/recommendations.py
+++ b/src/api-server/recommendations.py
@@ -1,0 +1,78 @@
+import logging
+import math
+from favorite import Favorite
+
+class Recommendations:
+
+    '''
+    This class contains the business logic of figuring out a set of recommendations for a user based
+    on their favorites and the favorites of their neighbors
+    '''
+
+    @staticmethod
+    def _get_neighbor_score(total_favorites, common_favorites):
+        # Took this formula from https://www.flickr.com/groups/709526@N23/discuss/72157604460161681/72157604455830572
+        return 150 * math.sqrt(common_favorites / (total_favorites + 250))
+
+    @staticmethod
+    def get_recommendations(my_user_id, favorites_list):
+
+        logging.info("Trying to calculate recommendations for user %s with a favorites list of %d items" % (my_user_id, len(favorites_list)))
+
+        # favorites_list contains a jumble of my own favorites as well as the favorites of my neighbors.
+        # So the first thing to do is to separate them from each other
+
+        my_favorite_photos = []
+        my_favorite_photo_ids = set()
+        my_neighbors = {}
+        all_neighbor_favorite_photos = {}
+
+        for photo in favorites_list:
+
+            if photo.get_favorited_by() == my_user_id:
+                
+                my_favorite_photos.append(photo)
+                my_favorite_photo_ids.add(photo.get_image_id())
+
+                if photo.get_image_owner() not in my_neighbors:
+                    
+                    my_neighbors[photo.get_image_owner()] = { 
+                        'user_id'               : photo.get_image_owner(), 
+                        'favorite_photo_ids'    : set(),
+                        'total_favorites'       : 0,
+                        'common_favorites'      : 0,
+                        'score'                 : 0
+                    }
+
+        logging.info("Found neighbors: %s" % ", ".join(my_neighbors.keys()))
+
+        logging.info("Found my favorite photo IDs: %s" % ", ".join(my_favorite_photo_ids))
+
+        # We need to go through the list twice because it can be in any order, so we might not
+        # have a neighbor object set up for a photo by the time we encounter it
+
+        for photo in favorites_list:
+
+            if photo.get_favorited_by() in my_neighbors.keys():
+                my_neighbors[photo.get_favorited_by()]['favorite_photo_ids'].add(photo.get_image_id())
+                all_neighbor_favorite_photos[photo.get_image_id()] = {
+                    'score': 0,
+                    'photo': photo,
+                }
+
+                if photo.get_image_id() in my_favorite_photo_ids:
+                    logging.info("Ah ha! Found one!")
+
+            else:
+                if photo.get_favorited_by() != my_user_id:
+                    logging.info("WTF -- where did this photo come from?")
+
+        # Now we can get the score for each neighbor, because we can calculate the total number of favorites
+        # that they have, and the number of favorites in common with us
+
+        for neighbor_id in my_neighbors:
+            my_neighbors[neighbor_id]['total_favorites']    = len(my_neighbors[neighbor_id]['favorite_photo_ids'])
+            my_neighbors[neighbor_id]['common_favorites']   = len(my_neighbors[neighbor_id]['favorite_photo_ids'] & my_favorite_photo_ids)
+            my_neighbors[neighbor_id]['score']              = Recommendations._get_neighbor_score(my_neighbors[neighbor_id]['total_favorites'], my_neighbors[neighbor_id]['common_favorites'])
+    
+            logging.info("Neighbor %s has %d total favorites and %d in common with me for a score of %f" % (neighbor_id, my_neighbors[neighbor_id]['total_favorites'], my_neighbors[neighbor_id]['common_favorites'], my_neighbors[neighbor_id]['score']))

--- a/src/api-server/recommendations.py
+++ b/src/api-server/recommendations.py
@@ -15,9 +15,9 @@ class Recommendations:
         return 150 * math.sqrt(common_favorites / (total_favorites + 250))
 
     @staticmethod
-    def get_recommendations(my_user_id, favorites_list):
+    def get_recommendations(my_user_id, favorites_list, num_photo_results):
 
-        logging.info("Trying to calculate recommendations for user %s with a favorites list of %d items" % (my_user_id, len(favorites_list)))
+        logging.debug("Trying to calculate recommendations for user %s with a favorites list of %d items" % (my_user_id, len(favorites_list)))
 
         # favorites_list contains a jumble of my own favorites as well as the favorites of my neighbors.
         # So the first thing to do is to separate them from each other
@@ -44,9 +44,9 @@ class Recommendations:
                         'score'                 : 0
                     }
 
-        logging.info("Found neighbors: %s" % ", ".join(my_neighbors.keys()))
+        logging.debug("Found neighbors: %s" % ", ".join(my_neighbors.keys()))
 
-        logging.info("Found my favorite photo IDs: %s" % ", ".join(my_favorite_photo_ids))
+        logging.debug("Found my favorite photo IDs: %s" % ", ".join(my_favorite_photo_ids))
 
         # We need to go through the list twice because it can be in any order, so we might not
         # have a neighbor object set up for a photo by the time we encounter it
@@ -60,13 +60,6 @@ class Recommendations:
                     'photo': photo,
                 }
 
-                if photo.get_image_id() in my_favorite_photo_ids:
-                    logging.info("Ah ha! Found one!")
-
-            else:
-                if photo.get_favorited_by() != my_user_id:
-                    logging.info("WTF -- where did this photo come from?")
-
         # Now we can get the score for each neighbor, because we can calculate the total number of favorites
         # that they have, and the number of favorites in common with us
 
@@ -75,4 +68,25 @@ class Recommendations:
             my_neighbors[neighbor_id]['common_favorites']   = len(my_neighbors[neighbor_id]['favorite_photo_ids'] & my_favorite_photo_ids)
             my_neighbors[neighbor_id]['score']              = Recommendations._get_neighbor_score(my_neighbors[neighbor_id]['total_favorites'], my_neighbors[neighbor_id]['common_favorites'])
     
-            logging.info("Neighbor %s has %d total favorites and %d in common with me for a score of %f" % (neighbor_id, my_neighbors[neighbor_id]['total_favorites'], my_neighbors[neighbor_id]['common_favorites'], my_neighbors[neighbor_id]['score']))
+            logging.debug("Neighbor %s has %d total favorites and %d in common with me for a score of %f" % (neighbor_id, my_neighbors[neighbor_id]['total_favorites'], my_neighbors[neighbor_id]['common_favorites'], my_neighbors[neighbor_id]['score']))
+
+        # And last we can go through all of our neighbors' favorites and score them
+        # The score of a photo is the sum of the scores of all the neighbors who favorited it.
+        # Taken from https://www.flickr.com/groups/709526@N23/discuss/72157604460161681/72157604455830572
+
+        for photo in all_neighbor_favorite_photos:
+            score = 0
+            if photo not in my_favorite_photo_ids: # Don't recommend photos to me that I already like
+                for neighbor_id in my_neighbors:
+                    if photo in my_neighbors[neighbor_id]['favorite_photo_ids']:
+                        score += my_neighbors[neighbor_id]['score']
+            all_neighbor_favorite_photos[photo]['score'] = score
+
+        # OPTIMIZATION: Note that this creates a copy of the list rather than sorting in place, and the list can be quite large
+
+        sorted_neighbor_favorite_photo_ids = sorted(all_neighbor_favorite_photos.items(), key=lambda x: x[1]['score'], reverse=True)
+
+        # The result is a list of tuples where the first element is the photo ID, and the second element is a dictionary of score and photo object
+
+        return map(lambda photo: {'image_owner': photo[1]['photo'].get_image_owner(), 'photo_id': photo[1]['photo'].get_id(), 'image_url': photo[1]['photo'].get_image_url()}, 
+            sorted_neighbor_favorite_photo_ids[0:num_photo_results])

--- a/src/common/queuewriter.py
+++ b/src/common/queuewriter.py
@@ -19,7 +19,7 @@ class SQSQueueWriter:
 
             message = {
                 'Id': str(len(current_batch)),
-                'MessageBody': to_string(objects[obj])
+                'MessageBody': to_string(obj)
             }
 
             current_batch.append(message)

--- a/src/puller-flickr/puller-flickr.py
+++ b/src/puller-flickr/puller-flickr.py
@@ -56,15 +56,14 @@ flickrapi = FlickrApiWrapper(flickr_api_key, flickr_api_secret, memcached_locati
 logging.info("Getting my favourites")
 
 my_favorites = flickrapi.get_favorites(flickr_user_id, flickr_api_max_favorites_per_call, flickr_api_max_favorites_to_get)
-favorite_photos = {}
+favorite_photos = []
 
 my_neighbors = {}
 
 for photo in my_favorites:
     logging.debug("Found photo I favorited: ", photo)
     
-    if photo['id'] not in favorite_photos:
-        favorite_photos[photo['id']] = IngesterQueueItem(favorited_by=flickr_user_id, image_id=photo['id'], image_url=photo.get('url_l', photo.get('url_m', '')), image_owner=photo['owner'])
+    favorite_photos.append(IngesterQueueItem(favorited_by=flickr_user_id, image_id=photo['id'], image_url=photo.get('url_l', photo.get('url_m', '')), image_owner=photo['owner']))
 
     if photo['owner'] not in my_neighbors:
         my_neighbors[photo['owner']] = { 'user_id': photo['owner'] }
@@ -81,8 +80,7 @@ for neighbor_id in my_neighbors:
     for photo in neighbor_favorites:
         logging.debug("Found neighbor favourite photo ", photo)
 
-        if photo['id'] not in favorite_photos: # If we already added the photo as favorited by us, don't overwrite that with one of our neighbors instead
-            favorite_photos[photo['id']] = IngesterQueueItem(favorited_by=my_neighbors[neighbor_id]['user_id'], image_id=photo['id'], image_url=photo.get('url_l', photo.get('url_m', '')), image_owner=photo['owner'])
+        favorite_photos.append(IngesterQueueItem(favorited_by=my_neighbors[neighbor_id]['user_id'], image_id=photo['id'], image_url=photo.get('url_l', photo.get('url_m', '')), image_owner=photo['owner']))
 
 #
 # Output all of the photos we found to our queue

--- a/terraform/dev/main.tf
+++ b/terraform/dev/main.tf
@@ -127,7 +127,7 @@ module "api_server" {
     mysql_database_username = "${module.ingester_database.output_database_username}"
     mysql_database_password = "${var.database_password_dev}"
     mysql_database_name     = "${module.ingester_database.output_database_name}"
-    mysql_database_fetch_batch_size = 1000
+    mysql_database_fetch_batch_size = 10000
 
     ecs_cluster_id          = "${module.elastic_container_service.cluster_id}"
     ecs_instances_role_name = "${module.elastic_container_service.instance_role_name}"

--- a/terraform/dev/main.tf
+++ b/terraform/dev/main.tf
@@ -127,6 +127,7 @@ module "api_server" {
     mysql_database_username = "${module.ingester_database.output_database_username}"
     mysql_database_password = "${var.database_password_dev}"
     mysql_database_name     = "${module.ingester_database.output_database_name}"
+    mysql_database_fetch_batch_size = 1000
 
     ecs_cluster_id          = "${module.elastic_container_service.cluster_id}"
     ecs_instances_role_name = "${module.elastic_container_service.instance_role_name}"

--- a/terraform/dev/main.tf
+++ b/terraform/dev/main.tf
@@ -136,6 +136,8 @@ module "api_server" {
     ecs_instances_cpu       = 1
     ecs_instances_log_configuration = "${module.elastic_container_service.cluster_log_configuration}"
     ecs_days_to_keep_images = 1
+
+    default_num_photo_recommendations = 10
 }
 
 

--- a/terraform/modules/api-server/parameter-store.tf
+++ b/terraform/modules/api-server/parameter-store.tf
@@ -41,6 +41,13 @@ resource "aws_ssm_parameter" "database_name" {
     value       = "${var.mysql_database_name}"
 }
 
+resource "aws_ssm_parameter" "database_fetch_batch_size" {
+    name        = "/${var.environment}/api-server/database-fetch-batch-size"
+    description = "Number of records to read from the database per batch"
+    type        = "String"
+    value       = "${var.mysql_database_fetch_batch_size}"
+}
+
 resource "aws_ssm_parameter" "api_server_host" {
     name        = "/${var.environment}/api-server/server-host"
     description = "Host we listen on to serve requests"

--- a/terraform/modules/api-server/parameter-store.tf
+++ b/terraform/modules/api-server/parameter-store.tf
@@ -62,3 +62,9 @@ resource "aws_ssm_parameter" "api_server_port" {
     value       = "${var.api_server_port}"
 }
 
+resource "aws_ssm_parameter" "default_num_photo_recommendations" {
+    name        = "/${var.environment}/api-server/default-num-photo-recommendations"
+    description = "Number of photo recommendations we return if the caller doesn't specify"
+    type        = "String"
+    value       = "${var.default_num_photo_recommendations}"
+}

--- a/terraform/modules/api-server/variables.tf
+++ b/terraform/modules/api-server/variables.tf
@@ -22,3 +22,4 @@ variable "load_balancer_port" {}
 variable "load_balancer_days_to_keep_access_logs" {}
 variable "load_balancer_access_logs_bucket" {}
 variable "load_balancer_access_logs_prefix" {}
+variable "default_num_photo_recommendations" {}

--- a/terraform/modules/api-server/variables.tf
+++ b/terraform/modules/api-server/variables.tf
@@ -5,6 +5,7 @@ variable "mysql_database_port" {}
 variable "mysql_database_username" {}
 variable "mysql_database_password" {}
 variable "mysql_database_name" {}
+variable "mysql_database_fetch_batch_size" {}
 variable "vpc_id" {}
 variable "vpc_public_subnet_ids" { type = "list" }
 variable "vpc_cidr" {}


### PR DESCRIPTION
- Fixed a bug in puller-flickr that was filtering out some results (in fact, the very ones we cared about!)
- Users can query the API server for photo recommendations. 

Sample query: 

http://api-server-lb-dev-1525400879.us-west-2.elb.amazonaws.com:4444/users/86466248@N00/recommendations?num-photos=5

Had some trouble getting results returning correctly from MySQL: had to use PyMySql package rather than mysql.connector package because the latter appears to contain a bug that results in the same result over and over when using an unbuffered cursor.

Currently we're doing a simple SQL query that's returning all of the user's and neighbors' favorites from MySQL to python then calculating the recommendations once that's all received. This results in throwing out almost all of the data that was transmitted. 

It takes about 4s per query for the sample user and a t2.micro RDS database and t2.micro ECS host.

Next step is to try calculating all of this in an SQL query and comparing the performance.