### PR TITLE
Auth bugfixes

### DIFF
--- a/backend/api-server/api-server.py
+++ b/backend/api-server/api-server.py
@@ -185,7 +185,16 @@ def flickr_auth():
         oauth_session       = flickr_auth_wrapper.get_oauth_session(token=oauth_token, token_secret=oauth_token_secret)
         access_token        = flickr_auth_wrapper.fetch_access_token(oauth_session, verifier)
 
-        favorites_store.save_user_auth_token(flickr_auth_wrapper.get_user_id_from_token(access_token), flickr_auth_wrapper.get_flickr_access_token_as_string(access_token))
+        user_id             = flickr_auth_wrapper.get_user_id_from_token(access_token)
+
+        logging.info(f"Attempting to create new user {user_id}")
+
+        try:
+            favorites_store.create_user(user_id)
+        except:
+            logging.info(f"User {user_id} already exists. Continuing")
+
+        favorites_store.save_user_auth_token(user_id, flickr_auth_wrapper.get_flickr_access_token_as_string(access_token))
 
         return_value = {
             'access_token': flickr_auth_wrapper.get_flickr_access_token_as_string_no_secret(access_token) # Return a version of the token that doesn't include the secret. We'll fill it in from the database on subsequent calls

--- a/frontend/src/views/Welcome.vue
+++ b/frontend/src/views/Welcome.vue
@@ -166,6 +166,7 @@ export default {
   computed: {
     currentlyProcessing() {
       return (this.currentState !== 'apiError')
+        && (this.currentState !== 'loginFailed')
         && (this.currentState !== 'userNotFound')
         && (this.currentState !== 'none');
     },
@@ -228,6 +229,11 @@ export default {
         await this.$store.dispatch('getUserIdCurrentlyLoggedIn'); // The login action just gets a token back that we want to treat as opaque and so doesn't actually know who was logged in. So there's a separate API call to get the ID of the currently-logged-in user
       } catch (error) {
         this.currentState = 'loginFailed';
+        try {
+          await this.$store.dispatch('logout');
+        } catch (error2) {
+          // Just keep going even if we can't log out: the goal here is just to be not logged in
+        }
         return;
       }
 


### PR DESCRIPTION
- Fix user token not being able to be saved if no user exists (i.e. trying to login for the first time, rather than having viewed the unauthenticated version of your results first)
- Fix welcome screen buttons remaining greyed out on login error