### PR TITLE
Parallelization

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,6 +58,8 @@ Copy the file `terraform/terraform.tfvars.example` to `terraform/terraform.tfvar
 
 You'll be able to ssh into any EC2 instances created with `ssh ec2-user@<public ip of instance>`
 
+To kick the ECS service, ssh onto the instance you want to kick then type `sudo systemctl restart ecs`
+
 ### Run terraform
 
 Note that this will create infrastructure within your AWS account and could result in billing charges from AWS

--- a/src/common/schedulerresponsequeueitem.py
+++ b/src/common/schedulerresponsequeueitem.py
@@ -2,19 +2,32 @@ import jsonpickle
 
 class SchedulerResponseQueueItem:
 
+    # The max size of an SQS message is 256kB, and a user ID takes about 16 bytes to store (12 digits, plus quotes, comma, and space).
+    # If we start to exceed this threshold, we should switch to storing the neighbor list in S3 
+    # (if it's bigger than a certain size, to prevent hitting S3 for super small lists?) and just having a link stored in this message
+    MAX_NUM_NEIGHBORS = 16000 
+
     '''
     An item placed onto or read from the scheduler response queue. It represents a user
     '''
 
-    def __init__(self, user_id, is_registered_user):
-        self.user_id            = user_id
-        self.is_registered_user = is_registered_user
+    def __init__(self, user_id, is_registered_user, neighbor_list):
+        self.user_id                = user_id
+        self.is_registered_user     = is_registered_user
+        self.max_neighbors_exceeded = len(neighbor_list) > SchedulerResponseQueueItem.MAX_NUM_NEIGHBORS
+        self.neighbor_list          = neighbor_list[:SchedulerResponseQueueItem.MAX_NUM_NEIGHBORS]
    
     def get_user_id(self):
         return self.user_id
 
     def get_is_registered_user(self):
         return self.is_registered_user
+
+    def get_neighbor_list(self):
+        return self.neighbor_list
+
+    def get_max_neighbors_exceeded(self):
+        return self.max_neighbors_exceeded
 
     def to_json(self):
         return jsonpickle.encode(self)

--- a/terraform/dev/main.tf
+++ b/terraform/dev/main.tf
@@ -43,7 +43,7 @@ module "scheduler" {
     ecs_cluster_id = "${module.elastic_container_service.cluster_id}"
     ecs_instances_role_name = "${module.elastic_container_service.instance_role_name}"
     ecs_instances_desired_count = 1
-    ecs_instances_memory = 256
+    ecs_instances_memory = 32
     ecs_instances_cpu = 1
     ecs_instances_log_configuration = "${module.elastic_container_service.cluster_log_configuration}"
     ecs_days_to_keep_images = 1
@@ -77,8 +77,8 @@ module "puller_flickr" {
 
     ecs_cluster_id = "${module.elastic_container_service.cluster_id}"
     ecs_instances_role_name = "${module.elastic_container_service.instance_role_name}"
-    ecs_instances_desired_count = 1
-    ecs_instances_memory = 256
+    ecs_instances_desired_count = 5
+    ecs_instances_memory = 32
     ecs_instances_cpu = 1
     ecs_instances_log_configuration = "${module.elastic_container_service.cluster_log_configuration}"
     ecs_days_to_keep_images = 1
@@ -127,8 +127,8 @@ module "ingester_database" {
 
     ecs_cluster_id          = "${module.elastic_container_service.cluster_id}"
     ecs_instances_role_name = "${module.elastic_container_service.instance_role_name}"
-    ecs_instances_desired_count = 0
-    ecs_instances_memory    = 256
+    ecs_instances_desired_count = 5
+    ecs_instances_memory    = 32
     ecs_instances_cpu       = 1
     ecs_instances_log_configuration = "${module.elastic_container_service.cluster_log_configuration}"
     ecs_days_to_keep_images = 1
@@ -167,7 +167,7 @@ module "api_server" {
     ecs_cluster_id          = "${module.elastic_container_service.cluster_id}"
     ecs_instances_role_name = "${module.elastic_container_service.instance_role_name}"
     ecs_instances_desired_count = 1
-    ecs_instances_memory    = 256
+    ecs_instances_memory    = 32
     ecs_instances_cpu       = 1
     ecs_instances_log_configuration = "${module.elastic_container_service.cluster_log_configuration}"
     ecs_days_to_keep_images = 1


### PR DESCRIPTION
Have puller-flickr only pull data for one user at a time, and have the scheduler request data for all neighbors of our user. 

puller-flickr will now return all of the neighbors of a user to the scheduler, so that it can request data for each of those neighbors. I would have rather had the scheduler ask the database for all the neighbors instead, but those will be written there by ingester-database at an undefined time in the future so we can't depend on that.

But the upshot is that now we can pull from Flickr in parallel and thus greatly speed up our processing.

Added several instances of puller-flickr and ingester-database to facilitate this parallelization