### PR TITLE
Various tweaks after some performance testing

### DIFF
--- a/README.md
+++ b/README.md
@@ -172,7 +172,8 @@ TODO:
 - Audit for XSS attacks
 - Add CSRF token
 - Make frontend vendor file smaller (it's mostly bootstrap): https://bootstrap-vue.js.org/docs/#tree-shaking-with-module-bundlers
- - See also https://medium.com/js-dojo/how-to-reduce-your-vue-js-bundle-size-with-webpack-3145bf5019b7
+-- See also https://medium.com/js-dojo/how-to-reduce-your-vue-js-bundle-size-with-webpack-3145bf5019b7
 - Add versioning to the front end, so that old versions of file (with different hashes) don't live in S3 forever: https://stackoverflow.com/questions/46166337/how-can-i-deploy-a-new-cloudfront-s3-version-without-a-small-period-of-unavailab?rq=1
 - Fix S3 bucket name conflicts if other people run this terraform
 - Fix website S3 bucket permissions to allow deployments but not allow public access
+- Get domain name + add hooks for google analytics

--- a/src/scheduler/Dockerfile
+++ b/src/scheduler/Dockerfile
@@ -16,4 +16,6 @@ ADD common/loop_command.sh /common/
 COPY scheduler/requirements.txt /
 RUN pip install -r /requirements.txt
 WORKDIR scheduler/
-CMD [ "../common/loop_command.sh", "./scheduler.py", "2" ]
+# Only loop every 10 seconds: it's how long our lock lasts, and there's no sense in
+# spamming the API server constantly looking for locks when there's > 1 instance of this process
+CMD [ "../common/loop_command.sh", "./scheduler.py", "10" ]

--- a/terraform/dev/main.tf
+++ b/terraform/dev/main.tf
@@ -28,9 +28,9 @@ module "elastic_container_service" {
     extra_security_groups = ["${module.api_server.security_group_id}"]
 
     instance_type = "t2.micro"#"c5.large"#"t2.micro"
-    cluster_desired_size = 2#20
+    cluster_desired_size = 0#2#20
     cluster_min_size = 0
-    cluster_max_size = 2#20
+    cluster_max_size = 0#2#20
     instances_log_retention_days = 1
 }
 

--- a/terraform/modules/frontend/s3.tf
+++ b/terraform/modules/frontend/s3.tf
@@ -32,6 +32,7 @@ resource "aws_s3_bucket_public_access_block" "frontend" {
                                         # Giving explicit permission to the IAM user doing the deployment doesn't help. 
                                         # The console still says "bucket and objects not public" (as desired), 
                                         # and trying to go to the website link for this bucket gives a 403 forbidden (as desired)
+                                        # I wrote up an issue here: https://github.com/multiplegeorges/vue-cli-plugin-s3-deploy/issues/79
     block_public_policy       = true
     ignore_public_acls        = true
     restrict_public_buckets   = true


### PR DESCRIPTION
The biggest one was changing the transaction type for the database bulk loader and adding some notes after performance testing. More testing is necessary because I think there's too much noise in the results due to looking at queue sizes to determine system runtime.

Also noticed deadlock exceptions in the API server (which I expected -- just needed to know the exception type for them), so added a block to specifically catch them and some notes explaining it (fixes https://github.com/euan-forrester/photo-recommender/issues/63)

Made the Scheduler execute less often to help with API server spamming when there's > 1 instance.

Added a link to the issue I wrote up about s3 bucket permissions for the front end.