### PR TITLE
Batch ingester messages together for performance & cost

### DIFF
--- a/src/common/ingesterqueuebatchitem.py
+++ b/src/common/ingesterqueuebatchitem.py
@@ -1,0 +1,21 @@
+import jsonpickle
+
+class IngesterQueueBatchItem:
+
+    '''
+    An item placed onto or read from the ingester queue. It represents a set of favorite (or equivalent) photos
+    '''
+
+    def __init__(self, item_list):
+        self.item_list = item_list
+   
+    def get_item_list(self):
+        return self.item_list
+
+    def to_json(self):
+        return jsonpickle.encode(self)
+
+    @staticmethod
+    def from_json(json):
+        return jsonpickle.decode(json)
+        

--- a/src/common/ingesterqueueitem.py
+++ b/src/common/ingesterqueueitem.py
@@ -1,9 +1,7 @@
-import jsonpickle
-
 class IngesterQueueItem:
 
     '''
-    An item placed onto or read from the ingester queue. It represents a favorite (or equivalent) photo
+    An item placed onto or read from a batch message on the ingester queue. It represents a favorite (or equivalent) photo
     '''
 
     def __init__(self, image_id, image_url, image_owner, favorited_by):
@@ -23,11 +21,3 @@ class IngesterQueueItem:
 
     def get_favorited_by(self):
         return self.favorited_by
-
-    def to_json(self):
-        return jsonpickle.encode(self)
-
-    @staticmethod
-    def from_json(json):
-        return jsonpickle.decode(json)
-        

--- a/src/common/queuewriter.py
+++ b/src/common/queuewriter.py
@@ -22,6 +22,8 @@ class SQSQueueWriter:
                 'MessageBody': to_string(obj)
             }
 
+            logging.info(f"Sending message with a body containing {len(message['MessageBody']) / 1024} kB")
+
             current_batch.append(message)
 
             if len(current_batch) >= self.batch_size:

--- a/src/ingester-database/Dockerfile
+++ b/src/ingester-database/Dockerfile
@@ -2,6 +2,7 @@ FROM python:3-alpine
 ADD ingester-database/ingester-database.py /ingester-database/
 ADD ingester-database/databasebatchwriter.py /ingester-database/
 ADD common/ingesterqueueitem.py /common/
+ADD common/ingesterqueuebatchitem.py /common/
 ADD common/queuereader.py /common/
 ADD common/confighelper.py /common/
 ADD common/loop_command.sh /common/

--- a/src/ingester-database/config/config.ini
+++ b/src/ingester-database/config/config.ini
@@ -9,7 +9,7 @@ output-database-username=favorites_dev
 output-database-host=favorites-dev.c3iwtdwtednb.us-west-2.rds.amazonaws.com
 output-database-port=3306
 output-database-name=favorites
-output-database-batchsize=100
+output-database-min-batchsize=100
 output-database-maxretries=3
 
 [dev]

--- a/src/puller-flickr/Dockerfile
+++ b/src/puller-flickr/Dockerfile
@@ -2,6 +2,7 @@ FROM python:3-alpine
 ADD puller-flickr/puller-flickr.py /puller-flickr/
 ADD puller-flickr/flickrapiwrapper.py /puller-flickr/
 ADD common/ingesterqueueitem.py /common/
+ADD common/ingesterqueuebatchitem.py /common/
 ADD common/schedulerqueueitem.py /common/
 ADD common/schedulerresponsequeueitem.py /common/
 ADD common/queuewriter.py /common/

--- a/src/scheduler/scheduler.py
+++ b/src/scheduler/scheduler.py
@@ -107,10 +107,12 @@ try:
 
         logging.info(f"Found {len(neighbors_to_request_data_for)} neighbors who need their data updated. Sending messages to queue {scheduler_queue_url} in batches of {scheduler_queue_batch_size}")
 
-        scheduler_queue.send_messages(objects=neighbors_to_request_data_for, to_string=lambda user : user.to_json())
+        if len(neighbors_to_request_data_for) > 0:
+            scheduler_queue.send_messages(objects=neighbors_to_request_data_for, to_string=lambda user : user.to_json())
 
-        for neighbor in neighbors_to_request_data_for:
-            logging.info(f"Requested data for user {neighbor.get_user_id()}")
+            if logging.getLogger().getEffectiveLevel() <= logging.INFO:
+                for neighbor in neighbors_to_request_data_for:
+                    logging.info(f"Requested data for user {neighbor.get_user_id()}")
 
         users_store.data_updated(response.get_user_id())
 

--- a/terraform/dev/main.tf
+++ b/terraform/dev/main.tf
@@ -28,7 +28,7 @@ module "elastic_container_service" {
     extra_security_groups = ["${module.api_server.security_group_id}"]
 
     instance_type = "t2.micro"
-    cluster_desired_size = 20
+    cluster_desired_size = 30
     cluster_min_size = 1
     cluster_max_size = 30
     instances_log_retention_days = 1
@@ -115,7 +115,7 @@ module "puller_flickr" {
 
     ecs_cluster_id = "${module.elastic_container_service.cluster_id}"
     ecs_instances_role_name = "${module.elastic_container_service.instance_role_name}"
-    ecs_instances_desired_count = 20
+    ecs_instances_desired_count = 30
     ecs_instances_memory = 64
     ecs_instances_cpu = 400
     ecs_instances_log_configuration = "${module.elastic_container_service.cluster_log_configuration}"
@@ -152,7 +152,7 @@ module "ingester_database" {
 
     ecs_cluster_id          = "${module.elastic_container_service.cluster_id}"
     ecs_instances_role_name = "${module.elastic_container_service.instance_role_name}"
-    ecs_instances_desired_count = 10
+    ecs_instances_desired_count = 20
     ecs_instances_memory    = 64
     ecs_instances_cpu       = 400
     ecs_instances_log_configuration = "${module.elastic_container_service.cluster_log_configuration}"
@@ -163,10 +163,10 @@ module "ingester_database" {
     mysql_database_username = "${module.database.database_username}"
     mysql_database_password = "${var.database_password_dev}"
     mysql_database_name     = "${module.database.database_name}"
-    mysql_database_batch_size = 1000
+    mysql_database_min_batch_size = 500
     mysql_database_maxretries = 3
 
-    input_queue_batch_size  = 10
+    input_queue_batch_size  = 1 # Each message takes a while to process because it contains many individual items, so only get one at a time so that we're not blocking other instances from picking them up
     input_queue_max_items_to_process = 10000
 }
 

--- a/terraform/modules/ingester-database/parameter-store.tf
+++ b/terraform/modules/ingester-database/parameter-store.tf
@@ -48,11 +48,11 @@ resource "aws_ssm_parameter" "output_database_name" {
     value       = "${var.mysql_database_name}"
 }
 
-resource "aws_ssm_parameter" "output_database_batch_size" {
-    name        = "/${var.environment}/ingester-database/output-database-batchsize"
-    description = "Number of items to put into the database in a single batch"
+resource "aws_ssm_parameter" "output_database_min_batch_size" {
+    name        = "/${var.environment}/ingester-database/output-database-min-batchsize"
+    description = "Minimum number of items to put into the database in a single batch"
     type        = "String"
-    value       = "${var.mysql_database_batch_size}"
+    value       = "${var.mysql_database_min_batch_size}"
 }
 
 resource "aws_ssm_parameter" "output_database_maxretries" {

--- a/terraform/modules/ingester-database/variables.tf
+++ b/terraform/modules/ingester-database/variables.tf
@@ -6,7 +6,7 @@ variable "mysql_database_port" {}
 variable "mysql_database_username" {}
 variable "mysql_database_password" {}
 variable "mysql_database_name" {}
-variable "mysql_database_batch_size" {}
+variable "mysql_database_min_batch_size" {}
 variable "mysql_database_maxretries" {}
 variable "ecs_instances_desired_count" {}
 variable "ecs_instances_memory" {}


### PR DESCRIPTION
Have one ingester-queue message contain many different photos rather than 1 photo/message, to reduce overhead in writing/reading to the queue for 10s of thousands of messages.

We get a max of 1000 photos from an individual user, which has a message size of around 218kB, just below the max SQS message size of 256kB

Also reduced the threshold for writing to the database, to help prevent individual instances of ingester-database from holding onto messages for a long period of time, and thus allowing them to be parallelized better.

And perhaps a slight optimization to the scheduler to not try and write out response messages if there aren't any.