### PR TITLE
Terraform initial setup fixes

### DIFF
--- a/terraform/dev/main.tf
+++ b/terraform/dev/main.tf
@@ -258,7 +258,7 @@ module "alarms" {
 
     queue_names = [ "${module.scheduler.scheduler_queue_full_name}", "${module.scheduler.scheduler_response_queue_full_name}", "${module.ingester_database.ingester_queue_full_name}"]
     queue_item_size_threshold = 235520 # 230kB -- 256kB is the absolute max
-    queue_item_age_threshold = 300 # 5 minutes
+    queue_item_age_threshold = 500 # 8.3 minutes
     queue_reader_error_threshold = 1
     queue_writer_error_threshold = 1
 

--- a/terraform/dev/main.tf
+++ b/terraform/dev/main.tf
@@ -52,6 +52,7 @@ module "database" {
     mysql_database_size_gb  = 5
     mysql_multi_az          = false # Disable database multi-AZ in dev to save billing charges
     mysql_backup_retention_period_days = 3
+    mysql_deletion_protection = false # No need for deletion protection in dev
 
     mysql_database_password = "${var.database_password_dev}"
 }
@@ -190,6 +191,7 @@ module "api_server" {
     load_balancer_port      = 4444
     api_server_port         = 4445
 
+    retain_load_balancer_access_logs_after_destroy = "false" # For dev, we don't care about retaining these logs after doing a terraform destroy
     load_balancer_days_to_keep_access_logs = 1
     load_balancer_access_logs_bucket = "api-server-access-logs-dev"
     load_balancer_access_logs_prefix = "api-server-lb-dev"

--- a/terraform/modules/api-server/load-balancer.tf
+++ b/terraform/modules/api-server/load-balancer.tf
@@ -36,6 +36,8 @@ resource "aws_lb_target_group" "load_balancer" {
         unhealthy_threshold = 3
         matcher             = "200"
     }
+
+    depends_on              = ["aws_lb.api_server"] # https://github.com/cds-snc/aws-ecs-fargate/issues/1
 }
 
 resource "aws_lb_listener" "load_balancer" {  
@@ -88,6 +90,7 @@ data "aws_elb_service_account" "main" {}
 resource "aws_s3_bucket" "load_balancer_access_logs" {
     bucket = "${var.load_balancer_access_logs_bucket}"
     acl    = "bucket-owner-full-control"
+    force_destroy = "${!var.retain_load_balancer_access_logs_after_destroy}"
     policy = <<EOF
 {
   "Id": "Policy1429136655940",

--- a/terraform/modules/api-server/variables.tf
+++ b/terraform/modules/api-server/variables.tf
@@ -25,4 +25,5 @@ variable "load_balancer_port" {}
 variable "load_balancer_days_to_keep_access_logs" {}
 variable "load_balancer_access_logs_bucket" {}
 variable "load_balancer_access_logs_prefix" {}
+variable "retain_load_balancer_access_logs_after_destroy" {}
 variable "default_num_photo_recommendations" {}

--- a/terraform/modules/database/mysql.tf
+++ b/terraform/modules/database/mysql.tf
@@ -14,5 +14,6 @@ module "mysql" {
     multi_az              = "${var.mysql_multi_az}"
     database_password     = "${var.mysql_database_password}"
     backup_retention_period_days = "${var.mysql_backup_retention_period_days}"
+    deletion_protection   = "${var.mysql_deletion_protection}"
     init_script_file      = "database/photo_recommender_init.sql"
 }

--- a/terraform/modules/database/variables.tf
+++ b/terraform/modules/database/variables.tf
@@ -8,6 +8,7 @@ variable "mysql_multi_az" {}
 variable "mysql_database_password" {}
 variable "mysql_backup_retention_period_days" {}
 variable "mysql_storage_encrypted" {}
+variable "mysql_deletion_protection" {}
 variable "vpc_id" {}
 variable "vpc_public_subnet_ids" { type = "list" }
 variable "local_machine_cidr" {}

--- a/terraform/modules/elastic-container-service/logging.tf
+++ b/terraform/modules/elastic-container-service/logging.tf
@@ -39,7 +39,7 @@ resource "aws_kms_key" "logs" {
 }
 
 resource "aws_cloudwatch_log_group" "log_group" {
-    name                = "${var.cluster_name}"
+    name                = "${var.cluster_name}-${var.environment}"
     retention_in_days   = "${var.instances_log_retention_days}"
     kms_key_id          = "${aws_kms_key.logs.arn}"
 }

--- a/terraform/modules/mysql/mysql.tf
+++ b/terraform/modules/mysql/mysql.tf
@@ -36,7 +36,10 @@ resource "aws_db_instance" "mysql_database" {
     auto_minor_version_upgrade      = true
     backup_retention_period         = "${var.backup_retention_period_days}"
     copy_tags_to_snapshot           = true
-    deletion_protection             = false
+
+    deletion_protection             = "${var.deletion_protection}"
+    skip_final_snapshot             = "${!var.deletion_protection}"
+    final_snapshot_identifier       = "${var.database_name}-${var.environment}-final-snapshot"
 
     enabled_cloudwatch_logs_exports = [ "error", "general", "slowquery" ]
     monitoring_interval             = 0

--- a/terraform/modules/mysql/variables.tf
+++ b/terraform/modules/mysql/variables.tf
@@ -12,3 +12,4 @@ variable "vpc_cidr" {}
 variable "backup_retention_period_days" {}
 variable "init_script_file" {}
 variable "storage_encrypted" {}
+variable "deletion_protection" {}


### PR DESCRIPTION
Various fixes so that setup from scratch works correctly, and teardown completes cleanly (in dev; in prod we don't want it to delete the database)

Fixes:

- Dependency fix for setting up load balancer from scratch
- Added environment to name of cloudwatch log group so dev/prod can be separate
- Increased alarm threshold for max item age so it doesn't go off spuriously in dev with few boxes

Made teardown cleaner:

- Added flag for deletion protection on database, so we can set it to false and have terraform delete our dev database for us, but not our prod
- Added flag to protect our load balancer access logs, so that in dev we can set it to false and have terraform delete them