### PR TITLE
Various performance improvements

### DIFF
--- a/src/puller-flickr/flickrapiwrapper.py
+++ b/src/puller-flickr/flickrapiwrapper.py
@@ -120,7 +120,9 @@ class FlickrApiWrapper:
             num_retries += 1
 
         if not success:
-            metrics_helper.increment_count("FlickrApiException")
+            self.metrics_helper.increment_count("FlickrApiException")
             raise FlickrApiException(f"Failed contacting Flickr API after {self.max_retries} retries") from error
+
+        self.metrics_helper.increment_count("flickr_api_retries", num_retries - 1)
 
         return result 

--- a/src/scheduler/config/config.ini
+++ b/src/scheduler/config/config.ini
@@ -14,4 +14,7 @@ seconds-between-user-data-updates=7200
 
 ingester-queue-url=https://sqs.us-west-2.amazonaws.com/257049685947/ingester-queue-dev
 
+max-iterations-before-exit=1000
+sleep-ms-between-iterations=500
+
 [dev]

--- a/terraform/modules/dashboard/dashboard.tf
+++ b/terraform/modules/dashboard/dashboard.tf
@@ -94,6 +94,13 @@ resource "aws_cloudwatch_dashboard" "main" {
           "width":12,
           "height":6,
           ${data.template_file.unhandled_exceptions.rendered} 
+       },
+       {
+          "x":12,
+          "y":30,
+          "width":12,
+          "height":6,
+          ${data.template_file.timing.rendered} 
        }
     ]
   }
@@ -229,4 +236,15 @@ data "template_file" "unhandled_exceptions" {
     }
 
     template = "${file("${path.module}/unhandled_exceptions.tpl")}"
+}
+
+data "template_file" "timing" {
+    vars = {
+        title                       = "Timing"
+        environment                 = "${var.environment}"
+        metrics_namespace           = "${var.metrics_namespace}"
+        region                      = "${var.region}"
+    }
+
+    template = "${file("${path.module}/timing.tpl")}"
 }

--- a/terraform/modules/dashboard/timing.tpl
+++ b/terraform/modules/dashboard/timing.tpl
@@ -1,0 +1,58 @@
+"type":"metric",
+"properties": {
+    "metrics": [
+        [
+            "Photo Recommender",
+            "duration_to_process_user",
+            "Environment",
+            "${environment}",
+            "Process",
+            "puller-flickr"
+        ],
+        [
+            "Photo Recommender",
+            "duration_to_query_flickr",
+            "Environment",
+            "${environment}",
+            "Process",
+            "puller-flickr"
+        ],
+        [
+            "Photo Recommender",
+            "flickr_api_retries",
+            "Environment",
+            "${environment}",
+            "Process",
+            "puller-flickr"
+        ],
+        [
+            "Photo Recommender",
+            "FlickrApiException",
+            "Environment",
+            "${environment}",
+            "Process",
+            "puller-flickr"
+        ],
+        [
+            "Photo Recommender",
+            "process_batch_message_duration",
+            "Environment",
+            "${environment}",
+            "Process",
+            "ingester-database"
+        ],
+        [
+            "Photo Recommender",
+            "database_write_duration",
+            "Environment",
+            "${environment}",
+            "Process",
+            "ingester-database"
+        ]
+
+    ],
+    "period":300,
+    "stat":"Maximum",
+    "region":"${region}",
+    "title":"${title}"
+}

--- a/terraform/modules/scheduler/parameter-store.tf
+++ b/terraform/modules/scheduler/parameter-store.tf
@@ -60,3 +60,18 @@ resource "aws_ssm_parameter" "ingester_queue_url" {
     type        = "String"
     value       = "${var.ingester_database_queue_url}"
 }
+
+resource "aws_ssm_parameter" "max_iterations_before_exit" {
+    name        = "/${var.environment}/scheduler/max-iterations-before-exit"
+    description = "Number of times we iterate over our tasks before exiting and being restarted"
+    type        = "String"
+    value       = "${var.max_iterations_before_exit}"
+}
+
+resource "aws_ssm_parameter" "sleep_ms_between_iterations" {
+    name        = "/${var.environment}/scheduler/sleep-ms-between-iterations"
+    description = "Number of milliseconds we sleep between iterations"
+    type        = "String"
+    value       = "${var.sleep_ms_between_iterations}"
+}
+

--- a/terraform/modules/scheduler/variables.tf
+++ b/terraform/modules/scheduler/variables.tf
@@ -15,3 +15,5 @@ variable "puller_queue_batch_size" {}
 variable "scheduler_seconds_between_user_data_updates" {}
 variable "ingester_database_queue_url" {}
 variable "ingester_database_queue_arn" {}
+variable "max_iterations_before_exit" {}
+variable "sleep_ms_between_iterations" {}

--- a/terraform/modules/sqs-queue/sqs-queue.tf
+++ b/terraform/modules/sqs-queue/sqs-queue.tf
@@ -4,7 +4,7 @@ resource "aws_sqs_queue" "queue" {
     delay_seconds               = 0
     max_message_size            = 262144 # 256kB
     message_retention_seconds   = "${var.message_retention_seconds}"
-    receive_wait_time_seconds   = 0
+    receive_wait_time_seconds   = 10 # Enable long polling: https://docs.aws.amazon.com/AWSSimpleQueueService/latest/SQSDeveloperGuide/sqs-short-and-long-polling.html#sqs-long-polling
     redrive_policy              = "{\"deadLetterTargetArn\":\"${aws_sqs_queue.dead_letter_queue.arn}\",\"maxReceiveCount\":${var.max_redrives}}"
 
     tags = {


### PR DESCRIPTION
Overall, this gets the time to get all of the data for the test user down to 8 seconds (16 seconds if we up the max calls to Flickr to 5 so we can get 1000 faves for each neighbor instead limiting the max calls to 1 and getting up to 500 faves per neighbor) 

There is now commented-out settings for a performance-oriented ECS cluster and database, as well as number of instances for each process.

With the simplest cluster (2 instances of t2.micro, 1 instance of each process, and a t2.micro DB), it takes about 150 seconds to process the same data)

Other changes:

- Add timing metrics to puler-flickr and ingester-database. and add graph to dashboard
- Enable long polling for the queues so that instances don't miss messages (and also restart less, because they're blocked polling)
- Make the Scheduler iterate over its tasks internally rather than having to be restarted each time (makes for quicker startup once a new user is added to the db, and more accurate timing of how long it takes to process all the data)
- Put the memcached location parameter into the disc cache to avoid getting throttled by the parameter store when we have lots of instances
- Increase number of database connections per API server instance so there's never a queue (this required increasing the instance type of the DB)
- Decrease the amount of CPU reserved for most processes, because they don't need so much (incidentally, most of the CPU seems to be taken up by restarting python over and over)
- Decrease the batch size when writing to the database, so that all the messages can be fanned out to individual instances rather than having a particular instance hording them and leaving other instances idle