### PR TITLE
Limit the number of calls that puller-flickr makes to flickr

### DIFF
--- a/src/puller-flickr/config/config.ini
+++ b/src/puller-flickr/config/config.ini
@@ -4,6 +4,7 @@ flickr-api-key=none
 flickr-api-retries=3
 flickr-api-favorites-maxpercall=500
 flickr-api-favorites-maxtoget=1000
+flickr-api-favorites-maxcallstomake=3
 
 memcached-location=puller-flickr-dev.j94z7t.cfg.usw2.cache.amazonaws.com:11211
 memcached-ttl=7200 

--- a/terraform/dev/main.tf
+++ b/terraform/dev/main.tf
@@ -127,6 +127,7 @@ module "puller_flickr" {
     flickr_api_retries = 3
     flickr_api_favorites_max_per_call = 500
     flickr_api_favorites_max_to_get = 1000
+    flickr_api_favorites_max_calls_to_make = 1
 
     output_queue_url = "${module.ingester_database.ingester_queue_url}"
     output_queue_arn = "${module.ingester_database.ingester_queue_arn}"

--- a/terraform/modules/puller-flickr/parameter-store.tf
+++ b/terraform/modules/puller-flickr/parameter-store.tf
@@ -48,6 +48,13 @@ resource "aws_ssm_parameter" "flickr_api_favorites_max_to_get" {
     value       = "${var.flickr_api_favorites_max_to_get}"
 }
 
+resource "aws_ssm_parameter" "flickr_api_favorites_max_calls_to_make" {
+    name        = "/${var.environment}/puller-flickr/flickr-api-favorites-maxcallstomake"
+    description = "Max number of calls to favorites endpoint to make per user."
+    type        = "String"
+    value       = "${var.flickr_api_favorites_max_calls_to_make}"
+}
+
 resource "aws_ssm_parameter" "memcached_ttl" {
     name        = "/${var.environment}/puller-flickr/memcached-ttl"
     description = "TTL in seconds of Flickr API calls put into memcached"

--- a/terraform/modules/puller-flickr/variables.tf
+++ b/terraform/modules/puller-flickr/variables.tf
@@ -16,6 +16,7 @@ variable "flickr_user_id" {}
 variable "flickr_api_retries" {}
 variable "flickr_api_favorites_max_per_call" {}
 variable "flickr_api_favorites_max_to_get" {}
+variable "flickr_api_favorites_max_calls_to_make" {}
 variable "output_queue_url" {}
 variable "output_queue_arn" {}
 variable "output_queue_batch_size" {}


### PR DESCRIPTION
When calling the Flickr API and asking for 500 photos, we often get back less than that. So, instead of taking the expected 2 calls to get to 1000 photos, it can often take 3 or more.

Let's limit the number of calls that we make to get our batch of photos, to help with performance

Also noticed a bug where we can send a batch message containing 0 photos, which ingester-database barfs on.