### PR TITLE
Serve the frontend via S3 and CloudFront

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,9 +20,10 @@ This project uses:
 - RDS for the initial stab at data storage, but consider changing to Clickhouse: https://clickhouse.yandex/ or Redshift https://aws.amazon.com/redshift/
 - A bunch of Python libs, most notably Flask and gunicorn
 - ALB for load balancing: https://aws.amazon.com/elasticloadbalancing/
+- S3 for serving static assets, CloudFront for routing requests, and Route53 for DNS
 - CloudWatch for metrics & alarms, and a dashboard:  https://aws.amazon.com/cloudwatch/
 - Random other parts of AWS like ElastiCache, Parameter Store, and Key Management Service
-- Vue.js and friends for the frontend: https://vuejs.org/
+- Vue.js and friends for the frontend: https://vuejs.org/. The frontend project based on the Vue CLI: https://cli.vuejs.org/
 
 # Instructions
 

--- a/README.md
+++ b/README.md
@@ -19,10 +19,10 @@ This project uses:
 - SQS for the initial stab at data injestion, but consider changing to Kafka https://aws.amazon.com/msk/ or Kinesis https://aws.amazon.com/kinesis/
 - RDS for the initial stab at data storage, but consider changing to Clickhouse: https://clickhouse.yandex/ or Redshift https://aws.amazon.com/redshift/
 - A bunch of Python libs, most notably Flask and gunicorn
-- ALB for load balancing
-- CloudWatch for metrics & alarms
+- ALB for load balancing: https://aws.amazon.com/elasticloadbalancing/
+- CloudWatch for metrics & alarms, and a dashboard:  https://aws.amazon.com/cloudwatch/
 - Random other parts of AWS like ElastiCache, Parameter Store, and Key Management Service
-- Vue.js: https://vuejs.org/
+- Vue.js and friends for the frontend: https://vuejs.org/
 
 # Instructions
 
@@ -127,10 +127,16 @@ docker push <URI of scheduler-dev repository in ECR>
 cd ../../frontend
 brew install yarn
 yarn install
-yarn run build
 ```
 
-### Project dashboard
+### Deploy the frontend
+
+```
+yarn build --mode development
+yarn deploy --mode development
+```
+
+### Optional project dashboard
 
 ```
 yarn global add @vue/cli
@@ -159,3 +165,6 @@ TODO:
 - Add auth to API server - use AWS API gateway?
 - Audit for XSS attacks
 - Add CSRF token
+- Make frontend vendor file smaller: https://github.com/vuejs-templates/webpack/issues/1297
+- Add versioning to the front end, so that old versions of file (with different hashes) don't live in S3 forever: https://stackoverflow.com/questions/46166337/how-can-i-deploy-a-new-cloudfront-s3-version-without-a-small-period-of-unavailab?rq=1
+- Fix S3 bucket name conflicts if other people run this terraform

--- a/frontend/.env.production
+++ b/frontend/.env.production
@@ -1,0 +1,1 @@
+VUE_APP_S3D_BUCKET="photo-recommender-prod"

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -6,6 +6,7 @@
     "serve": "vue-cli-service serve",
     "build": "vue-cli-service build",
     "lint": "vue-cli-service lint",
+    "deploy": "vue-cli-service s3-deploy",
     "test:unit": "vue-cli-service test:unit"
   },
   "dependencies": {
@@ -17,6 +18,7 @@
     "core-js": "^2.6.5",
     "mutationobserver-shim": "^0.3.3",
     "vue": "^2.6.10",
+    "vue-cli-plugin-s3-deploy": "^3.0.0",
     "vue-router": "^3.0.3",
     "vuelidate": "^0.7.4",
     "vuex": "^3.0.1"

--- a/frontend/vue.config.js
+++ b/frontend/vue.config.js
@@ -6,4 +6,25 @@ module.exports = {
       },
     },
   },
+
+  pluginOptions: {
+    s3Deploy: {
+      registry: undefined,
+      awsProfile: 'default',
+      region: 'us-west-2',
+      bucket: 'photo-recommender-dev',
+      createBucket: false,
+      staticHosting: true,
+      staticIndexPage: 'index.html',
+      staticErrorPage: 'index.html',
+      assetPath: 'dist',
+      assetMatch: '**',
+      deployPath: '/',
+      acl: 'public-read',
+      pwa: false,
+      enableCloudfront: false,
+      uploadConcurrency: 5,
+      pluginVersion: '3.0.0'
+    }
+  }
 };

--- a/frontend/yarn.lock
+++ b/frontend/yarn.lock
@@ -971,7 +971,7 @@
     webpack-dev-server "^3.4.1"
     webpack-merge "^4.2.1"
 
-"@vue/cli-shared-utils@^3.11.0":
+"@vue/cli-shared-utils@^3.0.0-rc.3", "@vue/cli-shared-utils@^3.11.0":
   version "3.11.0"
   resolved "https://registry.yarnpkg.com/@vue/cli-shared-utils/-/cli-shared-utils-3.11.0.tgz#a3d6f809b0dfb367e626b71405f85dea0631310b"
   integrity sha512-D7pst/4v9H1DD66fLxlZOwRR09R03MV0ROdKxBHmh3FmnApCA/RiaolFA/8w+B3CnevYMlV3SJ5fOAgedbswbA==
@@ -1496,6 +1496,11 @@ array-unique@^0.3.2:
   resolved "https://registry.yarnpkg.com/array-unique/-/array-unique-0.3.2.tgz#a894b75d4bc4f6cd679ef3244a9fd8f46ae2d428"
   integrity sha1-qJS3XUvE9s1nnvMkSp/Y9Gri1Cg=
 
+arrify@^1.0.1:
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/arrify/-/arrify-1.0.1.tgz#898508da2226f380df904728456849c1501a4b0d"
+  integrity sha1-iYUI2iIm84DfkEcoRWhJwVAaSw0=
+
 asap@^2.0.0:
   version "2.0.6"
   resolved "https://registry.yarnpkg.com/asap/-/asap-2.0.6.tgz#e50347611d7e690943208bbdafebcbc2fb866d46"
@@ -1592,6 +1597,21 @@ autoprefixer@^9.5.1:
     num2fraction "^1.2.2"
     postcss "^7.0.17"
     postcss-value-parser "^4.0.0"
+
+aws-sdk@^2.225.1:
+  version "2.521.0"
+  resolved "https://registry.yarnpkg.com/aws-sdk/-/aws-sdk-2.521.0.tgz#b7b41084fdc9e8b134520f054c06e3908df9321a"
+  integrity sha512-YRViGahZoHq0lEsy0Cq7bqaLzP8OTzjg35Hz08Rv88ltk+b5UWVpDgIWls7mXCBNTBTYjbfbeGXzNaHJBLKlpA==
+  dependencies:
+    buffer "4.9.1"
+    events "1.1.1"
+    ieee754 "1.1.8"
+    jmespath "0.15.0"
+    querystring "0.2.0"
+    sax "1.2.1"
+    url "0.10.3"
+    uuid "3.3.2"
+    xml2js "0.4.19"
 
 aws-sign2@~0.7.0:
   version "0.7.0"
@@ -1957,7 +1977,7 @@ buffer-xor@^1.0.3:
   resolved "https://registry.yarnpkg.com/buffer-xor/-/buffer-xor-1.0.3.tgz#26e61ed1422fb70dd42e6e36729ed51d855fe8d9"
   integrity sha1-JuYe0UIvtw3ULm42cp7VHYVf6Nk=
 
-buffer@^4.3.0:
+buffer@4.9.1, buffer@^4.3.0:
   version "4.9.1"
   resolved "https://registry.yarnpkg.com/buffer/-/buffer-4.9.1.tgz#6d1bb601b07a4efced97094132093027c95bc298"
   integrity sha1-bRu2AbB6TvztlwlBMgkwJ8lbwpg=
@@ -3236,6 +3256,14 @@ diffie-hellman@^5.0.0:
     miller-rabin "^4.0.0"
     randombytes "^2.0.0"
 
+dir-glob@2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/dir-glob/-/dir-glob-2.0.0.tgz#0b205d2b6aef98238ca286598a8204d29d0a0034"
+  integrity sha512-37qirFDz8cA5fimp9feo43fSuRo2gHwaIn6dXL8Ber1dGwUosDrGZeCCXq57WnIqE4aQ+u3eQZzsk1yOzhdwag==
+  dependencies:
+    arrify "^1.0.1"
+    path-type "^3.0.0"
+
 dir-glob@^2.0.0, dir-glob@^2.2.2:
   version "2.2.2"
   resolved "https://registry.yarnpkg.com/dir-glob/-/dir-glob-2.2.2.tgz#fa09f0694153c8918b18ba0deafae94769fc50c4"
@@ -3547,6 +3575,11 @@ es-to-primitive@^1.2.0:
     is-date-object "^1.0.1"
     is-symbol "^1.0.2"
 
+es6-promise-pool@^2.5.0:
+  version "2.5.0"
+  resolved "https://registry.yarnpkg.com/es6-promise-pool/-/es6-promise-pool-2.5.0.tgz#147c612b36b47f105027f9d2bf54a598a99d9ccb"
+  integrity sha1-FHxhKza0fxBQJ/nSv1SlmKmdnMs=
+
 es6-promise@^4.0.3:
   version "4.2.8"
   resolved "https://registry.yarnpkg.com/es6-promise/-/es6-promise-4.2.8.tgz#4eb21594c972bc40553d276e510539143db53e0a"
@@ -3853,6 +3886,11 @@ eventemitter3@^3.0.0:
   resolved "https://registry.yarnpkg.com/eventemitter3/-/eventemitter3-3.1.2.tgz#2d3d48f9c346698fce83a85d7d664e98535df6e7"
   integrity sha512-tvtQIeLVHjDkJYnzf2dgVMxfuSGJeM/7UCG17TT4EumTfNtF+0nebF/4zWOIkCreAbtNqhGEboB6BWrwqNaw4Q==
 
+events@1.1.1:
+  version "1.1.1"
+  resolved "https://registry.yarnpkg.com/events/-/events-1.1.1.tgz#9ebdb7635ad099c70dcc4c2a1f5004288e8bd924"
+  integrity sha1-nr23Y1rQmccNzEwqH1AEKI6L2SQ=
+
 events@^3.0.0:
   version "3.0.0"
   resolved "https://registry.yarnpkg.com/events/-/events-3.0.0.tgz#9a0a0dfaf62893d92b875b8f2698ca4114973e88"
@@ -4048,7 +4086,7 @@ fast-deep-equal@^2.0.1:
   resolved "https://registry.yarnpkg.com/fast-deep-equal/-/fast-deep-equal-2.0.1.tgz#7b05218ddf9667bf7f370bf7fdb2cb15fdd0aa49"
   integrity sha1-ewUhjd+WZ79/Nwv3/bLLFf3Qqkk=
 
-fast-glob@^2.2.6:
+fast-glob@^2.0.2, fast-glob@^2.2.6:
   version "2.2.7"
   resolved "https://registry.yarnpkg.com/fast-glob/-/fast-glob-2.2.7.tgz#6953857c3afa475fff92ee6015d52da70a4cd39d"
   integrity sha512-g1KuQwHOZAmOZMuBtHdxDtju+T2RT8jgCC9aANsbpdiDDTSnjgfuVsIBNKbUeJI3oKMRExcfNDtJl4OhbffMsw==
@@ -4550,6 +4588,19 @@ globby@^7.1.1:
     pify "^3.0.0"
     slash "^1.0.0"
 
+globby@^8.0.1:
+  version "8.0.2"
+  resolved "https://registry.yarnpkg.com/globby/-/globby-8.0.2.tgz#5697619ccd95c5275dbb2d6faa42087c1a941d8d"
+  integrity sha512-yTzMmKygLp8RUpG1Ymu2VXPSJQZjNAZPD4ywgYEaG7e4tBJeUQBO8OpXrf1RCNcEs5alsoJYPAMiIHP0cmeC7w==
+  dependencies:
+    array-union "^1.0.1"
+    dir-glob "2.0.0"
+    fast-glob "^2.0.2"
+    glob "^7.1.2"
+    ignore "^3.3.5"
+    pify "^3.0.0"
+    slash "^1.0.0"
+
 globby@^9.2.0:
   version "9.2.0"
   resolved "https://registry.yarnpkg.com/globby/-/globby-9.2.0.tgz#fd029a706c703d29bdd170f4b6db3a3f7a7cb63d"
@@ -4947,6 +4998,11 @@ icss-utils@^2.1.0:
   integrity sha1-g/Cg7DeL8yRheLbCrZE28TWxyWI=
   dependencies:
     postcss "^6.0.1"
+
+ieee754@1.1.8:
+  version "1.1.8"
+  resolved "https://registry.yarnpkg.com/ieee754/-/ieee754-1.1.8.tgz#be33d40ac10ef1926701f6f08a2d86fbfd1ad3e4"
+  integrity sha1-vjPUCsEO8ZJnAfbwii2G+/0a0+Q=
 
 ieee754@^1.1.4:
   version "1.1.13"
@@ -5530,6 +5586,11 @@ javascript-stringify@^1.6.0:
   version "1.6.0"
   resolved "https://registry.yarnpkg.com/javascript-stringify/-/javascript-stringify-1.6.0.tgz#142d111f3a6e3dae8f4a9afd77d45855b5a9cce3"
   integrity sha1-FC0RHzpuPa6PSpr9d9RYVbWpzOM=
+
+jmespath@0.15.0:
+  version "0.15.0"
+  resolved "https://registry.yarnpkg.com/jmespath/-/jmespath-0.15.0.tgz#a3f222a9aae9f966f5d27c796510e28091764217"
+  integrity sha1-o/Iiqarp+Wb10nx5ZRDigJF2Qhc=
 
 js-base64@^2.1.8:
   version "2.5.1"
@@ -6327,7 +6388,7 @@ mime-db@1.40.0, "mime-db@>= 1.40.0 < 2":
   resolved "https://registry.yarnpkg.com/mime-db/-/mime-db-1.40.0.tgz#a65057e998db090f732a68f6c276d387d4126c32"
   integrity sha512-jYdeOMPy9vnxEqFRRo6ZvTZ8d9oPb+k18PKoYNYUe2stVEBPPwsln/qWzdbmaIvnhZ9v2P+CuecK+fpUfsV2mA==
 
-mime-types@^2.1.12, mime-types@~2.1.17, mime-types@~2.1.19, mime-types@~2.1.24:
+mime-types@^2.1.12, mime-types@^2.1.18, mime-types@~2.1.17, mime-types@~2.1.19, mime-types@~2.1.24:
   version "2.1.24"
   resolved "https://registry.yarnpkg.com/mime-types/-/mime-types-2.1.24.tgz#b6f8d0b3e951efb77dedeca194cff6d16f676f81"
   integrity sha512-WaFHS3MCl5fapm3oLxU4eYDw77IQM2ACcxQ9RIxfaC3ooc6PFuBMGZZsYpvoXS5D5QTWPieo1jjLdAm3TBP3cQ==
@@ -8867,7 +8928,12 @@ sass-loader@^7.1.0:
     pify "^4.0.1"
     semver "^6.3.0"
 
-sax@^1.2.4, sax@~1.2.4:
+sax@1.2.1:
+  version "1.2.1"
+  resolved "https://registry.yarnpkg.com/sax/-/sax-1.2.1.tgz#7b8e656190b228e81a66aea748480d828cd2d37a"
+  integrity sha1-e45lYZCyKOgaZq6nSEgNgozS03o=
+
+sax@>=0.6.0, sax@^1.2.4, sax@~1.2.4:
   version "1.2.4"
   resolved "https://registry.yarnpkg.com/sax/-/sax-1.2.4.tgz#2816234e2378bddc4e5354fab5caa895df7100d9"
   integrity sha512-NqVDv9TpANUjFm0N8uM5GxL36UgKi9/atZw+x7YFnQ8ckwFGKrl4xX4yWtrey3UJm5nP1kUbnYgLopqWNSRhWw==
@@ -10091,6 +10157,14 @@ url-parse@^1.4.3:
     querystringify "^2.1.1"
     requires-port "^1.0.0"
 
+url@0.10.3:
+  version "0.10.3"
+  resolved "https://registry.yarnpkg.com/url/-/url-0.10.3.tgz#021e4d9c7705f21bbf37d03ceb58767402774c64"
+  integrity sha1-Ah5NnHcF8hu/N9A861h2dAJ3TGQ=
+  dependencies:
+    punycode "1.3.2"
+    querystring "0.2.0"
+
 url@^0.11.0:
   version "0.11.0"
   resolved "https://registry.yarnpkg.com/url/-/url-0.11.0.tgz#3838e97cfc60521eb73c525a8e55bfdd9e2e28f1"
@@ -10158,6 +10232,11 @@ uuid@*, uuid@^3.0.1, uuid@^3.3.2:
   resolved "https://registry.yarnpkg.com/uuid/-/uuid-3.3.3.tgz#4568f0216e78760ee1dbf3a4d2cf53e224112866"
   integrity sha512-pW0No1RGHgzlpHJO1nsVrHKpOEIxkGg1xB+v0ZmdNH5OAeAwzAVrCnI2/6Mtx+Uys6iaylxa+D3g4j63IKKjSQ==
 
+uuid@3.3.2:
+  version "3.3.2"
+  resolved "https://registry.yarnpkg.com/uuid/-/uuid-3.3.2.tgz#1b4af4955eb3077c501c23872fc6513811587131"
+  integrity sha512-yXJmeNaw3DnnKAOKJE51sL/ZaYfWJRl1pK9dr19YFCu0ObS231AB1/LbqTKRAQ5kw8A90rA6fr4riOUpTZvQZA==
+
 validate-npm-package-license@^3.0.1, validate-npm-package-license@^3.0.4:
   version "3.0.4"
   resolved "https://registry.yarnpkg.com/validate-npm-package-license/-/validate-npm-package-license-3.0.4.tgz#fc91f6b9c7ba15c857f4cb2c5defeec39d4f410a"
@@ -10201,6 +10280,17 @@ vue-cli-plugin-bootstrap-vue@^0.4.0:
   version "0.4.0"
   resolved "https://registry.yarnpkg.com/vue-cli-plugin-bootstrap-vue/-/vue-cli-plugin-bootstrap-vue-0.4.0.tgz#08b948adb712209b7e076f573128ea1e9f9892fc"
   integrity sha512-L/AFeUBDJhCbBFSKJytERTCV3m+Z+SxgnEYZayA3GNfweMQDw2eJbtcgw4+4aU348seH4+8fU4lrMOLkKlw8hw==
+
+vue-cli-plugin-s3-deploy@^3.0.0:
+  version "3.0.0"
+  resolved "https://registry.yarnpkg.com/vue-cli-plugin-s3-deploy/-/vue-cli-plugin-s3-deploy-3.0.0.tgz#4f60a9d9902da40240f05da0f52d3cce87437d85"
+  integrity sha512-6u+pOq9jBa0DITdLDHUydxIxvjPEr+03ei9B5iizCWZqts58jk6NHdIsn8crWKvvO2nKFZ8pbdtxhoWWXeikoA==
+  dependencies:
+    "@vue/cli-shared-utils" "^3.0.0-rc.3"
+    aws-sdk "^2.225.1"
+    es6-promise-pool "^2.5.0"
+    globby "^8.0.1"
+    mime-types "^2.1.18"
 
 vue-eslint-parser@^2.0.3:
   version "2.0.3"
@@ -10604,6 +10694,19 @@ xml-name-validator@^3.0.0:
   version "3.0.0"
   resolved "https://registry.yarnpkg.com/xml-name-validator/-/xml-name-validator-3.0.0.tgz#6ae73e06de4d8c6e47f9fb181f78d648ad457c6a"
   integrity sha512-A5CUptxDsvxKJEU3yO6DuWBSJz/qizqzJKOMIfUJHETbBw/sFaDxgd6fxm1ewUaM0jZ444Fc5vC5ROYurg/4Pw==
+
+xml2js@0.4.19:
+  version "0.4.19"
+  resolved "https://registry.yarnpkg.com/xml2js/-/xml2js-0.4.19.tgz#686c20f213209e94abf0d1bcf1efaa291c7827a7"
+  integrity sha512-esZnJZJOiJR9wWKMyuvSE1y6Dq5LCuJanqhxslH2bxM6duahNZ+HMpCLhBQGZkbX6xRf8x1Y2eJlgt2q3qo49Q==
+  dependencies:
+    sax ">=0.6.0"
+    xmlbuilder "~9.0.1"
+
+xmlbuilder@~9.0.1:
+  version "9.0.7"
+  resolved "https://registry.yarnpkg.com/xmlbuilder/-/xmlbuilder-9.0.7.tgz#132ee63d2ec5565c557e20f4c22df9aca686b10d"
+  integrity sha1-Ey7mPS7FVlxVfiD0wi35rKaGsQ0=
 
 xmlchars@^2.1.1:
   version "2.1.1"

--- a/terraform/dev/main.tf
+++ b/terraform/dev/main.tf
@@ -268,6 +268,7 @@ module "frontend" {
 
     load_balancer_arn       = "${module.api_server.load_balancer_arn}"
     load_balancer_dns_name  = "${module.api_server.load_balancer_dns_name}"
+    load_balancer_port      = "${module.api_server.load_balancer_port}"
     load_balancer_zone_id   = "${module.api_server.load_balancer_zone_id}"
 
     frontend_access_logs_bucket = "frontend-access-logs"

--- a/terraform/modules/api-server/load-balancer.tf
+++ b/terraform/modules/api-server/load-balancer.tf
@@ -1,6 +1,4 @@
 resource "aws_lb" "api_server" {
-    depends_on         = ["aws_s3_bucket.load_balancer_access_logs"]
-
     name               = "api-server-lb-${var.environment}"
     internal           = false
     load_balancer_type = "application"
@@ -10,7 +8,7 @@ resource "aws_lb" "api_server" {
     ip_address_type    = "ipv4"
 
     access_logs {
-        bucket  = "${var.load_balancer_access_logs_bucket}-${var.environment}"
+        bucket  = "${aws_s3_bucket.load_balancer_access_logs.id}"
         prefix  = "${var.load_balancer_access_logs_prefix}-${var.environment}"
         enabled = true
     }

--- a/terraform/modules/api-server/load-balancer.tf
+++ b/terraform/modules/api-server/load-balancer.tf
@@ -1,4 +1,6 @@
 resource "aws_lb" "api_server" {
+    depends_on         = ["aws_s3_bucket.load_balancer_access_logs"]
+
     name               = "api-server-lb-${var.environment}"
     internal           = false
     load_balancer_type = "application"
@@ -8,8 +10,8 @@ resource "aws_lb" "api_server" {
     ip_address_type    = "ipv4"
 
     access_logs {
-        bucket  = "${var.load_balancer_access_logs_bucket}"
-        prefix  = "${var.load_balancer_access_logs_prefix}"
+        bucket  = "${var.load_balancer_access_logs_bucket}-${var.environment}"
+        prefix  = "${var.load_balancer_access_logs_prefix}-${var.environment}"
         enabled = true
     }
 
@@ -40,7 +42,7 @@ resource "aws_lb_target_group" "load_balancer" {
     depends_on              = ["aws_lb.api_server"] # https://github.com/cds-snc/aws-ecs-fargate/issues/1
 }
 
-resource "aws_lb_listener" "load_balancer" {  
+resource "aws_lb_listener" "api_server" {  
     load_balancer_arn = "${aws_lb.api_server.arn}"  
     port              = "${var.load_balancer_port}"  
     protocol          = "HTTP"
@@ -88,7 +90,7 @@ data "aws_caller_identity" "load_balancer" {}
 data "aws_elb_service_account" "main" {}
 
 resource "aws_s3_bucket" "load_balancer_access_logs" {
-    bucket = "${var.load_balancer_access_logs_bucket}"
+    bucket = "${var.load_balancer_access_logs_bucket}-${var.environment}"
     acl    = "bucket-owner-full-control"
     force_destroy = "${!var.retain_load_balancer_access_logs_after_destroy}"
     policy = <<EOF
@@ -102,7 +104,7 @@ resource "aws_s3_bucket" "load_balancer_access_logs" {
         "s3:PutObject"
       ],
       "Effect": "Allow",
-      "Resource": "arn:aws:s3:::${var.load_balancer_access_logs_bucket}/${var.load_balancer_access_logs_prefix}/AWSLogs/${data.aws_caller_identity.load_balancer.account_id}/*",
+      "Resource": "arn:aws:s3:::${var.load_balancer_access_logs_bucket}-${var.environment}/${var.load_balancer_access_logs_prefix}-${var.environment}/AWSLogs/${data.aws_caller_identity.load_balancer.account_id}/*",
       "Principal": {
         "AWS": [
           "${data.aws_elb_service_account.main.id}"

--- a/terraform/modules/api-server/outputs.tf
+++ b/terraform/modules/api-server/outputs.tf
@@ -3,12 +3,22 @@ output "security_group_id" {
     description = "The ID of the security group we created containing the rules for talking to our API server"
 }
 
-output "load_balancer_host" {
-    value = "${aws_lb.api_server.dns_name}"
-    description = "The DNS hostname of the load balancer we created"
-}
-
 output "load_balancer_port" {
     value = "${var.load_balancer_port}"
     description = "The port the load balancer is listening on"
+}
+
+output "load_balancer_dns_name" {
+    value = "${aws_lb.api_server.dns_name}"
+    description = "DNS name of the load balancer we created"
+}
+
+output "load_balancer_zone_id" {
+    value = "${aws_lb.api_server.zone_id}"
+    description = "Zone ID of the load balancer we created"
+}
+
+output "load_balancer_arn" {
+    value = "${aws_lb.api_server.arn}"
+    description = "ARN of the load balancer we created"
 }

--- a/terraform/modules/api-server/variables.tf
+++ b/terraform/modules/api-server/variables.tf
@@ -27,7 +27,6 @@ variable "load_balancer_access_logs_bucket" {}
 variable "load_balancer_access_logs_prefix" {}
 variable "retain_load_balancer_access_logs_after_destroy" {}
 variable "default_num_photo_recommendations" {}
-variable "api_server_domain" {}
 variable "flickr_api_key" {}
 variable "flickr_secret_key" {}
 variable "flickr_api_retries" {}

--- a/terraform/modules/frontend/cloudfront.tf
+++ b/terraform/modules/frontend/cloudfront.tf
@@ -16,6 +16,7 @@ locals {
 resource "aws_cloudfront_distribution" "application" {
     
     enabled = true
+    default_root_object = "index.html"
 
     # Our S3 bucket
     origin {

--- a/terraform/modules/frontend/cloudfront.tf
+++ b/terraform/modules/frontend/cloudfront.tf
@@ -108,7 +108,7 @@ resource "aws_cloudfront_distribution" "application" {
 data "aws_iam_policy_document" "allow_cloudfront" {
     statement {
         actions   = ["s3:GetObject"]
-        resources = ["${aws_s3_bucket.frontend_access_logs.arn}/*"]
+        resources = ["${aws_s3_bucket.frontend.arn}/*"]
 
         principals {
             type        = "AWS"
@@ -118,7 +118,7 @@ data "aws_iam_policy_document" "allow_cloudfront" {
 
     statement {
         actions   = ["s3:ListBucket"]
-        resources = ["${aws_s3_bucket.frontend_access_logs.arn}"]
+        resources = ["${aws_s3_bucket.frontend.arn}"]
 
         principals {
             type        = "AWS"
@@ -127,7 +127,7 @@ data "aws_iam_policy_document" "allow_cloudfront" {
     }
 }
 
-resource "aws_s3_bucket_policy" "frontend_access_logs_cloudfront" {
-    bucket = "${aws_s3_bucket.frontend_access_logs.id}"
+resource "aws_s3_bucket_policy" "frontend_cloudfront" {
+    bucket = "${aws_s3_bucket.frontend.id}"
     policy = "${data.aws_iam_policy_document.allow_cloudfront.json}"
 }

--- a/terraform/modules/frontend/cloudfront.tf
+++ b/terraform/modules/frontend/cloudfront.tf
@@ -1,0 +1,133 @@
+
+# This is a special user that Cloudfront assumes when reading from the bucket. We set our bucket
+# permissions such that only this user has access, rather than making it publicly readable,
+# so that people can't directly access the bucket contents.
+# https://docs.aws.amazon.com/AmazonCloudFront/latest/DeveloperGuide/private-content-restricting-access-to-s3.html
+
+resource "aws_cloudfront_origin_access_identity" "origin_access_identity" {
+    comment = "Cloudfront user allowed to read from our S3 bucket"
+}
+
+locals {
+    s3_origin_id = "static_files_origin"
+    load_balancer_origin_id = "load_balancer_origin"
+}
+
+resource "aws_cloudfront_distribution" "application" {
+    
+    enabled = true
+
+    # Our S3 bucket
+    origin {
+        domain_name = "${aws_s3_bucket.frontend.bucket_regional_domain_name}"
+        origin_id   = "${local.s3_origin_id}"
+
+        s3_origin_config {
+            origin_access_identity = "${aws_cloudfront_origin_access_identity.origin_access_identity.cloudfront_access_identity_path}"
+        }
+    }
+
+    # Our load balancer
+    origin {
+        domain_name = "${var.load_balancer_dns_name}"
+        origin_id   = "${local.load_balancer_origin_id}"
+
+        custom_origin_config {
+            http_port = "${var.load_balancer_port}"
+            https_port = "${var.load_balancer_port}"
+            origin_protocol_policy = "match-viewer"
+            origin_ssl_protocols = ["SSLv3", "TLSv1", "TLSv1.1", "TLSv1.2"]
+            origin_keepalive_timeout = 30 # Max is 60
+            origin_read_timeout = 10 # Max is 60
+        }
+    }
+
+    # Forward requests beginning with /api to our load balancer
+    ordered_cache_behavior {
+        path_pattern     = "/api/*"
+        allowed_methods  = ["DELETE", "GET", "HEAD", "OPTIONS", "PATCH", "POST", "PUT"]
+        cached_methods   = ["GET", "HEAD", "OPTIONS"]
+        target_origin_id = "${local.load_balancer_origin_id}"
+
+        forwarded_values {
+            query_string = true
+
+            cookies {
+                forward = "all"
+            }
+        }
+
+        viewer_protocol_policy = "allow-all"
+        min_ttl                = 0
+        default_ttl            = 3600
+        max_ttl                = 86400
+    }
+
+    # Forward everything else to our S3 bucket
+    default_cache_behavior {
+        allowed_methods  = ["DELETE", "GET", "HEAD", "OPTIONS", "PATCH", "POST", "PUT"]
+        cached_methods   = ["GET", "HEAD", "OPTIONS"]
+        target_origin_id = "${local.s3_origin_id}"
+
+        forwarded_values {
+            query_string = true
+
+            cookies {
+                forward = "all"
+            }
+        }
+
+        viewer_protocol_policy = "allow-all"
+        min_ttl                = 0
+        default_ttl            = 3600
+        max_ttl                = 86400
+    }
+
+    logging_config {
+        include_cookies = false
+        bucket          = "${aws_s3_bucket.frontend_access_logs.bucket_domain_name}"
+        prefix          = "cloudfront/"
+    }
+
+    price_class = "PriceClass_100" # Only serve from US/Europe to keep costs down: https://aws.amazon.com/cloudfront/pricing/
+
+    restrictions {
+        geo_restriction {
+            restriction_type = "none"
+        }
+    }
+
+    viewer_certificate {
+        # For https requests, this allows us to use the cloudfront domain name to access our application.
+        # TODO: Needs update when we have our own domain name
+        # https://www.terraform.io/docs/providers/aws/r/cloudfront_distribution.html#viewer-certificate-arguments
+        cloudfront_default_certificate = true
+    }
+}
+
+data "aws_iam_policy_document" "allow_cloudfront" {
+    statement {
+        actions   = ["s3:GetObject"]
+        resources = ["${aws_s3_bucket.frontend_access_logs.arn}/*"]
+
+        principals {
+            type        = "AWS"
+            identifiers = ["${aws_cloudfront_origin_access_identity.origin_access_identity.iam_arn}"]
+        }
+    }
+
+    statement {
+        actions   = ["s3:ListBucket"]
+        resources = ["${aws_s3_bucket.frontend_access_logs.arn}"]
+
+        principals {
+            type        = "AWS"
+            identifiers = ["${aws_cloudfront_origin_access_identity.origin_access_identity.iam_arn}"]
+        }
+    }
+}
+
+resource "aws_s3_bucket_policy" "frontend_access_logs_cloudfront" {
+    bucket = "${aws_s3_bucket.frontend_access_logs.id}"
+    policy = "${data.aws_iam_policy_document.allow_cloudfront.json}"
+}

--- a/terraform/modules/frontend/dns.tf
+++ b/terraform/modules/frontend/dns.tf
@@ -10,8 +10,8 @@ resource "aws_route53_record" "api_server" {
     type    = "A"
 
     alias {
-        name                   = "${var.load_balancer_dns_name}"
-        zone_id                = "${var.load_balancer_zone_id}"
+        name                   = "${aws_cloudfront_distribution.application.domain_name}"
+        zone_id                = "${aws_cloudfront_distribution.application.hosted_zone_id}"
         evaluate_target_health = true
     }
 }

--- a/terraform/modules/frontend/dns.tf
+++ b/terraform/modules/frontend/dns.tf
@@ -1,17 +1,17 @@
 
 resource "aws_route53_zone" "primary" {
-    name = "${var.api_server_domain}"
+    name = "${var.application_domain}"
     force_destroy = true
 }
 
 resource "aws_route53_record" "api_server" {
     zone_id = "${aws_route53_zone.primary.zone_id}"
-    name    = "${var.api_server_domain}"
+    name    = "${var.application_domain}"
     type    = "A"
 
     alias {
-        name                   = "${aws_lb.api_server.dns_name}"
-        zone_id                = "${aws_lb.api_server.zone_id}"
+        name                   = "${var.load_balancer_dns_name}"
+        zone_id                = "${var.load_balancer_zone_id}"
         evaluate_target_health = true
     }
 }

--- a/terraform/modules/frontend/s3.tf
+++ b/terraform/modules/frontend/s3.tf
@@ -1,0 +1,70 @@
+resource "aws_s3_bucket" "frontend" {
+    bucket = "${var.application_name}-${var.environment}"
+    acl    = "public-read"
+    force_destroy = true
+
+    website {
+        index_document = "index.html"
+        error_document = "index.html"
+    }
+
+    logging {
+        target_bucket = "${aws_s3_bucket.frontend_access_logs.id}"
+        target_prefix = "access-log/"
+    }
+
+    lifecycle_rule {
+        id      = "expire-old-versions-after-N-days"
+        enabled = true
+
+        prefix = "*"
+
+        noncurrent_version_expiration {
+            days = "${var.days_to_keep_old_versions}"
+        }
+    }
+}
+
+resource "aws_s3_bucket_public_access_block" "frontend" {
+    bucket = "${aws_s3_bucket.frontend.id}"
+
+    block_public_acls         = false
+    block_public_policy       = false
+    ignore_public_acls        = false
+    restrict_public_buckets   = false
+}
+
+resource "aws_s3_bucket" "frontend_access_logs" {
+    bucket = "${var.frontend_access_logs_bucket}-${var.environment}"
+    acl    = "log-delivery-write"
+    force_destroy = "${!var.retain_frontend_access_logs_after_destroy}"
+
+    lifecycle_rule {
+        id      = "expire-logs-after-N-days"
+        enabled = true
+
+        prefix = "*"
+
+        expiration {
+            days = "${var.days_to_keep_frontend_access_logs}"
+        }
+    }
+
+    server_side_encryption_configuration {
+        rule {
+            apply_server_side_encryption_by_default {
+                # Keep this as AES for consistency with the load balancer access logs (see note there)
+                sse_algorithm = "AES256" 
+            }
+        }
+    }
+}
+
+resource "aws_s3_bucket_public_access_block" "frontend_access_logs" {
+    bucket = "${aws_s3_bucket.frontend_access_logs.id}"
+
+    block_public_acls         = true
+    block_public_policy       = true
+    ignore_public_acls        = true
+    restrict_public_buckets   = true
+}

--- a/terraform/modules/frontend/s3.tf
+++ b/terraform/modules/frontend/s3.tf
@@ -30,10 +30,10 @@ resource "aws_s3_bucket" "frontend" {
 resource "aws_s3_bucket_public_access_block" "frontend" {
     bucket = "${aws_s3_bucket.frontend.id}"
 
-    block_public_acls         = false
-    block_public_policy       = false
-    ignore_public_acls        = false
-    restrict_public_buckets   = false
+    block_public_acls         = true
+    block_public_policy       = true
+    ignore_public_acls        = true
+    restrict_public_buckets   = true
 }
 
 resource "aws_s3_bucket" "frontend_access_logs" {

--- a/terraform/modules/frontend/s3.tf
+++ b/terraform/modules/frontend/s3.tf
@@ -1,6 +1,8 @@
+# We will add a policy in cloudfront.tf that allows the cloudfront user to read from this bucket
+
 resource "aws_s3_bucket" "frontend" {
     bucket = "${var.application_name}-${var.environment}"
-    acl    = "public-read"
+    acl    = "bucket-owner-full-control"
     force_destroy = true
 
     website {

--- a/terraform/modules/frontend/variables.tf
+++ b/terraform/modules/frontend/variables.tf
@@ -1,0 +1,11 @@
+variable "environment" {}
+variable "region" {}
+variable "days_to_keep_old_versions" {}
+variable "load_balancer_dns_name" {}
+variable "load_balancer_zone_id" {}
+variable "load_balancer_arn" {}
+variable "application_name" {}
+variable "application_domain" {}
+variable "frontend_access_logs_bucket" {}
+variable "retain_frontend_access_logs_after_destroy" {}
+variable "days_to_keep_frontend_access_logs" {}

--- a/terraform/modules/frontend/variables.tf
+++ b/terraform/modules/frontend/variables.tf
@@ -2,6 +2,7 @@ variable "environment" {}
 variable "region" {}
 variable "days_to_keep_old_versions" {}
 variable "load_balancer_dns_name" {}
+variable "load_balancer_port" {}
 variable "load_balancer_zone_id" {}
 variable "load_balancer_arn" {}
 variable "application_name" {}


### PR DESCRIPTION
- Add yarn task to deploy the front end, both dev and prod versions
- Add bucket to serve the static front end files
- Add cloudfront distribution to direct requests to either bucket or load balancer based on request path
- Some fixes to the s3 bucket that stores our load balancer access logs
- New bucket to store s3 and cloudfront access logs
- Move route53 stuff into the new frontend module, and point it at cloudfront rather than our load balancer
- Readme fixes + new tasks
