### PR TITLE
Changed config helper to first look up parameters in memcached 

### DIFF
--- a/src/api-server/Dockerfile
+++ b/src/api-server/Dockerfile
@@ -10,6 +10,7 @@ RUN pip install flask_api
 RUN pip install gunicorn
 RUN pip install mysql-connector-python
 RUN pip install boto3
+RUN pip install pymemcache
 EXPOSE 4445
 WORKDIR /api-server/
 CMD [ "gunicorn", "-b", "0.0.0.0:4445", "--access-logfile", "-", "--error-logfile", "-", "api-server" ]

--- a/src/common/confighelper.py
+++ b/src/common/confighelper.py
@@ -3,6 +3,8 @@ import boto3
 from botocore.exceptions import ClientError
 import logging
 import os
+from pymemcache.client.base import Client
+from pymemcache import serde
 
 class ConfigHelper:
     
@@ -21,19 +23,22 @@ class ConfigHelper:
             return ConfigHelperParameterStore(environment=ENVIRONMENT, key_prefix=aws_parameter_prefix)
 
     @staticmethod
-    def _log_int(param, value, is_secret):
-        if is_secret:
-            logging.info(f"Got parameter {param} with value <secret>")
-        else:
-            logging.info(f"Got parameter {param} with value {value}")
+    def _log(param, value, is_secret, is_cached=False):
+        logging.info(f"Got parameter {param} {ConfigHelper._get_is_cached_log_string(is_cached)} with value {ConfigHelper._get_value_log_string(value, is_secret)}")
 
     @staticmethod
-    def _log_str(param, value, is_secret):
-        if is_secret:
-            logging.info(f"Got parameter {param} with value <secret>")
+    def _get_is_cached_log_string(is_cached):
+        if is_cached:
+            return "from the cache"
         else:
-            logging.info(f"Got parameter {param} with value {value}")
+            return "directly from the store" 
 
+    @staticmethod
+    def _get_value_log_string(value, is_secret):
+        if is_secret:
+            return "<secret>"
+        else:
+            return f"{value}" 
 
 class ConfigHelperFile(ConfigHelper):
     
@@ -52,7 +57,7 @@ class ConfigHelperFile(ConfigHelper):
     def get(self, key, is_secret=False):
         try:
             value = self.config.get(self.environment, key)
-            ConfigHelper._log_str(key, value, is_secret)
+            ConfigHelper._log(key, value, is_secret)
             return value
 
         except configparser.NoOptionError as e:
@@ -62,7 +67,7 @@ class ConfigHelperFile(ConfigHelper):
     def getInt(self, key, is_secret=False):
         try:
             value = self.config.getint(self.environment, key)
-            ConfigHelper._log_int(key, value, is_secret)
+            ConfigHelper._log(key, value, is_secret)
             return value
 
         except configparser.NoOptionError as e:
@@ -74,19 +79,77 @@ class ConfigHelperParameterStore(ConfigHelper):
     Reads config items from the AWS Parameter Store
     '''
 
+    MEMCACHED_TTL = 300             # 5 minutes
+    MEMCACHED_CONNECT_TIMEOUT = 5   # 5 seconds
+    MEMCACHED_TIMEOUT = 5           # 5 seconds
+
     def __init__(self, environment, key_prefix):
         self.environment    = environment
         self.key_prefix     = key_prefix
         self.ssm            = boto3.client('ssm') # Region is read from the AWS_DEFAULT_REGION env var
+        self.memcached_location = self._get_from_parameter_store(self._get_full_path("parameter-memcached-location"))
+        self.memcached_client = None
+
+        if self.memcached_location is None:
+            logging.info(f"Could not find parameter memcached location in parameter store at {self._get_full_path('parameter-memcached-location')}")
+
+        else:
+            logging.info(f"Found parameter memcached location {self.memcached_location}")
+
+            memcached_location_portions = self.memcached_location.split(":")
+            if len(memcached_location_portions) != 2:
+                raise ValueError(f"Found incorrectly formatted parameter memcached location: {self.memcached_location}") 
+
+            memcached_host = memcached_location_portions[0]
+            memcached_port = int(memcached_location_portions[1])
+            
+            self.memcached_client = Client(
+                server=(memcached_host, memcached_port), 
+                serializer=serde.python_memcache_serializer,
+                deserializer=serde.python_memcache_deserializer,
+                connect_timeout=ConfigHelperParameterStore.MEMCACHED_CONNECT_TIMEOUT,
+                timeout=ConfigHelperParameterStore.MEMCACHED_TIMEOUT)
 
     def get(self, key, is_secret=False):
-        
-        full_path = f'/{self.environment}/{self.key_prefix}/{key}'
 
-        try:
-            value = self.ssm.get_parameter(Name=full_path, WithDecryption=is_secret)['Parameter']['Value']
-            ConfigHelper._log_str(full_path, value, is_secret)
+        # With lots of container instances running, each one is constantly getting values from 
+        # the parameter store and we can start to see ourselves getting throttled. So,
+        # put all of our values into memcached instead
+
+        full_path = self._get_full_path(key)
+
+        if is_secret or self.memcached_client is None:
+            # Don't cache secret parameters because they'll be stored unencrypted in the cache
+            value = self._get_from_parameter_store(full_path, is_secret)
+            ConfigHelper._log(full_path, value, is_secret, is_cached=False)
             return value
+
+        value_from_cache = self._get_from_cache(full_path)
+
+        if value_from_cache is not None:
+            ConfigHelper._log(full_path, value_from_cache, is_secret, is_cached=True)
+            return value_from_cache
+
+        value = self._get_from_parameter_store(full_path, is_secret)
+
+        ConfigHelper._log(full_path, value, is_secret, is_cached=False)
+
+        self._write_to_cache(full_path, value)
+
+        return value
+
+    def _get_from_cache(self, full_path):
+
+        return self.memcached_client.get(full_path)
+
+    def _write_to_cache(self, full_path, value):
+
+        self.memcached_client.set(full_path, value, ConfigHelperParameterStore.MEMCACHED_TTL)        
+
+    def _get_from_parameter_store(self, full_path, is_secret=False):
+        
+        try:
+            return self.ssm.get_parameter(Name=full_path, WithDecryption=is_secret)['Parameter']['Value']
 
         except ClientError as e:
             error_code = e.response['Error']['Code']
@@ -96,6 +159,9 @@ class ConfigHelperParameterStore(ConfigHelper):
             else:
                 # Something else bad happened; better just let it through
                 raise
+
+    def _get_full_path(self, key):
+        return f'/{self.environment}/{self.key_prefix}/{key}'
 
     # This will throw a ValueError if the parameter doesn't contain an int
     def getInt(self, key, is_secret=False):

--- a/src/common/confighelper.py
+++ b/src/common/confighelper.py
@@ -16,23 +16,23 @@ class ConfigHelper:
         else:
             ENVIRONMENT = os.environ.get('ENVIRONMENT')
 
-            logging.info("Found ENVIRONMENT environment variable containing '%s': assuming we're running in AWS and getting our parameters from the AWS Parameter Store" % (ENVIRONMENT))
+            logging.info(f"Found ENVIRONMENT environment variable containing '{ENVIRONMENT}': assuming we're running in AWS and getting our parameters from the AWS Parameter Store")
 
             return ConfigHelperParameterStore(environment=ENVIRONMENT, key_prefix=aws_parameter_prefix)
 
     @staticmethod
     def _log_int(param, value, is_secret):
         if is_secret:
-            logging.info("Got parameter %s with value <secret>" % (param))
+            logging.info(f"Got parameter {param} with value <secret>")
         else:
-            logging.info("Got parameter %s with value %d" % (param, value))
+            logging.info(f"Got parameter {param} with value {value}")
 
     @staticmethod
     def _log_str(param, value, is_secret):
         if is_secret:
-            logging.info("Got parameter %s with value <secret>" % (param))
+            logging.info(f"Got parameter {param} with value <secret>")
         else:
-            logging.info("Got parameter %s with value %s" % (param, value))
+            logging.info(f"Got parameter {param} with value {value}")
 
 
 class ConfigHelperFile(ConfigHelper):
@@ -46,7 +46,7 @@ class ConfigHelperFile(ConfigHelper):
         self.config         = configparser.ConfigParser()
 
         for filename in filename_list:
-            logging.info("Reading in config file '%s'" % filename)
+            logging.info(f"Reading in config file '{filename}'")
             self.config.read(filename)
 
     def get(self, key, is_secret=False):
@@ -56,7 +56,7 @@ class ConfigHelperFile(ConfigHelper):
             return value
 
         except configparser.NoOptionError as e:
-            raise ParameterNotFoundException(message='Could not get parameter %s' % (key)) from e
+            raise ParameterNotFoundException(message=f'Could not get parameter {key}') from e
 
     # This will throw a ValueError if the parameter doesn't contain an int
     def getInt(self, key, is_secret=False):
@@ -66,7 +66,7 @@ class ConfigHelperFile(ConfigHelper):
             return value
 
         except configparser.NoOptionError as e:
-            raise ParameterNotFoundException(message='Could not get parameter %s' % (key)) from e
+            raise ParameterNotFoundException(message=f'Could not get parameter {key}') from e
 
 class ConfigHelperParameterStore(ConfigHelper):
 
@@ -81,7 +81,7 @@ class ConfigHelperParameterStore(ConfigHelper):
 
     def get(self, key, is_secret=False):
         
-        full_path = '/%s/%s/%s' % (self.environment, self.key_prefix, key)
+        full_path = f'/{self.environment}/{self.key_prefix}/{key}'
 
         try:
             value = self.ssm.get_parameter(Name=full_path, WithDecryption=is_secret)['Parameter']['Value']
@@ -92,7 +92,7 @@ class ConfigHelperParameterStore(ConfigHelper):
             error_code = e.response['Error']['Code']
 
             if error_code == "ParameterNotFound":
-                raise ParameterNotFoundException(message='Could not get parameter %s: %s' % (full_path, error_code)) from e
+                raise ParameterNotFoundException(message=f'Could not get parameter {full_path}: {error_code}') from e
             else:
                 # Something else bad happened; better just let it through
                 raise

--- a/src/ingester-database/Dockerfile
+++ b/src/ingester-database/Dockerfile
@@ -8,4 +8,5 @@ ADD common/loop_command.sh /common/
 RUN pip install boto3
 RUN pip install jsonpickle
 RUN pip install mysql-connector-python
+RUN pip install pymemcache
 CMD [ "./common/loop_command.sh", "./ingester-database/ingester-database.py", "2" ]

--- a/src/puller-flickr/Dockerfile
+++ b/src/puller-flickr/Dockerfile
@@ -13,4 +13,5 @@ RUN pip install python-memcached
 RUN pip install django
 RUN pip install boto3
 RUN pip install jsonpickle
+RUN pip install pymemcache
 CMD [ "./common/loop_command.sh", "./puller-flickr/puller-flickr.py", "2" ]

--- a/src/scheduler/Dockerfile
+++ b/src/scheduler/Dockerfile
@@ -12,5 +12,6 @@ RUN pip install boto3
 RUN pip install jsonpickle
 RUN pip install mysql-connector-python
 RUN pip install requests
+RUN pip install pymemcache
 WORKDIR scheduler/
 CMD [ "../common/loop_command.sh", "./scheduler.py", "2" ]

--- a/terraform/dev/main.tf
+++ b/terraform/dev/main.tf
@@ -56,6 +56,22 @@ module "database" {
     mysql_database_password = "${var.database_password_dev}"
 }
 
+module "memcached" {
+    source = "../modules/memcached"
+
+    environment = "dev"
+    region = "${var.region}"
+
+    vpc_id                  = "${module.vpc.vpc_id}"
+    vpc_public_subnet_ids   = "${module.vpc.vpc_public_subnet_ids}"
+    vpc_cidr                = "${module.vpc.vpc_cidr_block}"
+    local_machine_cidr      = "${var.local_machine_cidr}"
+
+    memcached_node_type = "cache.t2.micro"
+    memcached_num_cache_nodes = 0 # Set to 0 to disable memcached in dev to save billing charges
+    memcached_az_mode = "single-az" # Single az in dev to save billing charges
+}
+
 module "scheduler" {
     source = "../modules/scheduler"
 
@@ -87,14 +103,7 @@ module "puller_flickr" {
     environment = "dev"
     region = "${var.region}"
 
-    vpc_id = "${module.vpc.vpc_id}"
-    vpc_public_subnet_ids = "${module.vpc.vpc_public_subnet_ids}"
-    vpc_cidr = "${module.vpc.vpc_cidr_block}"
-    local_machine_cidr = "${var.local_machine_cidr}"
-
-    memcached_node_type = "cache.t2.micro"
-    memcached_num_cache_nodes = 0 # Disable memcached in dev to save billing charges
-    memcached_az_mode = "cross-az"
+    memcached_location = "${module.memcached.location}"
     memcached_ttl = 7200
 
     ecs_cluster_id = "${module.elastic_container_service.cluster_id}"

--- a/terraform/dev/main.tf
+++ b/terraform/dev/main.tf
@@ -68,7 +68,7 @@ module "memcached" {
     local_machine_cidr      = "${var.local_machine_cidr}"
 
     memcached_node_type = "cache.t2.micro"
-    memcached_num_cache_nodes = 0 # Set to 0 to disable memcached in dev to save billing charges
+    memcached_num_cache_nodes = 1 # Set to 0 to disable memcached in dev to save billing charges
     memcached_az_mode = "single-az" # Single az in dev to save billing charges
 }
 
@@ -77,6 +77,8 @@ module "scheduler" {
 
     environment = "dev"
     region = "${var.region}"
+
+    parameter_memcached_location = "${module.memcached.location}"
 
     ecs_cluster_id = "${module.elastic_container_service.cluster_id}"
     ecs_instances_role_name = "${module.elastic_container_service.instance_role_name}"
@@ -103,7 +105,9 @@ module "puller_flickr" {
     environment = "dev"
     region = "${var.region}"
 
-    memcached_location = "${module.memcached.location}"
+    parameter_memcached_location = "${module.memcached.location}"
+
+    memcached_location = "localhost:11211" # Disable cacheing Flickr API responses for now, so we can test performance
     memcached_ttl = 7200
 
     ecs_cluster_id = "${module.elastic_container_service.cluster_id}"
@@ -141,6 +145,8 @@ module "ingester_database" {
     environment             = "dev"
     region                  = "${var.region}"
 
+    parameter_memcached_location = "${module.memcached.location}"
+
     ecs_cluster_id          = "${module.elastic_container_service.cluster_id}"
     ecs_instances_role_name = "${module.elastic_container_service.instance_role_name}"
     ecs_instances_desired_count = 10
@@ -166,6 +172,8 @@ module "api_server" {
 
     environment             = "dev"
     region                  = "${var.region}"
+
+    parameter_memcached_location = "${module.memcached.location}"
 
     vpc_id                  = "${module.vpc.vpc_id}"
     vpc_public_subnet_ids   = "${module.vpc.vpc_public_subnet_ids}"

--- a/terraform/dev/main.tf
+++ b/terraform/dev/main.tf
@@ -28,9 +28,9 @@ module "elastic_container_service" {
     extra_security_groups = ["${module.api_server.security_group_id}"]
 
     instance_type = "t2.micro"
-    cluster_desired_size = 18
+    cluster_desired_size = 20
     cluster_min_size = 1
-    cluster_max_size = 18
+    cluster_max_size = 30
     instances_log_retention_days = 1
 }
 

--- a/terraform/modules/api-server/parameter-store.tf
+++ b/terraform/modules/api-server/parameter-store.tf
@@ -5,6 +5,13 @@ resource "aws_kms_key" "parameter_secrets" {
     deletion_window_in_days = 7
 }
 
+resource "aws_ssm_parameter" "parameter_memcached_location" {
+    name        = "/${var.environment}/api-server/parameter-memcached-location"
+    description = "Where to find a memcached instance to cache our parameter values"
+    type        = "String"
+    value       = "${var.parameter_memcached_location}"
+}
+
 resource "aws_ssm_parameter" "database_host" {
     name        = "/${var.environment}/api-server/database-host"
     description = "Host for the database from which we read our data"

--- a/terraform/modules/api-server/variables.tf
+++ b/terraform/modules/api-server/variables.tf
@@ -1,5 +1,6 @@
 variable "environment" {}
 variable "region" {}
+variable "parameter_memcached_location" {}
 variable "mysql_database_host" {}
 variable "mysql_database_port" {}
 variable "mysql_database_username" {}

--- a/terraform/modules/ingester-database/parameter-store.tf
+++ b/terraform/modules/ingester-database/parameter-store.tf
@@ -5,6 +5,13 @@ resource "aws_kms_key" "parameter_secrets" {
     deletion_window_in_days = 7
 }
 
+resource "aws_ssm_parameter" "parameter_memcached_location" {
+    name        = "/${var.environment}/ingester-database/parameter-memcached-location"
+    description = "Where to find a memcached instance to cache our parameter values"
+    type        = "String"
+    value       = "${var.parameter_memcached_location}"
+}
+
 resource "aws_ssm_parameter" "output_database_host" {
     name        = "/${var.environment}/ingester-database/output-database-host"
     description = "Host for the database into which we ingest data from the queue"

--- a/terraform/modules/ingester-database/variables.tf
+++ b/terraform/modules/ingester-database/variables.tf
@@ -1,5 +1,6 @@
 variable "environment" {}
 variable "region" {}
+variable "parameter_memcached_location" {}
 variable "mysql_database_host" {}
 variable "mysql_database_port" {}
 variable "mysql_database_username" {}

--- a/terraform/modules/memcached/memcached.tf
+++ b/terraform/modules/memcached/memcached.tf
@@ -1,5 +1,5 @@
 resource "aws_security_group" "elasticache" {
-    name        = "terraform-elasticache-${var.environment}"
+    name        = "memcached-${var.environment}"
     description = "Allow communication with the memcached instance"
     vpc_id      = "${var.vpc_id}"
 
@@ -19,14 +19,14 @@ resource "aws_security_group_rule" "elasticache-local-machine" {
 }
 
 resource "aws_elasticache_subnet_group" "public_subnet_group" {
-    name       = "public-elasticache-subnet-group-puller-flickr-memcached-${var.environment}"
+    name       = "public-elasticache-subnet-group-memcached-${var.environment}"
     subnet_ids = ["${var.vpc_public_subnet_ids}"]
 }
 
 resource "aws_elasticache_cluster" "memcached" {
     count                = "${var.memcached_num_cache_nodes != 0 ? 1 : 0}" # Don't create the resource at all if we specify 0 nodes. See https://itnext.io/things-i-wish-i-knew-about-terraform-before-jumping-into-it-43ee92a9dd65
 
-    cluster_id           = "puller-flickr-${var.environment}"
+    cluster_id           = "memcached-${var.environment}"
     engine               = "memcached"
     node_type            = "${var.memcached_node_type}"
     num_cache_nodes      = "${var.memcached_num_cache_nodes}"

--- a/terraform/modules/memcached/outputs.tf
+++ b/terraform/modules/memcached/outputs.tf
@@ -1,0 +1,8 @@
+output "location" {
+    # Ugly syntax here for referencing a resource that may not exist. See https://github.com/hashicorp/terraform/issues/16726
+    # Puts "localhost:11211" in this attribute if the memcached cluster wasn't created. The script will attempt to connect to there, fail, and continue in that case
+    # Also note that all variables are internally stored as strings, so having the port as an int results in a strange error message: https://github.com/hashicorp/terraform/issues/17033
+    value       = "${format("%s:%s", element(concat(aws_elasticache_cluster.memcached.*.cluster_address, list("localhost")), 0), element(concat(aws_elasticache_cluster.memcached.*.port, list("11211")), 0))}"
+
+    description = "Connection string for the memcached cluster created (or 'localhost:11211' if it was not created)"
+}

--- a/terraform/modules/memcached/variables.tf
+++ b/terraform/modules/memcached/variables.tf
@@ -1,0 +1,11 @@
+variable "environment" {}
+variable "region" {}
+
+variable "vpc_id" {}
+variable "vpc_public_subnet_ids" { type = "list" }
+variable "local_machine_cidr" {}
+variable "vpc_cidr" {}
+
+variable "memcached_node_type" {}
+variable "memcached_num_cache_nodes" {}
+variable "memcached_az_mode" {}

--- a/terraform/modules/puller-flickr/parameter-store.tf
+++ b/terraform/modules/puller-flickr/parameter-store.tf
@@ -52,10 +52,7 @@ resource "aws_ssm_parameter" "memcached_location" {
     name        = "/${var.environment}/puller-flickr/memcached-location"
     description = "Endpoint of the memcached cluster that we cache Flickr API calls to"
     type        = "String"
-    # Ugly syntax here for referencing a resource that may not exist. See https://github.com/hashicorp/terraform/issues/16726
-    # Puts "localhost:11211" in this attribute if the memcached cluster wasn't created. The script will attempt to connect to there, fail, and continue in that case
-    # Also note that all variables are internally stored as strings, so having the port as an int results in a strange error message: https://github.com/hashicorp/terraform/issues/17033
-    value       = "${format("%s:%s", element(concat(aws_elasticache_cluster.memcached.*.cluster_address, list("localhost")), 0), element(concat(aws_elasticache_cluster.memcached.*.port, list("11211")), 0))}"
+    value       = "${var.memcached_location}"
 }
 
 resource "aws_ssm_parameter" "output_queue_url" {

--- a/terraform/modules/puller-flickr/parameter-store.tf
+++ b/terraform/modules/puller-flickr/parameter-store.tf
@@ -5,6 +5,13 @@ resource "aws_kms_key" "parameter_secrets" {
     deletion_window_in_days = 7
 }
 
+resource "aws_ssm_parameter" "parameter_memcached_location" {
+    name        = "/${var.environment}/puller-flickr/parameter-memcached-location"
+    description = "Where to find a memcached instance to cache our parameter values"
+    type        = "String"
+    value       = "${var.parameter_memcached_location}"
+}
+
 resource "aws_ssm_parameter" "flickr_api_key" {
     name        = "/${var.environment}/puller-flickr/flickr-api-key"
     description = "Flickr API key"

--- a/terraform/modules/puller-flickr/variables.tf
+++ b/terraform/modules/puller-flickr/variables.tf
@@ -1,5 +1,6 @@
 variable "environment" {}
 variable "region" {}
+variable "parameter_memcached_location" {}
 variable "memcached_location" {}
 variable "memcached_ttl" {}
 variable "ecs_instances_desired_count" {}

--- a/terraform/modules/puller-flickr/variables.tf
+++ b/terraform/modules/puller-flickr/variables.tf
@@ -1,13 +1,7 @@
 variable "environment" {}
 variable "region" {}
-variable "vpc_id" {}
-variable "vpc_public_subnet_ids" { type = "list" }
-variable "memcached_node_type" {}
-variable "memcached_num_cache_nodes" {}
-variable "memcached_az_mode" {}
+variable "memcached_location" {}
 variable "memcached_ttl" {}
-variable "local_machine_cidr" {}
-variable "vpc_cidr" {}
 variable "ecs_instances_desired_count" {}
 variable "ecs_instances_memory" {}
 variable "ecs_instances_cpu" {}

--- a/terraform/modules/scheduler/parameter-store.tf
+++ b/terraform/modules/scheduler/parameter-store.tf
@@ -1,3 +1,10 @@
+resource "aws_ssm_parameter" "parameter_memcached_location" {
+    name        = "/${var.environment}/scheduler/parameter-memcached-location"
+    description = "Where to find a memcached instance to cache our parameter values"
+    type        = "String"
+    value       = "${var.parameter_memcached_location}"
+}
+
 resource "aws_ssm_parameter" "api_server_host" {
     name        = "/${var.environment}/scheduler/api-server-host"
     description = "Host for API server from which we get scheduling information"

--- a/terraform/modules/scheduler/variables.tf
+++ b/terraform/modules/scheduler/variables.tf
@@ -1,5 +1,6 @@
 variable "environment" {}
 variable "region" {}
+variable "parameter_memcached_location" {}
 variable "api_server_host" {}
 variable "api_server_port" {}
 variable "ecs_instances_desired_count" {}


### PR DESCRIPTION
Fixes https://github.com/euan-forrester/photo-recommender/issues/36

First read parameters from a memcached instance and only after that try and hit the actual parameter store, to prevent being throttled by the parameter store. Always look up secrets in the parameter store though, so they don't get stored unencrypted in our cache.

Also: 
- Moved the memcached terraform into its own top-level module
- Added some more EC2 instances to our cluster
- Update some more python to use the `f` style string formatting