### PR TITLE
Reduce batch size when writing to the database to improve overall system performance

### DIFF
--- a/README.md
+++ b/README.md
@@ -221,7 +221,6 @@ Point your browser there and enjoy!
 - Centralize logging and make it searchable. Maybe like this: https://aws.amazon.com/solutions/centralized-logging/
 - Make puller-flickr only get incremental updates since the last time it ran, rather than pulling all data every time
 - Make puller-flickr look for deletions of favorites
-- Investigate transaction usage in the batch database writer: what batch size should we use? is there a better transaction isolation level to use to help concurrency?
 - Add CSRF token
 - Add versioning to the front end, so that old versions of file (with different hashes) don't live in S3 forever: https://stackoverflow.com/questions/46166337/how-can-i-deploy-a-new-cloudfront-s3-version-without-a-small-period-of-unavailab?rq=1
 - Make batch messages for both types of response readers, rather than sending each message individually
@@ -238,3 +237,4 @@ Point your browser there and enjoy!
 - Add a message to the recommendations screen if the user doesn't have enough favorites to generate good recommendations. Suggest some groups to look at.
 - Highlight new recommendations by moving them to the top of the list. Maybe have a "first recommended on" field per user, and use that to boost score?
 - Move the domain into route53 and the SSL certificate into the AWS certificate manager
+- Investigate why puller-flickr often has such a long max time to process a single user

--- a/backend/ingester-database/databasebatchwriter.py
+++ b/backend/ingester-database/databasebatchwriter.py
@@ -28,17 +28,8 @@ class DatabaseBatchWriter:
         # The 4 types of transactions are 'READ UNCOMMITTED', 'READ COMMITTED', 'REPEATABLE READ', and 'SERIALIZABLE'
         # https://dev.mysql.com/doc/connector-python/en/connector-python-api-mysqlconnection-start-transaction.html
 
-        # Curiously, our lowest time for an individual process to write to the database is slightly lower
-        # with READ COMMITTED, with an overall average of 2.31s with our test dataset.
-        # However, READ UNCOMMITTED comes in with an overall average of 2.63s with the same dataset.
-        #
-        # But, our overall system run time is significantly faster with READ UNCOMMITTED.
-        # With READ COMMITTED, the average overall system runtime was 13.7s.
-        # However, with READ UNCOMMITTED, the average overall system runtime was 6.7s.
-        # I assume that READ UNCOMMITTED allows for more concurrency.
-
-        # I've also tried experimenting with committing after every batch, rather than at the end, and large and small batch sizes.
-        # No conclusive results yet due to imprecise measurements I think.
+        # We're just trying to get data into the database as fast as possible and don't care about ACID compliance
+        # for these transactions, so pick the lowest isolation level.
 
         self.cnx.start_transaction(isolation_level="READ UNCOMMITTED")
 

--- a/terraform/dev/main.tf
+++ b/terraform/dev/main.tf
@@ -238,7 +238,7 @@ module "ingester_database" {
     mysql_database_username = "${module.database.database_username}"
     mysql_database_password = "${var.database_password_dev}"
     mysql_database_name     = "${module.database.database_name}"
-    mysql_database_min_batch_size = 10000
+    mysql_database_min_batch_size = 100 # Counter-intuitively, the best overall system performance is gained by batching these the least. It's so that the process can flush as quickly as possible rather than storing up and flushing while everything else is waiting around
     mysql_database_maxretries = 3
 
     input_queue_batch_size  = 1 # Each message takes a while to process because it contains many individual items, so only get one at a time so that we're not blocking other instances from picking them up

--- a/terraform/prod/main.tf
+++ b/terraform/prod/main.tf
@@ -32,10 +32,10 @@ module "elastic_container_service" {
 
     extra_security_groups = ["${module.api_server.security_group_id}"]
 
-    instance_type = "t2.micro"#"c5.large"#"t2.micro"
-    cluster_desired_size = 2#0#2#20
+    instance_type = "c5.large"#"t2.micro"
+    cluster_desired_size = 20#0#2#20
     cluster_min_size = 0
-    cluster_max_size = 2#0#2#20
+    cluster_max_size = 20#0#2#20
     instances_log_retention_days = 1
 }
 
@@ -51,7 +51,7 @@ module "database" {
     local_machine_cidr      = "${var.local_machine_cidr}"
 
     mysql_database_name     = "photorecommender"
-    mysql_instance_type     = "db.t2.micro"#"db.m5.large"#"db.t2.micro" 
+    mysql_instance_type     = "db.m5.large"#"db.t2.micro" 
     mysql_storage_encrypted = false # db.t2.micro doesn't support encryption at rest -- needs to be at least db.t2.small
     mysql_storage_type      = "gp2" # General purpose SSD
     mysql_database_size_gb  = 5
@@ -91,7 +91,7 @@ module "scheduler" {
 
     ecs_cluster_id = "${module.elastic_container_service.cluster_id}"
     ecs_instances_role_name = "${module.elastic_container_service.instance_role_name}"
-    ecs_instances_desired_count = 1
+    ecs_instances_desired_count = 4
     ecs_instances_memory = 64
     ecs_instances_cpu = 200
     ecs_instances_log_configuration = "${module.elastic_container_service.cluster_log_configuration}"
@@ -127,7 +127,7 @@ module "puller-response-reader" {
 
     ecs_cluster_id = "${module.elastic_container_service.cluster_id}"
     ecs_instances_role_name = "${module.elastic_container_service.instance_role_name}"
-    ecs_instances_desired_count = 1#0#1#20
+    ecs_instances_desired_count = 20
     ecs_instances_memory = 64
     ecs_instances_cpu = 200
     ecs_instances_log_configuration = "${module.elastic_container_service.cluster_log_configuration}"
@@ -158,7 +158,7 @@ module "ingester_response_reader" {
 
     ecs_cluster_id = "${module.elastic_container_service.cluster_id}"
     ecs_instances_role_name = "${module.elastic_container_service.instance_role_name}"
-    ecs_instances_desired_count = 1#0#1#20
+    ecs_instances_desired_count = 20
     ecs_instances_memory = 64
     ecs_instances_cpu = 200
     ecs_instances_log_configuration = "${module.elastic_container_service.cluster_log_configuration}"
@@ -188,7 +188,7 @@ module "puller_flickr" {
 
     ecs_cluster_id = "${module.elastic_container_service.cluster_id}"
     ecs_instances_role_name = "${module.elastic_container_service.instance_role_name}"
-    ecs_instances_desired_count = 1#0#1#150
+    ecs_instances_desired_count = 150
     ecs_instances_memory = 64
     ecs_instances_cpu = 100
     ecs_instances_log_configuration = "${module.elastic_container_service.cluster_log_configuration}"
@@ -227,7 +227,7 @@ module "ingester_database" {
 
     ecs_cluster_id          = "${module.elastic_container_service.cluster_id}"
     ecs_instances_role_name = "${module.elastic_container_service.instance_role_name}"
-    ecs_instances_desired_count = 1#0#1#100
+    ecs_instances_desired_count = 100
     ecs_instances_memory    = 64
     ecs_instances_cpu       = 100
     ecs_instances_log_configuration = "${module.elastic_container_service.cluster_log_configuration}"
@@ -238,7 +238,7 @@ module "ingester_database" {
     mysql_database_username = "${module.database.database_username}"
     mysql_database_password = "${var.database_password_prod}"
     mysql_database_name     = "${module.database.database_name}"
-    mysql_database_min_batch_size = 10000
+    mysql_database_min_batch_size = 100 # Counter-intuitively, the best overall system performance is gained by batching these the least. It's so that the process can flush as quickly as possible rather than storing up and flushing while everything else is waiting around
     mysql_database_maxretries = 3
 
     input_queue_batch_size  = 1 # Each message takes a while to process because it contains many individual items, so only get one at a time so that we're not blocking other instances from picking them up
@@ -297,7 +297,7 @@ module "api_server" {
 
     ecs_cluster_id          = "${module.elastic_container_service.cluster_id}"
     ecs_instances_role_name = "${module.elastic_container_service.instance_role_name}"
-    ecs_instances_desired_count = 1#15
+    ecs_instances_desired_count = 15
     ecs_instances_memory    = 256
     ecs_instances_cpu       = 100
     ecs_instances_log_configuration = "${module.elastic_container_service.cluster_log_configuration}"


### PR DESCRIPTION
Waiting for big batches to finish up may mean that we have a single ingester process waiting to flush at the end of processing a user, rather than having several processes who've flushed multiple times during the processing.