### PR TITLE
Restart python jobs via script rather than restarting the container for performance

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@ src/puller-flickr/config/secrets.ini
 src/ingester-database/config/secrets.ini
 src/api-server/config/secrets.ini
 src/scheduler/config/secrets.ini
+src/common/dummy.sh

--- a/src/common/loop_command.sh
+++ b/src/common/loop_command.sh
@@ -1,0 +1,14 @@
+#!/bin/sh
+
+if [ $# -lt 2 ]; then
+    echo "Usage: loop_command.sh <command to run> <seconds to sleep in between>"
+    exit 0
+fi
+
+while true
+do
+    echo "loop_command.sh: Beginning command $1"
+    eval "$1"
+    echo "loop_command.sh: Finished command. Sleeping for $2"
+    sleep $2
+done

--- a/src/ingester-database/Dockerfile
+++ b/src/ingester-database/Dockerfile
@@ -4,7 +4,8 @@ ADD ingester-database/databasebatchwriter.py /ingester-database/
 ADD common/ingesterqueueitem.py /common/
 ADD common/queuereader.py /common/
 ADD common/confighelper.py /common/
+ADD common/loop_command.sh /common/
 RUN pip install boto3
 RUN pip install jsonpickle
 RUN pip install mysql-connector-python
-CMD [ "python", "./ingester-database/ingester-database.py" ]
+CMD [ "./common/loop_command.sh", "./ingester-database/ingester-database.py", "2" ]

--- a/src/puller-flickr/Dockerfile
+++ b/src/puller-flickr/Dockerfile
@@ -7,9 +7,10 @@ ADD common/schedulerresponsequeueitem.py /common/
 ADD common/queuewriter.py /common/
 ADD common/queuereader.py /common/
 ADD common/confighelper.py /common/
+ADD common/loop_command.sh /common/
 RUN pip install flickrapi
 RUN pip install python-memcached
 RUN pip install django
 RUN pip install boto3
 RUN pip install jsonpickle
-CMD [ "python", "./puller-flickr/puller-flickr.py" ]
+CMD [ "./common/loop_command.sh", "./puller-flickr/puller-flickr.py", "2" ]

--- a/src/scheduler/Dockerfile
+++ b/src/scheduler/Dockerfile
@@ -7,8 +7,10 @@ ADD common/schedulerresponsequeueitem.py /common/
 ADD common/queuereader.py /common/
 ADD common/queuewriter.py /common/
 ADD common/confighelper.py /common/
+ADD common/loop_command.sh /common/
 RUN pip install boto3
 RUN pip install jsonpickle
 RUN pip install mysql-connector-python
 RUN pip install requests
-CMD [ "python", "./scheduler/scheduler.py" ]
+WORKDIR scheduler/
+CMD [ "../common/loop_command.sh", "./scheduler.py", "2" ]

--- a/terraform/dev/main.tf
+++ b/terraform/dev/main.tf
@@ -28,7 +28,7 @@ module "elastic_container_service" {
     extra_security_groups = ["${module.api_server.security_group_id}"]
 
     instance_type = "t2.micro"
-    cluster_desired_size = 1
+    cluster_desired_size = 2
     cluster_min_size = 1
     cluster_max_size = 2
     instances_log_retention_days = 1
@@ -77,8 +77,8 @@ module "puller_flickr" {
 
     ecs_cluster_id = "${module.elastic_container_service.cluster_id}"
     ecs_instances_role_name = "${module.elastic_container_service.instance_role_name}"
-    ecs_instances_desired_count = 5
-    ecs_instances_memory = 32
+    ecs_instances_desired_count = 10
+    ecs_instances_memory = 64
     ecs_instances_cpu = 1
     ecs_instances_log_configuration = "${module.elastic_container_service.cluster_log_configuration}"
     ecs_days_to_keep_images = 1
@@ -127,8 +127,8 @@ module "ingester_database" {
 
     ecs_cluster_id          = "${module.elastic_container_service.cluster_id}"
     ecs_instances_role_name = "${module.elastic_container_service.instance_role_name}"
-    ecs_instances_desired_count = 5
-    ecs_instances_memory    = 32
+    ecs_instances_desired_count = 10
+    ecs_instances_memory    = 64
     ecs_instances_cpu       = 1
     ecs_instances_log_configuration = "${module.elastic_container_service.cluster_log_configuration}"
     ecs_days_to_keep_images = 1
@@ -167,7 +167,7 @@ module "api_server" {
     ecs_cluster_id          = "${module.elastic_container_service.cluster_id}"
     ecs_instances_role_name = "${module.elastic_container_service.instance_role_name}"
     ecs_instances_desired_count = 1
-    ecs_instances_memory    = 32
+    ecs_instances_memory    = 256
     ecs_instances_cpu       = 1
     ecs_instances_log_configuration = "${module.elastic_container_service.cluster_log_configuration}"
     ecs_days_to_keep_images = 1


### PR DESCRIPTION
- Added `loop_command.sh` script
- Increased size of ECS cluster for performance as well