### PR TITLE
Rename queues

### DIFF
--- a/src/common/pullerqueueitem.py
+++ b/src/common/pullerqueueitem.py
@@ -1,9 +1,9 @@
 import jsonpickle
 
-class SchedulerQueueItem:
+class PullerQueueItem:
 
     '''
-    An item placed onto or read from the scheduler queue. It represents a user
+    An item placed onto or read from the puller queue. It represents a user
     '''
 
     def __init__(self, user_id, is_registered_user):

--- a/src/common/pullerresponsequeueitem.py
+++ b/src/common/pullerresponsequeueitem.py
@@ -1,6 +1,6 @@
 import jsonpickle
 
-class SchedulerResponseQueueItem:
+class PullerResponseQueueItem:
 
     # The max size of an SQS message is 256kB, and a user ID takes about 16 bytes to store (12 digits, plus quotes, comma, and space).
     # If we start to exceed this threshold, we should switch to storing the neighbor list in S3 
@@ -8,14 +8,14 @@ class SchedulerResponseQueueItem:
     MAX_NUM_NEIGHBORS = 16000 
 
     '''
-    An item placed onto or read from the scheduler response queue. It represents a user
+    An item placed onto or read from the puller response queue. It represents a user
     '''
 
     def __init__(self, user_id, is_registered_user, neighbor_list):
         self.user_id                = user_id
         self.is_registered_user     = is_registered_user
-        self.max_neighbors_exceeded = len(neighbor_list) > SchedulerResponseQueueItem.MAX_NUM_NEIGHBORS
-        self.neighbor_list          = neighbor_list[:SchedulerResponseQueueItem.MAX_NUM_NEIGHBORS]
+        self.max_neighbors_exceeded = len(neighbor_list) > PullerResponseQueueItem.MAX_NUM_NEIGHBORS
+        self.neighbor_list          = neighbor_list[:PullerResponseQueueItem.MAX_NUM_NEIGHBORS]
    
     def get_user_id(self):
         return self.user_id

--- a/src/puller-flickr/Dockerfile
+++ b/src/puller-flickr/Dockerfile
@@ -3,8 +3,8 @@ ADD puller-flickr/puller-flickr.py /puller-flickr/
 ADD puller-flickr/flickrapiwrapper.py /puller-flickr/
 ADD common/ingesterqueueitem.py /common/
 ADD common/ingesterqueuebatchitem.py /common/
-ADD common/schedulerqueueitem.py /common/
-ADD common/schedulerresponsequeueitem.py /common/
+ADD common/pullerqueueitem.py /common/
+ADD common/pullerresponsequeueitem.py /common/
 ADD common/queuewriter.py /common/
 ADD common/queuereader.py /common/
 ADD common/confighelper.py /common/

--- a/src/scheduler/Dockerfile
+++ b/src/scheduler/Dockerfile
@@ -2,8 +2,8 @@ FROM python:3.7.4-alpine
 ADD scheduler/scheduler.py /scheduler/
 ADD scheduler/usersstoreapiserver.py /scheduler/
 ADD scheduler/usersstoreexception.py /scheduler/
-ADD common/schedulerqueueitem.py /common/
-ADD common/schedulerresponsequeueitem.py /common/
+ADD common/pullerqueueitem.py /common/
+ADD common/pullerresponsequeueitem.py /common/
 ADD common/queuereader.py /common/
 ADD common/queuewriter.py /common/
 ADD common/confighelper.py /common/

--- a/terraform/dev/main.tf
+++ b/terraform/dev/main.tf
@@ -95,10 +95,10 @@ module "scheduler" {
 
     scheduler_seconds_between_user_data_updates = 7200
 
-    scheduler_queue_batch_size = 10
+    puller_queue_batch_size = 10
 
-    scheduler_response_queue_batch_size = 10
-    scheduler_response_queue_max_items_to_process = 10000
+    puller_response_queue_batch_size = 10
+    puller_response_queue_max_items_to_process = 10000
 
     ingester_database_queue_url = "${module.ingester_database.ingester_queue_url}"
     ingester_database_queue_arn = "${module.ingester_database.ingester_queue_arn}"
@@ -136,14 +136,14 @@ module "puller_flickr" {
     output_queue_arn = "${module.ingester_database.ingester_queue_arn}"
     output_queue_batch_size = 10
 
-    scheduler_queue_url = "${module.scheduler.scheduler_queue_url}"
-    scheduler_queue_arn = "${module.scheduler.scheduler_queue_arn}"
-    scheduler_queue_batch_size = 1 # Each message takes a while to process, so hoarding a bunch of messages in an individual instance means that other instances may be underutilized
-    scheduler_queue_max_items_to_process = 1000
+    puller_queue_url = "${module.scheduler.puller_queue_url}"
+    puller_queue_arn = "${module.scheduler.puller_queue_arn}"
+    puller_queue_batch_size = 1 # Each message takes a while to process, so hoarding a bunch of messages in an individual instance means that other instances may be underutilized
+    puller_queue_max_items_to_process = 1000
 
-    scheduler_response_queue_url = "${module.scheduler.scheduler_response_queue_url}"
-    scheduler_response_queue_arn = "${module.scheduler.scheduler_response_queue_arn}"
-    scheduler_response_queue_batch_size = 10
+    puller_response_queue_url = "${module.scheduler.puller_response_queue_url}"
+    puller_response_queue_arn = "${module.scheduler.puller_response_queue_arn}"
+    puller_response_queue_batch_size = 10
 }
 
 module "ingester_database" {
@@ -224,13 +224,13 @@ module "dashboard" {
     region      = "${var.region}"
     metrics_namespace = "${var.metrics_namespace}"
 
-    scheduler_queue_base_name               = "${module.scheduler.scheduler_queue_base_name}"
-    scheduler_queue_full_name               = "${module.scheduler.scheduler_queue_full_name}"
-    scheduler_queue_dead_letter_full_name   = "${module.scheduler.scheduler_queue_dead_letter_full_name}"
+    puller_queue_base_name               = "${module.scheduler.puller_queue_base_name}"
+    puller_queue_full_name               = "${module.scheduler.puller_queue_full_name}"
+    puller_queue_dead_letter_full_name   = "${module.scheduler.puller_queue_dead_letter_full_name}"
 
-    scheduler_response_queue_base_name              = "${module.scheduler.scheduler_response_queue_base_name}"
-    scheduler_response_queue_full_name              = "${module.scheduler.scheduler_response_queue_full_name}"
-    scheduler_response_queue_dead_letter_full_name  = "${module.scheduler.scheduler_response_queue_dead_letter_full_name}"
+    puller_response_queue_base_name              = "${module.scheduler.puller_response_queue_base_name}"
+    puller_response_queue_full_name              = "${module.scheduler.puller_response_queue_full_name}"
+    puller_response_queue_dead_letter_full_name  = "${module.scheduler.puller_response_queue_dead_letter_full_name}"
 
     ingester_queue_base_name                = "${module.ingester_database.ingester_queue_base_name}"
     ingester_queue_full_name                = "${module.ingester_database.ingester_queue_full_name}"
@@ -256,13 +256,13 @@ module "alarms" {
 
     unhandled_exceptions_threshold = 1
 
-    queue_names = [ "${module.scheduler.scheduler_queue_full_name}", "${module.scheduler.scheduler_response_queue_full_name}", "${module.ingester_database.ingester_queue_full_name}"]
+    queue_names = [ "${module.scheduler.puller_queue_full_name}", "${module.scheduler.puller_response_queue_full_name}", "${module.ingester_database.ingester_queue_full_name}"]
     queue_item_size_threshold = 235520 # 230kB -- 256kB is the absolute max
     queue_item_age_threshold = 500 # 8.3 minutes
     queue_reader_error_threshold = 1
     queue_writer_error_threshold = 1
 
-    dead_letter_queue_names = [ "${module.scheduler.scheduler_queue_dead_letter_full_name}", "${module.scheduler.scheduler_response_queue_dead_letter_full_name}", "${module.ingester_database.ingester_queue_dead_letter_full_name}"]
+    dead_letter_queue_names = [ "${module.scheduler.puller_queue_dead_letter_full_name}", "${module.scheduler.puller_response_queue_dead_letter_full_name}", "${module.ingester_database.ingester_queue_dead_letter_full_name}"]
     dead_letter_queue_items_threshold = 1
 
     scheduler_users_store_exception_threshold = 1

--- a/terraform/modules/dashboard/dashboard.tf
+++ b/terraform/modules/dashboard/dashboard.tf
@@ -16,14 +16,14 @@ resource "aws_cloudwatch_dashboard" "main" {
           "y":6,
           "width":12,
           "height":6,
-          ${data.template_file.scheduler_queue.rendered}
+          ${data.template_file.puller_queue.rendered}
        },
        {
           "x":12,
           "y":6,
           "width":12,
           "height":6,
-          ${data.template_file.scheduler_response_queue.rendered}
+          ${data.template_file.puller_response_queue.rendered}
        },
        {
           "x":0,
@@ -112,22 +112,22 @@ data "template_file" "time_to_get_all_data" {
     template = "${file("${path.module}/generic_metric.tpl")}"
 }
 
-data "template_file" "scheduler_queue" {
+data "template_file" "puller_queue" {
     vars = {
-        queue_full_name             = "${var.scheduler_queue_full_name}"
-        queue_base_name             = "${var.scheduler_queue_base_name}"
-        queue_dead_letter_full_name = "${var.scheduler_queue_dead_letter_full_name}"
+        queue_full_name             = "${var.puller_queue_full_name}"
+        queue_base_name             = "${var.puller_queue_base_name}"
+        queue_dead_letter_full_name = "${var.puller_queue_dead_letter_full_name}"
         region                      = "${var.region}"
     }
 
     template = "${file("${path.module}/sqs_queue.tpl")}"
 }
 
-data "template_file" "scheduler_response_queue" {
+data "template_file" "puller_response_queue" {
     vars = {
-        queue_full_name             = "${var.scheduler_response_queue_full_name}"
-        queue_base_name             = "${var.scheduler_response_queue_base_name}"
-        queue_dead_letter_full_name = "${var.scheduler_response_queue_dead_letter_full_name}"
+        queue_full_name             = "${var.puller_response_queue_full_name}"
+        queue_base_name             = "${var.puller_response_queue_base_name}"
+        queue_dead_letter_full_name = "${var.puller_response_queue_dead_letter_full_name}"
         region                      = "${var.region}"
     }
 

--- a/terraform/modules/dashboard/variables.tf
+++ b/terraform/modules/dashboard/variables.tf
@@ -2,13 +2,13 @@ variable "environment" {}
 variable "region" {}
 variable "metrics_namespace" {}
 
-variable "scheduler_queue_base_name" {}
-variable "scheduler_queue_full_name" {}
-variable "scheduler_queue_dead_letter_full_name" {}
+variable "puller_queue_base_name" {}
+variable "puller_queue_full_name" {}
+variable "puller_queue_dead_letter_full_name" {}
 
-variable "scheduler_response_queue_base_name" {}
-variable "scheduler_response_queue_full_name" {}
-variable "scheduler_response_queue_dead_letter_full_name" {}
+variable "puller_response_queue_base_name" {}
+variable "puller_response_queue_full_name" {}
+variable "puller_response_queue_dead_letter_full_name" {}
 
 variable "ingester_queue_base_name" {}
 variable "ingester_queue_full_name" {}

--- a/terraform/modules/puller-flickr/parameter-store.tf
+++ b/terraform/modules/puller-flickr/parameter-store.tf
@@ -90,30 +90,30 @@ resource "aws_ssm_parameter" "output_queue_batch_size" {
     value       = "${var.output_queue_batch_size}"
 }
 
-resource "aws_ssm_parameter" "scheduler_queue_url" {
-    name        = "/${var.environment}/puller-flickr/scheduler-queue-url"
+resource "aws_ssm_parameter" "puller_queue_url" {
+    name        = "/${var.environment}/puller-flickr/puller-queue-url"
     description = "URL of the queue to get requests for data to be pulled"
     type        = "String"
-    value       = "${var.scheduler_queue_url}"
+    value       = "${var.puller_queue_url}"
 }
 
-resource "aws_ssm_parameter" "scheduler_queue_batch_size" {
-    name        = "/${var.environment}/puller-flickr/scheduler-queue-batchsize"
-    description = "Number of items to get from the scheduler queue in a single batch"
+resource "aws_ssm_parameter" "puller_queue_batch_size" {
+    name        = "/${var.environment}/puller-flickr/puller-queue-batchsize"
+    description = "Number of items to get from the puller queue in a single batch"
     type        = "String"
-    value       = "${var.scheduler_queue_batch_size}"
+    value       = "${var.puller_queue_batch_size}"
 }
 
-resource "aws_ssm_parameter" "scheduler_queue_max_items_to_process" {
-    name        = "/${var.environment}/puller-flickr/scheduler-queue-maxitemstoprocess"
-    description = "Maximum number of items to get from the scheduler queue before exiting"
+resource "aws_ssm_parameter" "puller_queue_max_items_to_process" {
+    name        = "/${var.environment}/puller-flickr/puller-queue-maxitemstoprocess"
+    description = "Maximum number of items to get from the puller queue before exiting"
     type        = "String"
-    value       = "${var.scheduler_queue_max_items_to_process}"
+    value       = "${var.puller_queue_max_items_to_process}"
 }
 
-resource "aws_ssm_parameter" "scheduler_response_queue_url" {
-    name        = "/${var.environment}/puller-flickr/scheduler-response-queue-url"
+resource "aws_ssm_parameter" "puller_response_queue_url" {
+    name        = "/${var.environment}/puller-flickr/puller-response-queue-url"
     description = "URL where we put messages saying we've successfully pulled data"
     type        = "String"
-    value       = "${var.scheduler_response_queue_url}"
+    value       = "${var.puller_response_queue_url}"
 }

--- a/terraform/modules/puller-flickr/task-definition.tf
+++ b/terraform/modules/puller-flickr/task-definition.tf
@@ -58,7 +58,7 @@ resource "aws_iam_policy" "ecs-instance-puller-flickr-extra-policy" {
         "sqs:SendMessage"
       ],
       "Effect": "Allow",
-      "Resource": "${var.scheduler_response_queue_arn}"
+      "Resource": "${var.puller_response_queue_arn}"
     },
     {
       "Action": [
@@ -67,7 +67,7 @@ resource "aws_iam_policy" "ecs-instance-puller-flickr-extra-policy" {
         "sqs:DeleteMessage"
       ],
       "Effect": "Allow",
-      "Resource": "${var.scheduler_queue_arn}"
+      "Resource": "${var.puller_queue_arn}"
     }
   ]
 }

--- a/terraform/modules/puller-flickr/variables.tf
+++ b/terraform/modules/puller-flickr/variables.tf
@@ -21,10 +21,10 @@ variable "flickr_api_favorites_max_calls_to_make" {}
 variable "output_queue_url" {}
 variable "output_queue_arn" {}
 variable "output_queue_batch_size" {}
-variable "scheduler_queue_url" {}
-variable "scheduler_queue_arn" {}
-variable "scheduler_queue_batch_size" {}
-variable "scheduler_queue_max_items_to_process" {}
-variable "scheduler_response_queue_url" {}
-variable "scheduler_response_queue_arn" {}
-variable "scheduler_response_queue_batch_size" {}
+variable "puller_queue_url" {}
+variable "puller_queue_arn" {}
+variable "puller_queue_batch_size" {}
+variable "puller_queue_max_items_to_process" {}
+variable "puller_response_queue_url" {}
+variable "puller_response_queue_arn" {}
+variable "puller_response_queue_batch_size" {}

--- a/terraform/modules/scheduler/outputs.tf
+++ b/terraform/modules/scheduler/outputs.tf
@@ -1,49 +1,49 @@
-output "scheduler_queue_url" {
-    value = "${module.scheduler_queue.queue_url}"
-    description = "The URL of the scheduler queue"
+output "puller_queue_url" {
+    value = "${module.puller_queue.queue_url}"
+    description = "The URL of the puller queue"
 }
 
-output "scheduler_queue_arn" {
-    value = "${module.scheduler_queue.queue_arn}"
-    description = "The ARN of the scheduler queue"
+output "puller_queue_arn" {
+    value = "${module.puller_queue.queue_arn}"
+    description = "The ARN of the puller queue"
 }
 
-output "scheduler_queue_base_name" {
-    value = "${module.scheduler_queue.queue_base_name}"
-    description = "The base name of the scheduler queue"
+output "puller_queue_base_name" {
+    value = "${module.puller_queue.queue_base_name}"
+    description = "The base name of the puller queue"
 }
 
-output "scheduler_queue_full_name" {
-    value = "${module.scheduler_queue.queue_full_name}"
-    description = "The full name of the scheduler queue"
+output "puller_queue_full_name" {
+    value = "${module.puller_queue.queue_full_name}"
+    description = "The full name of the puller queue"
 }
 
-output "scheduler_queue_dead_letter_full_name" {
-    value = "${module.scheduler_queue.queue_dead_letter_full_name}"
-    description = "The full name of the scheduler dead letter queue"
+output "puller_queue_dead_letter_full_name" {
+    value = "${module.puller_queue.queue_dead_letter_full_name}"
+    description = "The full name of the puller dead letter queue"
 }
 
-output "scheduler_response_queue_url" {
-    value = "${module.scheduler_response_queue.queue_url}"
-    description = "The URL of the scheduler response queue"
+output "puller_response_queue_url" {
+    value = "${module.puller_response_queue.queue_url}"
+    description = "The URL of the puller response queue"
 }
 
-output "scheduler_response_queue_arn" {
-    value = "${module.scheduler_response_queue.queue_arn}"
-    description = "The ARN of the scheduler response queue"
+output "puller_response_queue_arn" {
+    value = "${module.puller_response_queue.queue_arn}"
+    description = "The ARN of the puller response queue"
 }
 
-output "scheduler_response_queue_base_name" {
-    value = "${module.scheduler_response_queue.queue_base_name}"
-    description = "The base name of the scheduler response queue"
+output "puller_response_queue_base_name" {
+    value = "${module.puller_response_queue.queue_base_name}"
+    description = "The base name of the puller response queue"
 }
 
-output "scheduler_response_queue_full_name" {
-    value = "${module.scheduler_response_queue.queue_full_name}"
-    description = "The full name of the scheduler response queue"
+output "puller_response_queue_full_name" {
+    value = "${module.puller_response_queue.queue_full_name}"
+    description = "The full name of the puller response queue"
 }
 
-output "scheduler_response_queue_dead_letter_full_name" {
-    value = "${module.scheduler_response_queue.queue_dead_letter_full_name}"
-    description = "The full name of the scheduler response dead letter queue"
+output "puller_response_queue_dead_letter_full_name" {
+    value = "${module.puller_response_queue.queue_dead_letter_full_name}"
+    description = "The full name of the puller response dead letter queue"
 }

--- a/terraform/modules/scheduler/parameter-store.tf
+++ b/terraform/modules/scheduler/parameter-store.tf
@@ -26,39 +26,39 @@ resource "aws_ssm_parameter" "api_server_port" {
     value       = "${var.api_server_port}"
 }
 
-resource "aws_ssm_parameter" "scheduler_queue_url" {
-    name        = "/${var.environment}/scheduler/scheduler-queue-url"
+resource "aws_ssm_parameter" "puller_queue_url" {
+    name        = "/${var.environment}/scheduler/puller-queue-url"
     description = "URL of the queue to put requests for data to be pulled"
     type        = "String"
-    value       = "${module.scheduler_queue.queue_url}"
+    value       = "${module.puller_queue.queue_url}"
 }
 
-resource "aws_ssm_parameter" "scheduler_queue_batch_size" {
-    name        = "/${var.environment}/scheduler/scheduler-queue-batchsize"
-    description = "Number of items to put on the scheduler queue in a single batch"
+resource "aws_ssm_parameter" "puller_queue_batch_size" {
+    name        = "/${var.environment}/scheduler/puller-queue-batchsize"
+    description = "Number of items to put on the puller queue in a single batch"
     type        = "String"
-    value       = "${var.scheduler_queue_batch_size}"
+    value       = "${var.puller_queue_batch_size}"
 }
 
-resource "aws_ssm_parameter" "scheduler_response_queue_url" {
-    name        = "/${var.environment}/scheduler/scheduler-response-queue-url"
+resource "aws_ssm_parameter" "puller_response_queue_url" {
+    name        = "/${var.environment}/scheduler/puller-response-queue-url"
     description = "Endpoint of queue we use to ingest responses about successful data pulling"
     type        = "String"
-    value       = "${module.scheduler_response_queue.queue_url}"
+    value       = "${module.puller_response_queue.queue_url}"
 }
 
-resource "aws_ssm_parameter" "scheduler_response_queue_batch_size" {
-    name        = "/${var.environment}/scheduler/scheduler-response-queue-batchsize"
-    description = "Number of items to take off of the scheduler response queue in a single batch"
+resource "aws_ssm_parameter" "puller_response_queue_batch_size" {
+    name        = "/${var.environment}/scheduler/puller-response-queue-batchsize"
+    description = "Number of items to take off of the puller response queue in a single batch"
     type        = "String"
-    value       = "${var.scheduler_response_queue_batch_size}"
+    value       = "${var.puller_response_queue_batch_size}"
 }
 
-resource "aws_ssm_parameter" "scheduler_response_queue_max_items_to_process" {
-    name        = "/${var.environment}/scheduler/scheduler-response-queue-maxitemstoprocess"
-    description = "Maximum number of items to take off the scheduler response queue before exiting"
+resource "aws_ssm_parameter" "puller_response_queue_max_items_to_process" {
+    name        = "/${var.environment}/scheduler/puller-response-queue-maxitemstoprocess"
+    description = "Maximum number of items to take off the puller response queue before exiting"
     type        = "String"
-    value       = "${var.scheduler_response_queue_max_items_to_process}"
+    value       = "${var.puller_response_queue_max_items_to_process}"
 }
 
 resource "aws_ssm_parameter" "scheduler_seconds_between_user_data_updates" {

--- a/terraform/modules/scheduler/puller-queue.tf
+++ b/terraform/modules/scheduler/puller-queue.tf
@@ -1,7 +1,7 @@
-module "scheduler_queue" {
+module "puller_queue" {
     source = "../sqs-queue"
 
-    queue_name                  = "scheduler-queue"
+    queue_name                  = "puller-queue"
     environment                 = "${var.environment}"
     max_redrives                = 4
     visibility_timeout_seconds  = 900 # 15 minutes. It can take quite a while to pull all of the favorites for a user if they have a lot 

--- a/terraform/modules/scheduler/puller-response-queue.tf
+++ b/terraform/modules/scheduler/puller-response-queue.tf
@@ -1,7 +1,7 @@
-module "scheduler_response_queue" {
+module "puller_response_queue" {
     source = "../sqs-queue"
 
-    queue_name                  = "scheduler-response-queue"
+    queue_name                  = "puller-response-queue"
     environment                 = "${var.environment}"
     max_redrives                = 4
     visibility_timeout_seconds  = 30

--- a/terraform/modules/scheduler/task-definition.tf
+++ b/terraform/modules/scheduler/task-definition.tf
@@ -44,7 +44,7 @@ resource "aws_iam_policy" "ecs-instance-scheduler-extra-policy" {
         "sqs:GetQueueAttributes"
       ],
       "Effect": "Allow",
-      "Resource": "${module.scheduler_queue.queue_arn}"
+      "Resource": "${module.puller_queue.queue_arn}"
     },
     {
       "Action": [
@@ -54,7 +54,7 @@ resource "aws_iam_policy" "ecs-instance-scheduler-extra-policy" {
         "sqs:GetQueueAttributes"
       ],
       "Effect": "Allow",
-      "Resource": "${module.scheduler_response_queue.queue_arn}"
+      "Resource": "${module.puller_response_queue.queue_arn}"
     },
     {
       "Action": [

--- a/terraform/modules/scheduler/variables.tf
+++ b/terraform/modules/scheduler/variables.tf
@@ -11,9 +11,9 @@ variable "ecs_cluster_id" {}
 variable "ecs_instances_log_configuration" {}
 variable "ecs_instances_role_name" {}
 variable "ecs_days_to_keep_images" {}
-variable "scheduler_queue_batch_size" {}
-variable "scheduler_response_queue_batch_size" {}
-variable "scheduler_response_queue_max_items_to_process" {}
+variable "puller_queue_batch_size" {}
+variable "puller_response_queue_batch_size" {}
+variable "puller_response_queue_max_items_to_process" {}
 variable "scheduler_seconds_between_user_data_updates" {}
 variable "ingester_database_queue_url" {}
 variable "ingester_database_queue_arn" {}


### PR DESCRIPTION
Renamed `scheduler-queue` -> `puller-queue` and `scheduler-response-queue` -> `puller-response-queue` to better fit the convention of having them named after the process that consumes them, like `ingester-queue`