### PR TITLE
Access our prod instance via https

### DIFF
--- a/frontend/src/repositories/flickrRepository.js
+++ b/frontend/src/repositories/flickrRepository.js
@@ -38,7 +38,7 @@ export default {
     let iconUrl = 'https://www.flickr.com/images/buddyicon.gif';
 
     if (iconServer > 0) {
-      iconUrl = `http://farm${iconFarm}.staticflickr.com/${iconServer}/buddyicons/${nsId}.jpg`;
+      iconUrl = `https://farm${iconFarm}.staticflickr.com/${iconServer}/buddyicons/${nsId}.jpg`;
     }
 
     const profileUrl = `https://www.flickr.com/photos/${nsId}/`;

--- a/terraform/modules/frontend/cloudfront.tf
+++ b/terraform/modules/frontend/cloudfront.tf
@@ -53,7 +53,7 @@ resource "aws_cloudfront_distribution" "application" {
         custom_origin_config {
             http_port = "${var.load_balancer_port}"
             https_port = "${var.load_balancer_port}"
-            origin_protocol_policy = "match-viewer"
+            origin_protocol_policy = "http-only"
             origin_ssl_protocols = ["SSLv3", "TLSv1", "TLSv1.1", "TLSv1.2"]
             origin_keepalive_timeout = 30 # Max is 60
             origin_read_timeout = 10 # Max is 60
@@ -78,7 +78,7 @@ resource "aws_cloudfront_distribution" "application" {
             }
         }
 
-        viewer_protocol_policy = "allow-all"
+        viewer_protocol_policy = "${var.use_https == "true" ? "redirect-to-https" : "allow-all"}"
         min_ttl                = 0
         default_ttl            = 0
         max_ttl                = 0
@@ -98,7 +98,7 @@ resource "aws_cloudfront_distribution" "application" {
             }
         }
 
-        viewer_protocol_policy = "allow-all"
+        viewer_protocol_policy = "${var.use_https == "true" ? "redirect-to-https" : "allow-all"}"
         min_ttl                = 0
         default_ttl            = 3600
         max_ttl                = 86400

--- a/terraform/prod/main.tf
+++ b/terraform/prod/main.tf
@@ -33,9 +33,9 @@ module "elastic_container_service" {
     extra_security_groups = ["${module.api_server.security_group_id}"]
 
     instance_type = "t2.micro"#"c5.large"#"t2.micro"
-    cluster_desired_size = 0#2#20
+    cluster_desired_size = 2#0#2#20
     cluster_min_size = 0
-    cluster_max_size = 0#2#20
+    cluster_max_size = 2#0#2#20
     instances_log_retention_days = 1
 }
 
@@ -91,7 +91,7 @@ module "scheduler" {
 
     ecs_cluster_id = "${module.elastic_container_service.cluster_id}"
     ecs_instances_role_name = "${module.elastic_container_service.instance_role_name}"
-    ecs_instances_desired_count = 0
+    ecs_instances_desired_count = 1
     ecs_instances_memory = 64
     ecs_instances_cpu = 200
     ecs_instances_log_configuration = "${module.elastic_container_service.cluster_log_configuration}"


### PR DESCRIPTION
Now we can access our prod instance via https://photorecommender.com

We have CloudFront doing our SSL termination for us. Eventually in prod we should enable https for the load balancer as well, which will require adding a separate cert for it too.

- CloudFront redirects http -> https
- Access all Flickr images by https