### PR TITLE
Exclude users we already follow from our user recommendations

### DIFF
--- a/README.md
+++ b/README.md
@@ -178,4 +178,3 @@ TODO:
 - Fix website S3 bucket permissions to allow deployments but not allow public access
 - Get domain name + add hooks for google analytics
 - Add button to dismiss a photo or user recommendation, and add that photo/user to a table so that they aren't recommended again
-- Don't recommend users who we already follow

--- a/frontend/src/components/PhotoRecommendation.vue
+++ b/frontend/src/components/PhotoRecommendation.vue
@@ -7,7 +7,9 @@
 </template>
 
 <script>
-import { getPhotoUrl } from '../repositories/flickrRepository'
+import RepositoryFactory from '../repositories/repositoryFactory';
+
+const FlickrRepository = RepositoryFactory.get('flickr');
 
 export default {
   props: {
@@ -17,11 +19,11 @@ export default {
   },
   data() {
     return {
-      photoUrl,
+      photoUrl: '',
     };
   },
   async mounted() {
-    this.photoUrl = getPhotoUrl(this.imageOwner, this.imageId);
+    this.photoUrl = FlickrRepository.getPhotoUrl(this.imageOwner, this.imageId);
   },
 };
 </script>

--- a/frontend/src/components/UserRecommendation.vue
+++ b/frontend/src/components/UserRecommendation.vue
@@ -25,7 +25,6 @@ export default {
   },
   async mounted() {
     try {
-
       // It would probably be better if we had all the information we needed about each potential
       // user recommendation in our database already. That would allow us to get information about
       // how to display them faster.

--- a/frontend/src/repositories/flickrRepository.js
+++ b/frontend/src/repositories/flickrRepository.js
@@ -19,7 +19,7 @@ export default {
   },
   async getPersonInfo(userId) {
     const response = await repository.get(`${resource}/people/get-info`, { params: { 'user-id': userId } });
-  
+
     // 'realname' may not be defined, or it may be defined and contains an empty string.
     // Either way, we want to default to their username instead
 
@@ -51,5 +51,5 @@ export default {
   },
   getPhotoUrl(imageOwner, imageId) {
     return `https://www.flickr.com/photos/${imageOwner}/${imageId}`;
-  }
+  },
 };

--- a/frontend/src/store.js
+++ b/frontend/src/store.js
@@ -41,7 +41,7 @@ export default new Vuex.Store({
       const userResponse = await FlickrRepository.getUserIdFromUrl(userUrl);
 
       const user = {
-        id: userReponse.id,
+        id: userResponse.id,
         name: userResponse.name,
         recommendations: [],
         currentlyProcessingData: false,

--- a/src/api-server/Dockerfile
+++ b/src/api-server/Dockerfile
@@ -3,6 +3,7 @@ ADD api-server/api-server.py /api-server/
 ADD api-server/photorecommendation.py /api-server/
 ADD api-server/favoritesstoredatabase.py /api-server/
 ADD api-server/favoritesstoreexception.py /api-server/
+ADD api-server/userrecommendation.py /api-server/
 ADD common/flickrapiwrapper.py /common/
 ADD common/confighelper.py /common/
 ADD common/metricshelper.py /common/

--- a/src/api-server/api-server.py
+++ b/src/api-server/api-server.py
@@ -214,16 +214,6 @@ def put_user_data_requested(user_id=None):
 
     return "OK", status.HTTP_200_OK
 
-# Notifies that a particular user has had their data successfully updated (i.e. for just themsolves)
-@application.route("/api/users/<user_id>/data-updated", methods = ['PUT'])
-def put_user_data_updated(user_id=None):
-    if user_id is None:
-        return user_not_specified()
-
-    favorites_store.user_data_updated(user_id)
-
-    return "OK", status.HTTP_200_OK
-
 # Notifies that a particular user has had all of their data successfully updated (i.e. for all their neighbors)
 @application.route("/api/users/<user_id>/all-data-updated", methods = ['PUT'])
 def put_user_all_data_updated(user_id=None):

--- a/src/api-server/api-server.py
+++ b/src/api-server/api-server.py
@@ -303,6 +303,19 @@ def get_flickr_get_person_info():
 
     return resp
 
+@application.route("/api/flickr/contacts/get-list", methods = ['GET'])
+def get_flickr_get_contacts():
+
+    user_id = request.args.get("user-id")
+
+    if not user_id:
+        return parameter_not_specified("user-id")
+
+    resp = jsonify(flickrapi.get_contacts(user_id=user_id, max_contacts_per_call=1000))
+    resp.status_code = status.HTTP_200_OK
+
+    return resp
+
 @application.route("/favicon.ico", methods = ['GET'])
 def get_favicon():
     # Browsers like to call this, and without defining this route we see 404 errors in our logs

--- a/src/api-server/favoritesstoredatabase.py
+++ b/src/api-server/favoritesstoredatabase.py
@@ -349,31 +349,6 @@ class FavoritesStoreDatabase:
             cursor.close()
             cnx.close()         
 
-    def user_data_updated(self, user_id):
-        cnx = self.cnxpool.get_connection()
-
-        cursor = cnx.cursor() 
-
-        try:
-            cursor.execute("""
-                UPDATE 
-                    registered_users 
-                SET 
-                    data_last_successfully_processed_at = NOW() 
-                WHERE 
-                    user_id=%s;
-            """, (user_id,))
-
-            cnx.commit()
-
-        except Exception as e:
-            cnx.rollback()
-            raise FavoritesStoreException from e
-
-        finally:
-            cursor.close()
-            cnx.close()    
-
     def all_user_data_updated(self, user_id):
         cnx = self.cnxpool.get_connection()
 

--- a/src/common/flickrapiwrapper.py
+++ b/src/common/flickrapiwrapper.py
@@ -82,7 +82,10 @@ class FlickrApiWrapper:
 
     def _get_favorites_page(self, user_id, page_number, max_favorites_per_call):
 
-        lambda_to_call = lambda: self.flickr.favorites.getList(user_id=user_id, extras='url_l,url_m', per_page=max_favorites_per_call, page=page_number)
+        # There's also flickr.favorites.getList(), which gets all the faves that our current API key can see. While it would be nice to get
+        # more photos, some users might not be able to see the same things as this API key, so ultimately it'll result in broken links. 
+        # Also some users might be upset at having their semi-private photos surfaced.
+        lambda_to_call = lambda: self.flickr.favorites.getPublicList(user_id=user_id, extras='url_l,url_m', per_page=max_favorites_per_call, page=page_number)
 
         favorites = self._call_with_retries(lambda_to_call)
 

--- a/src/common/ingesterqueuebatchitem.py
+++ b/src/common/ingesterqueuebatchitem.py
@@ -13,12 +13,17 @@ class IngesterQueueBatchItem:
 
     MAX_CONTACTS = 15000 # A contact is just an ID string, about 17 bytes long
 
-    def __init__(self, favorites_list, contacts_list):
+    def __init__(self, user_id, favorites_list, contacts_list):
+        self.user_id                = user_id
+
         self.max_favorites_exceeded = len(favorites_list) > IngesterQueueBatchItem.MAX_FAVORITES
         self.favorites_list         = favorites_list[:IngesterQueueBatchItem.MAX_FAVORITES]
     
         self.max_contacts_exceeded  = len(contacts_list) > IngesterQueueBatchItem.MAX_CONTACTS
         self.contacts_list          = contacts_list[:IngesterQueueBatchItem.MAX_CONTACTS]
+
+    def get_user_id(self):
+        return self.user_id
 
     def get_favorites_list(self):
         return self.favorites_list

--- a/src/common/ingesterqueuebatchitem.py
+++ b/src/common/ingesterqueuebatchitem.py
@@ -3,23 +3,34 @@ import jsonpickle
 class IngesterQueueBatchItem:
 
     '''
-    An item placed onto or read from the ingester queue. It represents a set of favorite (or equivalent) photos
+    An item placed onto or read from the ingester queue. It represents a set of favorite (or equivalent) photos and/or a set of contacts
     '''
 
     # The max size of an SQS message is 256kB, and 1000 photos takes about 218kB
     # If we start to exceed this threshold, we should switch to breaking up the batch message into multiple messages or storing the photo list in S3 
     # (if it's bigger than a certain size, to prevent hitting S3 for super small lists?) and just having a link stored in this message
-    MAX_NUM_ITEMS = 1000 
+    MAX_FAVORITES = 1000 
 
-    def __init__(self, item_list):
-        self.max_items_exceeded = len(item_list) > IngesterQueueBatchItem.MAX_NUM_ITEMS
-        self.item_list          = item_list[:IngesterQueueBatchItem.MAX_NUM_ITEMS]
+    MAX_CONTACTS = 15000 # A contact is just an ID string, about 17 bytes long
+
+    def __init__(self, favorites_list, contacts_list):
+        self.max_favorites_exceeded = len(favorites_list) > IngesterQueueBatchItem.MAX_FAVORITES
+        self.favorites_list         = favorites_list[:IngesterQueueBatchItem.MAX_FAVORITES]
     
-    def get_item_list(self):
-        return self.item_list
+        self.max_contacts_exceeded  = len(contacts_list) > IngesterQueueBatchItem.MAX_CONTACTS
+        self.contacts_list          = contacts_list[:IngesterQueueBatchItem.MAX_CONTACTS]
 
-    def get_max_items_exceeded(self):
-        return self.max_items_exceeded
+    def get_favorites_list(self):
+        return self.favorites_list
+
+    def get_max_favorites_exceeded(self):
+        return self.max_favorites_exceeded
+
+    def get_contacts_list(self):
+        return self.contacts_list
+
+    def get_max_contacts_exceeded(self):
+        return self.max_contacts_exceeded
 
     def to_json(self):
         return jsonpickle.encode(self)

--- a/src/common/ingesterqueuefavorite.py
+++ b/src/common/ingesterqueuefavorite.py
@@ -1,7 +1,7 @@
-class IngesterQueueItem:
+class IngesterQueueFavorite:
 
     '''
-    An item placed onto or read from a batch message on the ingester queue. It represents a favorite (or equivalent) photo
+    Part of an IngesterQueueBatchItem: represents a favorite (or equivalent) photo
     '''
 
     def __init__(self, image_id, image_url, image_owner, favorited_by):

--- a/src/common/pullerqueueitem.py
+++ b/src/common/pullerqueueitem.py
@@ -6,15 +6,23 @@ class PullerQueueItem:
     An item placed onto or read from the puller queue. It represents a user
     '''
 
-    def __init__(self, user_id, is_registered_user):
-        self.user_id            = user_id
-        self.is_registered_user = is_registered_user
+    def __init__(self, user_id, request_favorites, request_contacts, request_neighbor_list):
+        self.user_id                = user_id
+        self.request_favorites      = request_favorites # Should the puller get the user's favorites?
+        self.request_contacts       = request_contacts  # Should the puller get the user's contacts?
+        self.request_neighbor_list  = request_neighbor_list # Should the puller return the user's neighbors?
    
     def get_user_id(self):
         return self.user_id
 
-    def get_is_registered_user(self):
-        return self.is_registered_user
+    def get_request_favorites(self):
+        return self.request_favorites
+
+    def get_request_contacts(self):
+        return self.request_contacts
+
+    def get_request_neighbor_list(self):
+        return self.request_neighbor_list
 
     def to_json(self):
         return jsonpickle.encode(self)

--- a/src/common/pullerresponsequeueitem.py
+++ b/src/common/pullerresponsequeueitem.py
@@ -11,17 +11,25 @@ class PullerResponseQueueItem:
     An item placed onto or read from the puller response queue. It represents a user
     '''
 
-    def __init__(self, user_id, is_registered_user, neighbor_list):
-        self.user_id                = user_id
-        self.is_registered_user     = is_registered_user
-        self.max_neighbors_exceeded = len(neighbor_list) > PullerResponseQueueItem.MAX_NUM_NEIGHBORS
-        self.neighbor_list          = neighbor_list[:PullerResponseQueueItem.MAX_NUM_NEIGHBORS]
+    def __init__(self, user_id, favorites_requested, contacts_requested, neighbor_list_requested, neighbor_list):
+        self.user_id                    = user_id
+        self.favorites_requested        = favorites_requested
+        self.contacts_requested         = contacts_requested
+        self.neighbor_list_requested    = neighbor_list_requested
+        self.max_neighbors_exceeded     = len(neighbor_list) > PullerResponseQueueItem.MAX_NUM_NEIGHBORS
+        self.neighbor_list              = neighbor_list[:PullerResponseQueueItem.MAX_NUM_NEIGHBORS]
    
     def get_user_id(self):
         return self.user_id
 
-    def get_is_registered_user(self):
-        return self.is_registered_user
+    def get_favorites_requested(self):
+        return self.favorites_requested
+
+    def get_contacts_requested(self):
+        return self.contacts_requested
+
+    def get_neighbor_list_requested(self):
+        return self.neighbor_list_requested
 
     def get_neighbor_list(self):
         return self.neighbor_list

--- a/src/common/usersstoreapiserver.py
+++ b/src/common/usersstoreapiserver.py
@@ -68,18 +68,6 @@ class UsersStoreAPIServer:
         except HTTPError as http_err:
             raise UsersStoreException from http_err
 
-    def data_updated(self, user_id):
-
-        try:
-            response = requests.put(f"{self.url_prefix}/users/{user_id}/data-updated")
-
-            response.raise_for_status()
-
-            return
-
-        except HTTPError as http_err:
-            raise UsersStoreException from http_err
-
     def all_data_updated(self, user_id):
 
         try:

--- a/src/ingester-database/Dockerfile
+++ b/src/ingester-database/Dockerfile
@@ -2,7 +2,7 @@ FROM python:3.7.4-alpine
 ADD ingester-database/ingester-database.py /ingester-database/
 ADD ingester-database/databasebatchwriter.py /ingester-database/
 ADD ingester-database/contactitem.py /ingester-database/
-ADD common/ingesterqueueitem.py /common/
+ADD common/ingesterqueuefavorite.py /common/
 ADD common/ingesterqueuebatchitem.py /common/
 ADD common/queuereader.py /common/
 ADD common/confighelper.py /common/

--- a/src/ingester-database/Dockerfile
+++ b/src/ingester-database/Dockerfile
@@ -1,6 +1,7 @@
 FROM python:3.7.4-alpine
 ADD ingester-database/ingester-database.py /ingester-database/
 ADD ingester-database/databasebatchwriter.py /ingester-database/
+ADD ingester-database/contactitem.py /ingester-database/
 ADD common/ingesterqueueitem.py /common/
 ADD common/ingesterqueuebatchitem.py /common/
 ADD common/queuereader.py /common/

--- a/src/ingester-database/contactitem.py
+++ b/src/ingester-database/contactitem.py
@@ -1,0 +1,11 @@
+class ContactItem:
+
+    def __init__(self, follower_id, followee_id):
+        self.follower_id = follower_id
+        self.followee_id = followee_id
+
+    def get_follower_id(self):
+        return self.follower_id
+
+    def get_followee_id(self):
+        return self.followee_id

--- a/src/puller-flickr/Dockerfile
+++ b/src/puller-flickr/Dockerfile
@@ -1,7 +1,7 @@
 FROM python:3.7.4-alpine
 ADD puller-flickr/puller-flickr.py /puller-flickr/
 ADD common/flickrapiwrapper.py /puller-flickr/
-ADD common/ingesterqueueitem.py /common/
+ADD common/ingesterqueuefavorite.py /common/
 ADD common/ingesterqueuebatchitem.py /common/
 ADD common/pullerqueueitem.py /common/
 ADD common/pullerresponsequeueitem.py /common/

--- a/src/puller-flickr/config/config.ini
+++ b/src/puller-flickr/config/config.ini
@@ -7,6 +7,7 @@ flickr-api-retries=3
 flickr-api-favorites-maxpercall=500
 flickr-api-favorites-maxtoget=1000
 flickr-api-favorites-maxcallstomake=3
+flickr-api-contacts-maxpercall=1000
 
 memcached-location=puller-flickr-dev.j94z7t.cfg.usw2.cache.amazonaws.com:11211
 memcached-ttl=7200 

--- a/src/puller-flickr/puller-flickr.py
+++ b/src/puller-flickr/puller-flickr.py
@@ -48,6 +48,7 @@ flickr_api_retries                  = config_helper.getInt("flickr-api-retries")
 flickr_api_max_favorites_per_call   = config_helper.getInt("flickr-api-favorites-maxpercall")
 flickr_api_max_favorites_to_get     = config_helper.getInt("flickr-api-favorites-maxtoget")
 flickr_api_max_calls_to_make        = config_helper.getInt("flickr-api-favorites-maxcallstomake")
+flickr_api_max_contacts_per_call    = config_helper.getInt("flickr-api-contacts-maxpercall")
 
 memcached_location                  = config_helper.get("memcached-location")
 memcached_ttl                       = config_helper.getInt("memcached-ttl")

--- a/src/puller-flickr/puller-flickr.py
+++ b/src/puller-flickr/puller-flickr.py
@@ -212,7 +212,7 @@ try:
             if not puller_queue_item.get_request_neighbor_list():
                 my_neighbors_list = [] # The Scheduler doesn't care about neighbors this time
 
-            puller_response_queue_item = PullerResponseQueueItem(   user_id=flickr_user_id, 
+            puller_response_queue_item = PullerResponseQueueItem(   user_id=puller_queue_item.get_user_id(), 
                                                                     favorites_requested=puller_queue_item.get_request_favorites(), 
                                                                     contacts_requested=puller_queue_item.get_request_contacts(), 
                                                                     neighbor_list_requested=puller_queue_item.get_request_neighbor_list(), 

--- a/src/puller-flickr/puller-flickr.py
+++ b/src/puller-flickr/puller-flickr.py
@@ -131,7 +131,7 @@ def get_favorites_for_user(puller_queue_item):
 
     if len(favorite_photos) > 0:
 
-        batch_item = IngesterQueueBatchItem(favorites_list=favorite_photos, contacts_list=[])
+        batch_item = IngesterQueueBatchItem(user_id=flickr_user_id, favorites_list=favorite_photos, contacts_list=[])
 
         if batch_item.get_max_favorites_exceeded():
             logging.warn(f"User {flickr_user_id} exceeded max number of batched favorite photos: has {len(favorite_photos)} favorites. Consider putting this list is S3 rather than in this SQS message")
@@ -162,7 +162,7 @@ def get_contacts_for_user(puller_queue_item):
 
     if len(my_contacts) > 0:
 
-        batch_item = IngesterQueueBatchItem(favorites_list=[], contacts_list=my_contacts)
+        batch_item = IngesterQueueBatchItem(user_id=flickr_user_id, favorites_list=[], contacts_list=my_contacts)
 
         if batch_item.get_max_contacts_exceeded():
             logging.warn(f"User {flickr_user_id} exceeded max number of batched contacts: has {len(my_contacts)} contacts. Consider putting this list is S3 rather than in this SQS message")

--- a/terraform/dev/main.tf
+++ b/terraform/dev/main.tf
@@ -163,6 +163,7 @@ module "puller_flickr" {
     flickr_api_favorites_max_per_call = 500
     flickr_api_favorites_max_to_get = 1000
     flickr_api_favorites_max_calls_to_make = 1
+    flickr_api_contacts_max_per_call = 1000
 
     output_queue_url = "${module.ingester_database.ingester_queue_url}"
     output_queue_arn = "${module.ingester_database.ingester_queue_arn}"

--- a/terraform/dev/main.tf
+++ b/terraform/dev/main.tf
@@ -28,9 +28,9 @@ module "elastic_container_service" {
     extra_security_groups = ["${module.api_server.security_group_id}"]
 
     instance_type = "t2.micro"#"c5.large"#"t2.micro"
-    cluster_desired_size = 0#2#20
+    cluster_desired_size = 2#0#2#20
     cluster_min_size = 0
-    cluster_max_size = 0#2#20
+    cluster_max_size = 2#0#2#20
     instances_log_retention_days = 1
 }
 
@@ -201,7 +201,7 @@ module "ingester_database" {
     mysql_database_username = "${module.database.database_username}"
     mysql_database_password = "${var.database_password_dev}"
     mysql_database_name     = "${module.database.database_name}"
-    mysql_database_min_batch_size = 50 # Small batches here to take advantage of having lots of instances. Otherwise, messages get tied up getting batched with other messages while some instances are sitting unused
+    mysql_database_min_batch_size = 10000
     mysql_database_maxretries = 3
 
     input_queue_batch_size  = 1 # Each message takes a while to process because it contains many individual items, so only get one at a time so that we're not blocking other instances from picking them up
@@ -319,7 +319,7 @@ module "alarms" {
 
     queue_names = [ "${module.scheduler.puller_queue_full_name}", "${module.scheduler.puller_response_queue_full_name}", "${module.ingester_database.ingester_queue_full_name}"]
     queue_item_size_threshold = 235520 # 230kB -- 256kB is the absolute max
-    queue_item_age_threshold = 500 # 8.3 minutes
+    queue_item_age_threshold = 900 # 15 minutes: it can take a long time to process stuff in dev, with a limited numbers of workers
     queue_reader_error_threshold = 1
     queue_writer_error_threshold = 1
 

--- a/terraform/modules/dashboard/timing.tpl
+++ b/terraform/modules/dashboard/timing.tpl
@@ -43,7 +43,7 @@
         ],
         [
             "Photo Recommender",
-            "process_batch_message_duration",
+            "database_favorites_write_duration",
             "Environment",
             "${environment}",
             "Process",
@@ -51,7 +51,7 @@
         ],
         [
             "Photo Recommender",
-            "database_write_duration",
+            "database_contacts_write_duration",
             "Environment",
             "${environment}",
             "Process",

--- a/terraform/modules/dashboard/timing.tpl
+++ b/terraform/modules/dashboard/timing.tpl
@@ -11,7 +11,15 @@
         ],
         [
             "Photo Recommender",
-            "duration_to_query_flickr",
+            "duration_to_get_favorites_from_flickr",
+            "Environment",
+            "${environment}",
+            "Process",
+            "puller-flickr"
+        ],
+        [
+            "Photo Recommender",
+            "duration_to_get_contacts_from_flickr",
             "Environment",
             "${environment}",
             "Process",

--- a/terraform/modules/database/photo_recommender_init.sql
+++ b/terraform/modules/database/photo_recommender_init.sql
@@ -15,7 +15,6 @@ CREATE TABLE registered_users (
     id INT AUTO_INCREMENT,
     user_id VARCHAR(64) NOT NULL,
     data_last_requested_at TIMESTAMP,
-    data_last_successfully_processed_at TIMESTAMP,
     all_data_last_successfully_processed_at TIMESTAMP,
     created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
     updated_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP,

--- a/terraform/modules/database/photo_recommender_init.sql
+++ b/terraform/modules/database/photo_recommender_init.sql
@@ -21,7 +21,6 @@ CREATE TABLE registered_users (
     PRIMARY KEY (id),
     UNIQUE KEY (user_id),
     KEY (data_last_requested_at),
-    KEY (data_last_successfully_processed_at),
     KEY (all_data_last_successfully_processed_at)
 ) ENGINE = InnoDB, CHARACTER SET = utf8mb4;
 

--- a/terraform/modules/database/photo_recommender_init.sql
+++ b/terraform/modules/database/photo_recommender_init.sql
@@ -36,3 +36,13 @@ CREATE TABLE task_locks (
     UNIQUE KEY (process_id),
     KEY (task_id)
 ) ENGINE = InnoDB, CHARACTER SET = utf8mb4;
+
+CREATE TABLE followers (
+    id INT AUTO_INCREMENT,
+    follower_id VARCHAR(16) NOT NULL,
+    followee_id VARCHAR(16) NOT NULL,
+    PRIMARY KEY (id),
+    KEY (follower_id),
+    KEY (followee_id),
+    UNIQUE KEY (followee_id, follower_id)
+) ENGINE = InnoDB, CHARACTER SET = utf8mb4;

--- a/terraform/modules/puller-flickr/parameter-store.tf
+++ b/terraform/modules/puller-flickr/parameter-store.tf
@@ -41,6 +41,13 @@ resource "aws_ssm_parameter" "flickr_api_retries" {
     value       = "${var.flickr_api_retries}"
 }
 
+resource "aws_ssm_parameter" "flickr_api_contacts_max_per_call" {
+    name        = "/${var.environment}/puller-flickr/flickr-api-contacts-maxpercall"
+    description = "Max number of contacts to get per API call"
+    type        = "String"
+    value       = "${var.flickr_api_contacts_max_per_call}"
+}
+
 resource "aws_ssm_parameter" "flickr_api_favorites_max_per_call" {
     name        = "/${var.environment}/puller-flickr/flickr-api-favorites-maxpercall"
     description = "Max number of favorites to get per API call"

--- a/terraform/modules/puller-flickr/variables.tf
+++ b/terraform/modules/puller-flickr/variables.tf
@@ -17,6 +17,7 @@ variable "flickr_api_retries" {}
 variable "flickr_api_favorites_max_per_call" {}
 variable "flickr_api_favorites_max_to_get" {}
 variable "flickr_api_favorites_max_calls_to_make" {}
+variable "flickr_api_contacts_max_per_call" {}
 variable "output_queue_url" {}
 variable "output_queue_arn" {}
 variable "output_queue_batch_size" {}


### PR DESCRIPTION
This required quite a lot of changes to how the system runs. puller-flickr and ingester-database are now able to request and write out a user's contacts respectively.

The scheduler now makes 2 initial requests when beginning processing for a user: one for its faves and one for its contacts. No other users have their contacts requested, so this shouldn't have an impact on runtime.

Renamed a bunch of stuff in the messages passed between the processes so that they make more sense now given the different datatypes.

Fixed a major bug in database-ingester where it was deleting SQS messages for which it hadn't committed database rows yet, possibly leading to lost data. Need to redo all performance timing now because that process works quite differently now: committing to the database more often so that it can release its SQS messages.

Added a database table to hold the new contacts information.

Got rid of the column in the users table that stored when their initial data had been successfully pulled, since it was largely meaningless. Similarly killed a couple of timing metrics that weren't helpful.