### PR TITLE
Fixed race condition when checking if we're done processing a user

### DIFF
--- a/backend/api-server/api-server.py
+++ b/backend/api-server/api-server.py
@@ -255,9 +255,16 @@ def put_user_received_puller_responses(user_id=None):
     if not num_puller_responses:
         return parameter_not_specified("num-puller-responses")
 
-    favorites_store.received_puller_responses(user_id, num_puller_responses)
+    finished_processing = favorites_store.received_puller_responses(user_id, num_puller_responses)
 
-    return "OK", status.HTTP_200_OK
+    response_object = {
+        'finished_processing': finished_processing
+    }
+
+    resp = jsonify(response_object)
+    resp.status_code = status.HTTP_200_OK
+
+    return resp
 
 # Notifies that there have been some ingester responses for a particular user
 @application.route("/api/users/<user_id>/received-ingester-responses", methods = ['PUT'])

--- a/backend/common/usersstoreapiserver.py
+++ b/backend/common/usersstoreapiserver.py
@@ -90,7 +90,11 @@ class UsersStoreAPIServer:
 
             response.raise_for_status()
 
-            return
+            response.encoding = "utf-8"
+
+            response_object = response.json()
+
+            return response_object
 
         except HTTPError as http_err:
             raise UsersStoreException from http_err

--- a/backend/puller-response-reader/puller-response-reader.py
+++ b/backend/puller-response-reader/puller-response-reader.py
@@ -110,6 +110,9 @@ try:
         puller_response_queue.finished_with_message(queue_message)
 
     # Now that we have no new messages to process, tell the API server how many messages we saw for each user
+    #
+    # Note that we have to do this *after* making any more puller requests above, so that we don't 
+    # accidentally mark this user as being complete if only their initial requests have been fully processed.
 
     for initial_requesting_user_id in messages_received:
         logging.info(f"Telling users store that we received {messages_received[initial_requesting_user_id]['count']} responses for initial requesting user {initial_requesting_user_id}")

--- a/backend/puller-response-reader/puller-response-reader.py
+++ b/backend/puller-response-reader/puller-response-reader.py
@@ -113,7 +113,12 @@ try:
 
     for initial_requesting_user_id in messages_received:
         logging.info(f"Telling users store that we received {messages_received[initial_requesting_user_id]['count']} responses for initial requesting user {initial_requesting_user_id}")
-        users_store.received_puller_responses(initial_requesting_user_id, messages_received[initial_requesting_user_id]['count'])
+        processing_status = users_store.received_puller_responses(initial_requesting_user_id, messages_received[initial_requesting_user_id]['count'])
+
+        if processing_status['finished_processing']:
+            time_in_seconds = users_store.get_time_to_update_all_data(initial_requesting_user_id)
+            logging.info(f"We have finished processing user {initial_requesting_user_id}. It took {time_in_seconds}")
+            metrics_helper.send_time("time_to_get_all_data", time_in_seconds)
 
 except UsersStoreException as e:
     logging.error("Unable to talk to our users store. Exiting.", e)

--- a/terraform/dev/main.tf
+++ b/terraform/dev/main.tf
@@ -28,9 +28,9 @@ module "elastic_container_service" {
     extra_security_groups = ["${module.api_server.security_group_id}"]
 
     instance_type = "t2.micro"#"c5.large"#"t2.micro"
-    cluster_desired_size = 0#2#20
+    cluster_desired_size = 2#0#2#20
     cluster_min_size = 0
-    cluster_max_size = 0#2#20
+    cluster_max_size = 2#0#2#20
     instances_log_retention_days = 1
 }
 

--- a/terraform/modules/dashboard/dashboard.tf
+++ b/terraform/modules/dashboard/dashboard.tf
@@ -116,14 +116,11 @@ resource "aws_cloudwatch_dashboard" "main" {
 
 data "template_file" "time_to_get_all_data" {
     vars = {
-        title                       = "Time to get all data"
         environment                 = "${var.environment}"
-        process_name                = "ingester-response-reader"
-        metric_name                 = "time_to_get_all_data"
         region                      = "${var.region}"
     }
 
-    template = "${file("${path.module}/generic_metric.tpl")}"
+    template = "${file("${path.module}/time_to_get_all_data.tpl")}"
 }
 
 data "template_file" "puller_queue" {

--- a/terraform/modules/dashboard/time_to_get_all_data.tpl
+++ b/terraform/modules/dashboard/time_to_get_all_data.tpl
@@ -1,0 +1,25 @@
+"type":"metric",
+"properties": {
+    "metrics": [
+        [
+            "Photo Recommender",
+            "time_to_get_all_data",
+            "Environment",
+            "${environment}",
+            "Process",
+            "ingester-response-reader"
+        ],
+        [
+            "Photo Recommender",
+            "time_to_get_all_data",
+            "Environment",
+            "${environment}",
+            "Process",
+            "puller-response-reader"
+        ]
+    ],
+    "period":300,
+    "stat":"Average",
+    "region":"${region}",
+    "title":"Time to get all data"
+}


### PR DESCRIPTION
Check for being done both when we get an ingester done message and a puller done message. This fixes a potential race condition where the ingester done messages are processed first and the puller ones are processed later. The potential issue if if the final puller response message requested more data to be pulled: the user would be marked as being done but there would be more processing to do.

So this checks if we're done when either type of message is processed, and only marks the user as being done when both types of messages have been fully received.

Fixes https://github.com/euan-forrester/photo-recommender/issues/73