### PR TITLE
Proxy calls to Flickr through our API server

### DIFF
--- a/src/api-server/Dockerfile
+++ b/src/api-server/Dockerfile
@@ -4,6 +4,7 @@ ADD api-server/photorecommendation.py /api-server/
 ADD api-server/favoritesstoredatabase.py /api-server/
 ADD api-server/favoritesstoreexception.py /api-server/
 ADD api-server/output.py /api-server/
+ADD common/flickrapiwrapper.py /common/
 ADD common/confighelper.py /common/
 ADD common/metricshelper.py /common/
 ADD common/unhandledexceptionhelper.py /common/

--- a/src/api-server/config/config.ini
+++ b/src/api-server/config/config.ini
@@ -12,6 +12,14 @@ database-connection-pool-size=10
 server-host=127.0.0.1
 server-port=4445
 
+flickr-api-key=none
+flickr-api-retries=3
+
+flickr-api-memcached-location=localhost:11211
+flickr-api-memcached-ttl=7200 
+
 default-num-photo-recommendations=10
 
 [dev]
+
+flickr-api-key=236d0914f5c9cb19088e332fc33685b8

--- a/src/api-server/requirements.txt
+++ b/src/api-server/requirements.txt
@@ -5,3 +5,6 @@ mysql-connector-python==8.0.17
 boto3==1.9.214
 pymemcache==2.2.2
 diskcache==4.0.0
+flickrapi==2.4.0
+django==2.2.4
+python-memcached==1.59

--- a/src/puller-flickr/Dockerfile
+++ b/src/puller-flickr/Dockerfile
@@ -1,6 +1,6 @@
 FROM python:3.7.4-alpine
 ADD puller-flickr/puller-flickr.py /puller-flickr/
-ADD puller-flickr/flickrapiwrapper.py /puller-flickr/
+ADD common/flickrapiwrapper.py /puller-flickr/
 ADD common/ingesterqueueitem.py /common/
 ADD common/ingesterqueuebatchitem.py /common/
 ADD common/pullerqueueitem.py /common/

--- a/src/puller-flickr/puller-flickr.py
+++ b/src/puller-flickr/puller-flickr.py
@@ -77,9 +77,6 @@ flickrapi = FlickrApiWrapper(
     memcached_location, 
     memcached_ttl, 
     flickr_api_retries, 
-    flickr_api_max_favorites_per_call, 
-    flickr_api_max_favorites_to_get,
-    flickr_api_max_calls_to_make,
     metrics_helper)
 
 puller_queue            = SQSQueueReader(queue_url=puller_queue_url,            batch_size=puller_queue_batch_size, max_messages_to_read=puller_queue_max_items_to_process,   metrics_helper=metrics_helper)
@@ -107,7 +104,7 @@ def process_user(puller_queue_item):
     logging.info(f"Getting favourites for requested user {flickr_user_id}")
 
     begin_query_flickr = time.perf_counter()
-    my_favorites = flickrapi.get_favorites(flickr_user_id)
+    my_favorites = flickrapi.get_favorites(flickr_user_id, flickr_api_max_favorites_per_call, flickr_api_max_favorites_to_get, flickr_api_max_calls_to_make)
     end_query_flickr = time.perf_counter()
 
     favorite_photos = []

--- a/terraform/dev/main.tf
+++ b/terraform/dev/main.tf
@@ -159,7 +159,6 @@ module "puller_flickr" {
 
     flickr_api_key = "${var.flickr_api_key}"
     flickr_secret_key = "${var.flickr_secret_key}"
-    flickr_user_id = "${var.flickr_user_id}"
     flickr_api_retries = 3
     flickr_api_favorites_max_per_call = 500
     flickr_api_favorites_max_to_get = 1000
@@ -223,6 +222,12 @@ module "api_server" {
 
     load_balancer_port      = 4444
     api_server_port         = 4445
+
+    flickr_api_key = "${var.flickr_api_key}"
+    flickr_secret_key = "${var.flickr_secret_key}"
+    flickr_api_retries = 3
+    flickr_api_memcached_location = "localhost:11211" # Disable cacheing Flickr API responses for now
+    flickr_api_memcached_ttl = 7200
 
     api_server_domain       = "dev.${var.dns_address}"
 

--- a/terraform/dev/variables.tf
+++ b/terraform/dev/variables.tf
@@ -5,6 +5,5 @@ variable "local_machine_cidr" {}
 variable "local_machine_public_key" {}
 variable "flickr_api_key" {}
 variable "flickr_secret_key" {}
-variable "flickr_user_id" {}
 variable "database_password_dev" {}
 variable "dns_address" {}

--- a/terraform/modules/api-server/parameter-store.tf
+++ b/terraform/modules/api-server/parameter-store.tf
@@ -83,6 +83,42 @@ resource "aws_ssm_parameter" "api_server_port" {
     value       = "${var.api_server_port}"
 }
 
+resource "aws_ssm_parameter" "flickr_api_key" {
+    name        = "/${var.environment}/api-server/flickr-api-key"
+    description = "Flickr API key"
+    type        = "String"
+    value       = "${var.flickr_api_key}"
+}
+
+resource "aws_ssm_parameter" "flickr_secret_key" {
+    name        = "/${var.environment}/api-server/flickr-api-secret"
+    description = "Flickr API secret key"
+    type        = "SecureString"
+    key_id      = "${aws_kms_key.parameter_secrets.id}"
+    value       = "${var.flickr_secret_key}"
+}
+
+resource "aws_ssm_parameter" "flickr_api_retries" {
+    name        = "/${var.environment}/api-server/flickr-api-retries"
+    description = "Max number of times to retry a Flickr API call"
+    type        = "String"
+    value       = "${var.flickr_api_retries}"
+}
+
+resource "aws_ssm_parameter" "flickr_api_memcached_ttl" {
+    name        = "/${var.environment}/api-server/flickr-api-memcached-ttl"
+    description = "TTL in seconds of Flickr API calls put into memcached"
+    type        = "String"
+    value       = "${var.flickr_api_memcached_ttl}"
+}
+
+resource "aws_ssm_parameter" "flickr_api_memcached_location" {
+    name        = "/${var.environment}/api-server/flickr-api-memcached-location"
+    description = "Endpoint of the memcached cluster that we cache Flickr API calls to"
+    type        = "String"
+    value       = "${var.flickr_api_memcached_location}"
+}
+
 resource "aws_ssm_parameter" "default_num_photo_recommendations" {
     name        = "/${var.environment}/api-server/default-num-photo-recommendations"
     description = "Number of photo recommendations we return if the caller doesn't specify"

--- a/terraform/modules/api-server/variables.tf
+++ b/terraform/modules/api-server/variables.tf
@@ -28,3 +28,8 @@ variable "load_balancer_access_logs_prefix" {}
 variable "retain_load_balancer_access_logs_after_destroy" {}
 variable "default_num_photo_recommendations" {}
 variable "api_server_domain" {}
+variable "flickr_api_key" {}
+variable "flickr_secret_key" {}
+variable "flickr_api_retries" {}
+variable "flickr_api_memcached_location" {}
+variable "flickr_api_memcached_ttl" {}

--- a/terraform/modules/puller-flickr/variables.tf
+++ b/terraform/modules/puller-flickr/variables.tf
@@ -13,7 +13,6 @@ variable "ecs_instances_role_name" {}
 variable "ecs_days_to_keep_images" {}
 variable "flickr_api_key" {}
 variable "flickr_secret_key" {}
-variable "flickr_user_id" {}
 variable "flickr_api_retries" {}
 variable "flickr_api_favorites_max_per_call" {}
 variable "flickr_api_favorites_max_to_get" {}

--- a/terraform/terraform.tfvars.example
+++ b/terraform/terraform.tfvars.example
@@ -6,7 +6,6 @@ local_machine_public_key = "ssh-rsa blahblahblah a@b.com"
 
 flickr_api_key = ""
 flickr_secret_key = "" 
-flickr_user_id = ""
 
 database_password_dev = ""
 


### PR DESCRIPTION
We need to make calls to Flickr from our front end, but we need to hold onto a secret. So we can't make these calls directly from the browser because that would mean exposing our secret to end users. Instead we call our API server, who holds the secret and makes the calls on our behalf.