### PR TITLE
Added disc-based cache for secret parameters

### DIFF
--- a/src/api-server/requirements.txt
+++ b/src/api-server/requirements.txt
@@ -4,3 +4,4 @@ gunicorn==19.9.0
 mysql-connector-python==8.0.17
 boto3==1.9.214
 pymemcache==2.2.2
+diskcache==4.0.0

--- a/src/ingester-database/requirements.txt
+++ b/src/ingester-database/requirements.txt
@@ -2,3 +2,4 @@ boto3==1.9.214
 jsonpickle==1.2
 mysql-connector-python==8.0.17
 pymemcache==2.2.2
+diskcache==4.0.0

--- a/src/puller-flickr/requirements.txt
+++ b/src/puller-flickr/requirements.txt
@@ -4,3 +4,4 @@ django==2.2.4
 boto3==1.9.214
 jsonpickle==1.2
 pymemcache==2.2.2
+diskcache==4.0.0

--- a/src/puller-response-reader/requirements.txt
+++ b/src/puller-response-reader/requirements.txt
@@ -2,3 +2,4 @@ boto3==1.9.214
 jsonpickle==1.2
 pymemcache==2.2.2
 requests==2.22.0
+diskcache==4.0.0

--- a/src/scheduler/requirements.txt
+++ b/src/scheduler/requirements.txt
@@ -3,3 +3,4 @@ jsonpickle==1.2
 mysql-connector-python==8.0.17
 requests==2.22.0
 pymemcache==2.2.2
+diskcache==4.0.0


### PR DESCRIPTION
This helps cut down on billing costs by cacheing secret parameters on local disc. We don't want to use memcached for secrets because it's potentially publicly-accessible, and they're stored unencrypted. But having them on local disc seems safer.

Especially with a lot of instances we were seeing a lot of hits to KMS, so this should help reduce that significantly.