### PR TITLE
Added retry when encounter deadlock writing to db

### DIFF
--- a/src/ingester-database/config/config.ini
+++ b/src/ingester-database/config/config.ini
@@ -10,5 +10,6 @@ output-database-host=favorites-dev.c3iwtdwtednb.us-west-2.rds.amazonaws.com
 output-database-port=3306
 output-database-name=favorites
 output-database-batchsize=100
+output-database-maxretries=3
 
 [dev]

--- a/terraform/dev/main.tf
+++ b/terraform/dev/main.tf
@@ -28,9 +28,9 @@ module "elastic_container_service" {
     extra_security_groups = ["${module.api_server.security_group_id}"]
 
     instance_type = "t2.micro"
-    cluster_desired_size = 10
+    cluster_desired_size = 18
     cluster_min_size = 1
-    cluster_max_size = 10
+    cluster_max_size = 18
     instances_log_retention_days = 1
 }
 
@@ -99,7 +99,7 @@ module "puller_flickr" {
 
     ecs_cluster_id = "${module.elastic_container_service.cluster_id}"
     ecs_instances_role_name = "${module.elastic_container_service.instance_role_name}"
-    ecs_instances_desired_count = 9
+    ecs_instances_desired_count = 20
     ecs_instances_memory = 64
     ecs_instances_cpu = 400
     ecs_instances_log_configuration = "${module.elastic_container_service.cluster_log_configuration}"
@@ -118,7 +118,7 @@ module "puller_flickr" {
 
     scheduler_queue_url = "${module.scheduler.scheduler_queue_url}"
     scheduler_queue_arn = "${module.scheduler.scheduler_queue_arn}"
-    scheduler_queue_batch_size = 10
+    scheduler_queue_batch_size = 1 # Each message takes a while to process, so hoarding a bunch of messages in an individual instance means that other instances may be underutilized
     scheduler_queue_max_items_to_process = 1000
 
     scheduler_response_queue_url = "${module.scheduler.scheduler_response_queue_url}"
@@ -134,7 +134,7 @@ module "ingester_database" {
 
     ecs_cluster_id          = "${module.elastic_container_service.cluster_id}"
     ecs_instances_role_name = "${module.elastic_container_service.instance_role_name}"
-    ecs_instances_desired_count = 9
+    ecs_instances_desired_count = 10
     ecs_instances_memory    = 64
     ecs_instances_cpu       = 400
     ecs_instances_log_configuration = "${module.elastic_container_service.cluster_log_configuration}"
@@ -146,6 +146,7 @@ module "ingester_database" {
     mysql_database_password = "${var.database_password_dev}"
     mysql_database_name     = "${module.database.database_name}"
     mysql_database_batch_size = 1000
+    mysql_database_maxretries = 3
 
     input_queue_batch_size  = 10
     input_queue_max_items_to_process = 10000

--- a/terraform/modules/ingester-database/parameter-store.tf
+++ b/terraform/modules/ingester-database/parameter-store.tf
@@ -48,6 +48,13 @@ resource "aws_ssm_parameter" "output_database_batch_size" {
     value       = "${var.mysql_database_batch_size}"
 }
 
+resource "aws_ssm_parameter" "output_database_maxretries" {
+    name        = "/${var.environment}/ingester-database/output-database-maxretries"
+    description = "Number of items to retry a put operation to the database"
+    type        = "String"
+    value       = "${var.mysql_database_maxretries}"
+}
+
 resource "aws_ssm_parameter" "input_queue_url" {
     name        = "/${var.environment}/ingester-database/input-queue-url"
     description = "Endpoint of queue we use to ingest favorites data intended for the database"

--- a/terraform/modules/ingester-database/variables.tf
+++ b/terraform/modules/ingester-database/variables.tf
@@ -6,6 +6,7 @@ variable "mysql_database_username" {}
 variable "mysql_database_password" {}
 variable "mysql_database_name" {}
 variable "mysql_database_batch_size" {}
+variable "mysql_database_maxretries" {}
 variable "ecs_instances_desired_count" {}
 variable "ecs_instances_memory" {}
 variable "ecs_instances_cpu" {}


### PR DESCRIPTION
Fixes https://github.com/euan-forrester/photo-recommender/issues/34

Various tweaks to improve performance:
- Stop logging so much in ingester-database to use less networking resources
- Increase size of ECS cluster
- More instances of processes