### PR TITLE
Reduce bundle size by only bringing in the bits of bootstrap that we use

### DIFF
--- a/README.md
+++ b/README.md
@@ -184,14 +184,14 @@ TODO:
 - Make puller-flickr look for deletions of favorites
 - Investigate transaction usage in the batch database writer: what batch size should we use? is there a better transaction isolation level to use to help concurrency?
 - Add CSRF token
-- Make frontend vendor file smaller (it's mostly bootstrap): https://bootstrap-vue.js.org/docs/#tree-shaking-with-module-bundlers
-  - See also https://medium.com/js-dojo/how-to-reduce-your-vue-js-bundle-size-with-webpack-3145bf5019b7
 - Add versioning to the front end, so that old versions of file (with different hashes) don't live in S3 forever: https://stackoverflow.com/questions/46166337/how-can-i-deploy-a-new-cloudfront-s3-version-without-a-small-period-of-unavailab?rq=1
 - Get domain name + add hooks for google analytics
 - Make batch messages for both types of response readers, rather than sending each message individually
 - Have dismissed photos + users feed back into recommendations with negative scores
 - Make visualization of how many instances of each process are doing work at a given time - send task ID to metics and get a count of distinct IDs?
 - Have Scheduler ask for the number of seconds until the next user needs updating, then sleep for that long
+  - Note that would miss new users that get added in the meantime
+  - We can have the API server request data for a new user when it is created
 - Need to have the browser authenticate with the API server to prevent API abuse of users whose tokens we have 
   - Same as CSRF prevention or different?
   - AWS API Gateway?
@@ -199,4 +199,3 @@ TODO:
   - What is the impact on write throughput of this change?
 - Add a message to the recommendations screen if the user doesn't have enough favorites to generate good recommendations. Suggest some groups to look at.
 - Highlight new recommendations by moving them to the top of the list. Maybe have a "first recommended on" field per user, and use that to boost score?
-

--- a/frontend/src/plugins/bootstrap-vue.js
+++ b/frontend/src/plugins/bootstrap-vue.js
@@ -1,7 +1,49 @@
 import Vue from 'vue';
 
-import BootstrapVue from 'bootstrap-vue';
-import 'bootstrap/dist/css/bootstrap.min.css';
-import 'bootstrap-vue/dist/bootstrap-vue.css';
+// Reduce bundle size by pulling in only what we need from bootstrap.
+// We could further optimize this by pulling in only the actual specific elements and directives
+// that we use, but it would be more work for not a ton more gain.
+// See here for more details: https://bootstrap-vue.js.org/docs/#tree-shaking-with-module-bundlers
+//
+// Note that this makes devving a bit annoying since anytime you want to try out a new
+// type you have to add it here. So consider temporarily just using
+//
+//      import { BootstrapVue } from 'bootstrap-vue';
+//      Vue.use(BootstrapVue);
+//
+// in those situations.
 
-Vue.use(BootstrapVue);
+// Place all imports from 'bootstrap-vue' in a single import
+// statement for optimal bundle sizes
+import {
+  LayoutPlugin,
+  JumbotronPlugin,
+  FormPlugin,
+  FormInputPlugin,
+  FormGroupPlugin,
+  FormTextareaPlugin,
+  ButtonPlugin,
+  AlertPlugin,
+  ImagePlugin,
+  SpinnerPlugin,
+  LinkPlugin,
+  PopoverPlugin,
+  CollapsePlugin,
+} from 'bootstrap-vue';
+
+import 'bootstrap/dist/css/bootstrap.min.css';
+// import 'bootstrap-vue/dist/bootstrap-vue.css'; // Is this file necessary? The docs say it is, but I don't see anything missing without it: https://bootstrap-vue.js.org/docs/
+
+Vue.use(LayoutPlugin);
+Vue.use(JumbotronPlugin);
+Vue.use(FormPlugin);
+Vue.use(FormInputPlugin);
+Vue.use(FormGroupPlugin);
+Vue.use(FormTextareaPlugin);
+Vue.use(ButtonPlugin);
+Vue.use(AlertPlugin);
+Vue.use(ImagePlugin);
+Vue.use(SpinnerPlugin);
+Vue.use(LinkPlugin);
+Vue.use(PopoverPlugin);
+Vue.use(CollapsePlugin);


### PR DESCRIPTION
This didn't reduce our dist size as much as I hoped.

Uncompressed we went from 867kB -> 623kB total (still well over the webpack warning limit of 244kB)
Compressed we went from 213kB -> 164kB

So a 49kB (23%) savings in what's actually shipped to users.

This takes care of the low-hanging fruit anyway. There is more that could be done according to the bootstrap docs if we just pulled in only the actual elements and directives that we use (rather than the plugin bundles), and if we only transpile the bootstrap stuff for our target browsers/environments rather than everything.