### PR TITLE
Make python dependencies explicit

### DIFF
--- a/README.md
+++ b/README.md
@@ -129,7 +129,7 @@ TODO:
 - Make a build pipeline
 - Consider moving MySQL passwords into config files rather than passing on command line from terraform script
 - Add tests
-- Lock python lib version numbers (see https://docs.docker.com/samples/library/python/#pythonversion-alpine to lock python version)
+- Look into how to lock versions of python dependencies of our dependencies (rather than just the packages we explicitly reference)
 - Have the prod load balancer only listen on https
 - Encrypt SQS messages in prod
 - Use templating lib for outputting HTML from API server

--- a/src/api-server/Dockerfile
+++ b/src/api-server/Dockerfile
@@ -1,4 +1,4 @@
-FROM python:3-alpine
+FROM python:3.7.4-alpine
 ADD api-server/api-server.py /api-server/
 ADD api-server/photorecommendation.py /api-server/
 ADD api-server/favoritesstoredatabase.py /api-server/
@@ -7,12 +7,10 @@ ADD api-server/output.py /api-server/
 ADD common/confighelper.py /common/
 ADD common/metricshelper.py /common/
 ADD common/unhandledexceptionhelper.py /common/
-RUN pip install flask
-RUN pip install flask_api
-RUN pip install gunicorn
-RUN pip install mysql-connector-python
-RUN pip install boto3
-RUN pip install pymemcache
+# Take advantage of layer cacheing, so that everything referenced by this file is cached if the file doesn't change:
+# https://blog.realkinetic.com/building-minimal-docker-containers-for-python-applications-37d0272c52f3
+COPY api-server/requirements.txt /
+RUN pip install -r /requirements.txt
 EXPOSE 4445
 WORKDIR /api-server/
 CMD [ "gunicorn", "-b", "0.0.0.0:4445", "--access-logfile", "-", "--error-logfile", "-", "api-server" ]

--- a/src/api-server/requirements.txt
+++ b/src/api-server/requirements.txt
@@ -1,0 +1,6 @@
+flask==1.1.1
+flask_api==1.1
+gunicorn==19.9.0
+mysql-connector-python==8.0.17
+boto3==1.9.214
+pymemcache==2.2.2

--- a/src/ingester-database/Dockerfile
+++ b/src/ingester-database/Dockerfile
@@ -1,4 +1,4 @@
-FROM python:3-alpine
+FROM python:3.7.4-alpine
 ADD ingester-database/ingester-database.py /ingester-database/
 ADD ingester-database/databasebatchwriter.py /ingester-database/
 ADD common/ingesterqueueitem.py /common/
@@ -8,8 +8,8 @@ ADD common/confighelper.py /common/
 ADD common/metricshelper.py /common/
 ADD common/unhandledexceptionhelper.py /common/
 ADD common/loop_command.sh /common/
-RUN pip install boto3
-RUN pip install jsonpickle
-RUN pip install mysql-connector-python
-RUN pip install pymemcache
+# Take advantage of layer cacheing, so that everything referenced by this file is cached if the file doesn't change:
+# https://blog.realkinetic.com/building-minimal-docker-containers-for-python-applications-37d0272c52f3
+COPY ingester-database/requirements.txt /
+RUN pip install -r /requirements.txt
 CMD [ "./common/loop_command.sh", "./ingester-database/ingester-database.py", "2" ]

--- a/src/ingester-database/requirements.txt
+++ b/src/ingester-database/requirements.txt
@@ -1,0 +1,4 @@
+boto3==1.9.214
+jsonpickle==1.2
+mysql-connector-python==8.0.17
+pymemcache==2.2.2

--- a/src/puller-flickr/Dockerfile
+++ b/src/puller-flickr/Dockerfile
@@ -1,4 +1,4 @@
-FROM python:3-alpine
+FROM python:3.7.4-alpine
 ADD puller-flickr/puller-flickr.py /puller-flickr/
 ADD puller-flickr/flickrapiwrapper.py /puller-flickr/
 ADD common/ingesterqueueitem.py /common/
@@ -11,10 +11,8 @@ ADD common/confighelper.py /common/
 ADD common/metricshelper.py /common/
 ADD common/unhandledexceptionhelper.py /common/
 ADD common/loop_command.sh /common/
-RUN pip install flickrapi
-RUN pip install python-memcached
-RUN pip install django
-RUN pip install boto3
-RUN pip install jsonpickle
-RUN pip install pymemcache
+# Take advantage of layer cacheing, so that everything referenced by this file is cached if the file doesn't change:
+# https://blog.realkinetic.com/building-minimal-docker-containers-for-python-applications-37d0272c52f3
+COPY puller-flickr/requirements.txt /
+RUN pip install -r /requirements.txt
 CMD [ "./common/loop_command.sh", "./puller-flickr/puller-flickr.py", "2" ]

--- a/src/puller-flickr/requirements.txt
+++ b/src/puller-flickr/requirements.txt
@@ -1,0 +1,6 @@
+flickrapi==2.4.0
+python-memcached==1.59
+django==2.2.4
+boto3==1.9.214
+jsonpickle==1.2
+pymemcache==2.2.2

--- a/src/scheduler/Dockerfile
+++ b/src/scheduler/Dockerfile
@@ -1,4 +1,4 @@
-FROM python:3-alpine
+FROM python:3.7.4-alpine
 ADD scheduler/scheduler.py /scheduler/
 ADD scheduler/usersstoreapiserver.py /scheduler/
 ADD scheduler/usersstoreexception.py /scheduler/
@@ -10,10 +10,9 @@ ADD common/confighelper.py /common/
 ADD common/metricshelper.py /common/
 ADD common/unhandledexceptionhelper.py /common/
 ADD common/loop_command.sh /common/
-RUN pip install boto3
-RUN pip install jsonpickle
-RUN pip install mysql-connector-python
-RUN pip install requests
-RUN pip install pymemcache
+# Take advantage of layer cacheing, so that everything referenced by this file is cached if the file doesn't change:
+# https://blog.realkinetic.com/building-minimal-docker-containers-for-python-applications-37d0272c52f3
+COPY scheduler/requirements.txt /
+RUN pip install -r /requirements.txt
 WORKDIR scheduler/
 CMD [ "../common/loop_command.sh", "./scheduler.py", "2" ]

--- a/src/scheduler/requirements.txt
+++ b/src/scheduler/requirements.txt
@@ -1,0 +1,5 @@
+boto3==1.9.214
+jsonpickle==1.2
+mysql-connector-python==8.0.17
+requests==2.22.0
+pymemcache==2.2.2


### PR DESCRIPTION
- Use explicit version of `python:3-alpine` in each `Dockerfile`
- List Python dependencies in `requirements.txt` rather than having separate `RUN pip install` commands
- Copy `requirements.txt` to the image so that it can be cached and packages are only downloaded if that file changes
- Set explicit version number for each package

TODO: Lock down versions of the dependencies of our dependencies