### PR TITLE
Support having multiple instances of the Scheduler

### DIFF
--- a/src/api-server/api-server.py
+++ b/src/api-server/api-server.py
@@ -178,6 +178,33 @@ def get_time_to_update_all_data(user_id=None):
 
     return resp
 
+@application.route("/locks/request", methods = ['PUT'])
+def request_lock():
+
+    process_id              = request.args.get("process-id")
+    task_id                 = request.args.get("task-id")
+    lock_duration_seconds   = request.args.get("lock-duration-seconds")
+
+    if not process_id:
+        return parameter_not_specified("process-id")
+
+    if not task_id:
+        return parameter_not_specified("task-id")
+
+    if not lock_duration_seconds:
+        return parameter_not_specified("lock-duration-seconds")
+
+    response_object = {
+        'process_id':       process_id,
+        'task_id':          task_id,
+        'lock-acquired':    favorites_store.request_lock(process_id, task_id, lock_duration_seconds)
+    }
+
+    resp = jsonify(response_object)
+    resp.status_code = status.HTTP_200_OK
+
+    return resp
+
 @application.route("/favicon.ico", methods = ['GET'])
 def get_favicon():
     # Browsers like to call this, and without defining this route we see 404 errors in our logs

--- a/src/api-server/api-server.py
+++ b/src/api-server/api-server.py
@@ -6,7 +6,6 @@ sys.path.insert(0, '../common')
 import argparse
 import logging
 import atexit
-import traceback
 from flask import Flask
 from flask import request
 from flask import jsonify
@@ -221,19 +220,14 @@ def parameter_not_specified(param_name, error=None):
 @application.errorhandler(FavoritesStoreException)
 def encountered_favorites_store_exception(e):
     metrics_helper.increment_count("FavoritesStoreException")
-    logging.error("Encountered FavoritesStoreException: %s", e)
-    log_traceback(e)
+    logging.exception("Encountered FavoritesStoreException") # Logs a stack trace
     return "Internal server error", status.HTTP_500_INTERNAL_SERVER_ERROR
 
 @application.errorhandler(Exception)
 def encountered_exception(e):
     metrics_helper.increment_count("Exception")
-    logging.error("Encountered general Exception: %s", e)
-    log_traceback(e)
+    logging.exception("Excountered Exception") # Logs a stack trace
     return "Internal server error", status.HTTP_500_INTERNAL_SERVER_ERROR
-
-def log_traceback(exception):
-    logging.error("Traceback: \n%s", "".join(traceback.format_tb(exception.__traceback__)))
 
 if __name__ == '__main__':
     # Note that running Flask like this results in the output saying "lazy loading" and I'm not sure what that means.

--- a/src/common/executionenvironmenthelper.py
+++ b/src/common/executionenvironmenthelper.py
@@ -1,0 +1,85 @@
+import os
+import json
+import time
+import logging
+
+class ExecutionEnvironmentHelper:
+
+    #
+    # Gives us information about the current execution environment we're running in: task ID, etc
+    #
+
+    @staticmethod
+    def get():
+        if not "ECS_CONTAINER_METADATA_FILE" in os.environ:
+            return ExecutionEnvironmentHelperLocalMachine()
+        else:
+            return ExecutionEnvironmentHelperECS()
+
+
+class ExecutionEnvironmentHelperLocalMachine(ExecutionEnvironmentHelper):
+
+    #
+    # Gives us information about the local machine we're running on: task ID, etc.
+    #
+
+    def get_task_id(self):
+        return "local machine"
+
+class ExecutionEnvironmentHelperECS(ExecutionEnvironmentHelper):
+
+    #
+    # Gives us information about the ECS cluster we're running in: task ID, etc
+    #
+    # More info on the file we're reading: https://docs.aws.amazon.com/AmazonECS/latest/developerguide/container-metadata.html
+    #
+
+    MAX_ATTEMPTS_TO_READ_METADATA_FILE = 3
+
+    def __init__(self):
+
+        ecs_container_metadata_file = os.environ.get("ECS_CONTAINER_METADATA_FILE")
+
+        logging.info(f"Attempting to read ECS environment info from {ecs_container_metadata_file}")
+
+        self.task_id = None
+
+        file_successfully_read = False
+        num_iterations = 0
+
+        # This metadata file may take a while for the ECS system to write, so might not be completely available the first time we try to read it
+
+        while True:
+
+            with open(ecs_container_metadata_file, "r") as metadata_file:
+                text = metadata_file.read()
+
+                metadata = json.loads(text)
+
+                if ("MetadataFileStatus" in metadata) and (metadata["MetadataFileStatus"] == "READY"):
+
+                    task_arn = metadata["TaskARN"] # The task ARN looks like "arn:aws:ecs:us-west-2:012345678910:task/2b88376d-aba3-4950-9ddf-bcb0f388a40c"
+
+                    if task_arn is not None:
+                        task_arn_portions = task_arn.split("/")
+
+                        if len(task_arn_portions) > 1:
+                            self.task_id = task_arn_portions[1]
+
+                            file_successfully_read = True
+
+            num_iterations += 1
+
+            if file_successfully_read or (num_iterations >= ExecutionEnvironmentHelperECS.MAX_ATTEMPTS_TO_READ_METADATA_FILE):
+                break
+                
+            time.sleep(1.0) # The file is generally ready within one second of the container starting up according to the docs above
+
+        if not file_successfully_read:
+            raise RuntimeError(f"Unable to read ECS metadata file {ecs_container_metadata_file} after {num_iterations} attempts")
+
+        logging.info(f"Successfully read ECS environment info in {num_iterations} attempts")
+        logging.info(f"Found task ID {self.task_id}")
+
+    def get_task_id(self):
+        return self.task_id

--- a/src/common/usersstoreapiserver.py
+++ b/src/common/usersstoreapiserver.py
@@ -91,3 +91,25 @@ class UsersStoreAPIServer:
 
         except HTTPError as http_err:
             raise UsersStoreException from http_err
+
+    def request_lock(self, process_id, task_id, lock_duration_seconds):
+
+        try:
+            response = requests.put(f"{self.url_prefix}/locks/request",
+                params={
+                    'process-id':               process_id,
+                    'task-id':                  task_id,
+                    'lock-duration-seconds':    lock_duration_seconds
+                }
+            )
+
+            response.raise_for_status()
+
+            response.encoding = "utf-8"
+
+            response_object = response.json()
+
+            return bool(response_object['lock-acquired'])
+
+        except HTTPError as http_err:
+            raise UsersStoreException from http_err

--- a/src/scheduler/Dockerfile
+++ b/src/scheduler/Dockerfile
@@ -9,6 +9,7 @@ ADD common/queuewriter.py /common/
 ADD common/confighelper.py /common/
 ADD common/metricshelper.py /common/
 ADD common/unhandledexceptionhelper.py /common/
+ADD common/executionenvironmenthelper.py /common/
 ADD common/loop_command.sh /common/
 # Take advantage of layer cacheing, so that everything referenced by this file is cached if the file doesn't change:
 # https://blog.realkinetic.com/building-minimal-docker-containers-for-python-applications-37d0272c52f3

--- a/src/scheduler/config/config.ini
+++ b/src/scheduler/config/config.ini
@@ -17,4 +17,6 @@ ingester-queue-url=https://sqs.us-west-2.amazonaws.com/257049685947/ingester-que
 max-iterations-before-exit=1000
 sleep-ms-between-iterations=500
 
+duration-to-request-lock-seconds=10
+
 [dev]

--- a/terraform/dev/main.tf
+++ b/terraform/dev/main.tf
@@ -28,9 +28,9 @@ module "elastic_container_service" {
     extra_security_groups = ["${module.api_server.security_group_id}"]
 
     instance_type = "t2.micro"#"c5.large"#"t2.micro"
-    cluster_desired_size = 0#2#20
+    cluster_desired_size = 2#20
     cluster_min_size = 0
-    cluster_max_size = 0#2#20
+    cluster_max_size = 2#20
     instances_log_retention_days = 1
 }
 
@@ -102,6 +102,8 @@ module "scheduler" {
 
     max_iterations_before_exit = 1000
     sleep_ms_between_iterations = 500
+
+    duration_to_request_lock_seconds = 10
 }
 
 module "puller-response-reader" {

--- a/terraform/dev/main.tf
+++ b/terraform/dev/main.tf
@@ -28,9 +28,9 @@ module "elastic_container_service" {
     extra_security_groups = ["${module.api_server.security_group_id}"]
 
     instance_type = "t2.micro"#"c5.large"#"t2.micro"
-    cluster_desired_size = 2#20
+    cluster_desired_size = 0#2#20
     cluster_min_size = 0
-    cluster_max_size = 2#20
+    cluster_max_size = 0#2#20
     instances_log_retention_days = 1
 }
 

--- a/terraform/modules/database/photo_recommender_init.sql
+++ b/terraform/modules/database/photo_recommender_init.sql
@@ -25,3 +25,15 @@ CREATE TABLE registered_users (
     KEY (data_last_successfully_processed_at),
     KEY (all_data_last_successfully_processed_at)
 ) ENGINE = InnoDB, CHARACTER SET = utf8mb4;
+
+CREATE TABLE task_locks (
+    id INT AUTO_INCREMENT,
+    process_id VARCHAR(64) NOT NULL,
+    task_id VARCHAR(64) NOT NULL,
+    lock_expiry TIMESTAMP NOT NULL,
+    created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
+    updated_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP,
+    PRIMARY KEY (id),
+    UNIQUE KEY (process_id),
+    KEY (task_id)
+) ENGINE = InnoDB, CHARACTER SET = utf8mb4;

--- a/terraform/modules/elastic-container-service/cluster.tf
+++ b/terraform/modules/elastic-container-service/cluster.tf
@@ -25,6 +25,7 @@ resource "aws_launch_configuration" "ecs-launch-configuration" {
     user_data                   = <<EOF
                                   #!/bin/bash
                                   echo ECS_CLUSTER=${aws_ecs_cluster.ecs-cluster.name} >> /etc/ecs/ecs.config
+                                  echo ECS_ENABLE_CONTAINER_METADATA=true >> /etc/ecs/ecs.config
                                   EOF
 }
 

--- a/terraform/modules/scheduler/parameter-store.tf
+++ b/terraform/modules/scheduler/parameter-store.tf
@@ -75,3 +75,9 @@ resource "aws_ssm_parameter" "sleep_ms_between_iterations" {
     value       = "${var.sleep_ms_between_iterations}"
 }
 
+resource "aws_ssm_parameter" "duration_to_request_lock_seconds" {
+    name        = "/${var.environment}/scheduler/duration-to-request-lock-seconds"
+    description = "Number of seconds for which to request a lock on other scheduler instances beginning processing"
+    type        = "String"
+    value       = "${var.duration_to_request_lock_seconds}"
+}

--- a/terraform/modules/scheduler/variables.tf
+++ b/terraform/modules/scheduler/variables.tf
@@ -17,3 +17,4 @@ variable "ingester_database_queue_url" {}
 variable "ingester_database_queue_arn" {}
 variable "max_iterations_before_exit" {}
 variable "sleep_ms_between_iterations" {}
+variable "duration_to_request_lock_seconds" {}


### PR DESCRIPTION
We want to be able to support having several instances of the Scheduler running at once: for redundancy in different availability zones, and also it happens when a new version is deployed. The trick is that there can only be one at a time doing actual processing. That's because if there's > 1 then multiple instances might notice at the same time that a certain user needs to be updated, and request multiple updates for that user. 

So, this adds a locking mechanism where only one instance is allowed to do processing at a given time. If that instance dies then the lock expires in a few seconds and another is allowed to begin processing.

Changes:
- Added function to request lock to the api-server
- Called this function from the Scheduler before beginning processing
- Added a helper to get the current task ID: used for requesting and holding a lock
- Added a new table for locks to the database
- Enable container metadata in ECS
- Fixed logging of exceptions in the api-server
- Add some calls to `rollback()` when an exception occurs during a database update. Not necessary, but nicer