### PR TITLE
Added onboarding screen for users without enough favorites

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,4 @@ backend/scheduler/config/secrets.ini
 backend/puller-response-reader/config/secrets.ini
 backend/ingester-response-reader/config/secrets.ini
 backend/common/dummy.sh
+.DS_Store

--- a/README.md
+++ b/README.md
@@ -233,7 +233,8 @@ Point your browser there and enjoy!
   - AWS API Gateway?
 - Consider normalizing the `favorites` table by splitting it into a table that just has the photos, and another table of who's favorited them
   - What is the impact on write throughput of this change?
-- Add a message to the recommendations screen if the user doesn't have enough favorites to generate good recommendations. Suggest some groups to look at.
 - Highlight new recommendations by moving them to the top of the list. Maybe have a "first recommended on" field per user, and use that to boost score?
 - Move the domain into route53 and the SSL certificate into the AWS certificate manager
 - Investigate why puller-flickr often has such a long max time to process a single user
+- Remove already-favorited images from the AddFavorites screen
+- Add logout to the navigation bar

--- a/backend/api-server/api-server.py
+++ b/backend/api-server/api-server.py
@@ -61,6 +61,7 @@ server_port                 = config_helper.getInt("server-port")
 session_encryption_key      = config_helper.get("session-encryption-key", is_secret=True)
 default_num_photo_recommendations = config_helper.getInt('default-num-photo-recommendations')
 default_num_user_recommendations = config_helper.getInt('default-num-user-recommendations')
+default_num_photos_from_group = config_helper.getInt('default-num-photos-from-group')
 
 flickr_api_key              = config_helper.get("flickr-api-key")
 flickr_api_secret           = config_helper.get("flickr-api-secret", is_secret=True)
@@ -612,6 +613,33 @@ def get_flickr_get_contacts():
         return parameter_not_specified("user-id")
 
     resp = jsonify(flickrapi.get_contacts(user_id=user_id, max_contacts_per_call=1000))
+    resp.status_code = status.HTTP_200_OK
+
+    return resp
+
+@application.route("/api/flickr/groups/get-info", methods = ['GET'])
+def get_flickr_get_group_info():
+
+    group_id = request.args.get("group-id")
+
+    if not group_id:
+        return parameter_not_specified("group-id")
+
+    resp = jsonify(flickrapi.get_group_info(group_id=group_id))
+    resp.status_code = status.HTTP_200_OK
+
+    return resp
+
+@application.route("/api/flickr/groups/pools/get-photos", methods = ['GET'])
+def get_flickr_get_group_photos():
+
+    group_id    = request.args.get("group-id")
+    num_photos  = int(request.args.get('num-photos', default_num_photos_from_group))
+
+    if not group_id:
+        return parameter_not_specified("group-id")
+
+    resp = jsonify(flickrapi.get_group_photos(group_id=group_id, num_photos=num_photos))
     resp.status_code = status.HTTP_200_OK
 
     return resp

--- a/backend/api-server/api-server.py
+++ b/backend/api-server/api-server.py
@@ -299,11 +299,41 @@ def flickr_add_favorite():
     return "OK", status.HTTP_200_OK
 
 @application.route("/api/flickr/test/login", methods = ['POST'])
-def flickr_get_logged_in_user():
+def flickr_test_login():
     
+    # Note that this API function appears to be broken on the Flickr side: you can call it with
+    # the token from one user, and get back info about a different user. It seems to be related to
+    # having > 1 user account associated with each other, having been logged in from the same machine?
+
     full_token = _get_and_test_full_user_oauth_token(request)
 
     resp = jsonify(flickrapi.login_test(full_token))
+    resp.status_code = status.HTTP_200_OK
+
+    return resp  
+
+@application.route("/api/flickr/get-logged-in-user", methods = ['POST'])
+def flickr_get_logged_in_user():
+
+    # When the frontend calls our auth function, all they get back is a token. It's vue-authenticate
+    # doing the calling, so we can't return anything else in the response. We don't want the frontend
+    # to have to know how to parse the token to get the user's ID and name, so let's add a function
+    # here instead to do it so that all the knowledge of how the token is constructed is in one place.
+    #
+    # Note that we tried using the flickr/test/login API function to do this, which would give us
+    # a bit of extra feeling that we've done everything right because it would be testing the token for us.
+    # However, as you can see above, this function appears to be broken on the Flickr side and can return
+    # the wrong token for a given user in some circumstances.
+
+    full_token = _get_and_test_full_user_oauth_token(request)
+
+    response_object = {
+        'user_nsid': full_token.user_nsid,
+        'username': full_token.username, 
+        'fullname': full_token.fullname
+    }
+
+    resp = jsonify(response_object)
     resp.status_code = status.HTTP_200_OK
 
     return resp  

--- a/backend/api-server/config/config.ini
+++ b/backend/api-server/config/config.ini
@@ -23,6 +23,7 @@ flickr-auth-memcached-location=localhost:11211
 
 default-num-photo-recommendations=10
 default-num-user-recommendations=5
+default-num-photos-from-group=20
 
 puller-queue-url=https://sqs.us-west-2.amazonaws.com/257049685947/puller-queue-dev
 puller-queue-batchsize=10

--- a/backend/api-server/favoritesstoredatabase.py
+++ b/backend/api-server/favoritesstoredatabase.py
@@ -120,6 +120,8 @@ class FavoritesStoreDatabase:
             cursor.execute("""
                 SELECT
                     UNIX_TIMESTAMP(created_at),
+                    (SELECT COUNT(*) FROM favorites WHERE favorited_by=%s) as num_favorites,
+                    (SELECT COUNT(DISTINCT image_owner) FROM favorites WHERE favorited_by=%s) as num_neighbors,
                     (all_data_last_successfully_processed_at IS NOT NULL) AS have_initially_processed_data,
                     ((data_last_requested_at IS NOT NULL) AND 
                         (IFNULL(all_data_last_successfully_processed_at, TIMESTAMP('1970-01-01')) < data_last_requested_at)) AS currently_processing_data,
@@ -132,19 +134,21 @@ class FavoritesStoreDatabase:
                 WHERE
                     user_id=%s
                 ;
-            """, (user_id,))
+            """, (user_id, user_id, user_id))
      
             row = self._get_first_row(cursor)
             
             if row is not None:
                 user_info = {
                     'created_at':                       row[0],
-                    'have_initially_processed_data':    bool(row[1]),
-                    'currently_processing_data':        bool(row[2]),
-                    'num_puller_requests_made':         row[3],
-                    'num_puller_requests_finished':     row[4],
-                    'num_ingester_requests_made':       row[5],
-                    'num_ingester_requests_finished':   row[6]
+                    'num_favorites':                    row[1],
+                    'num_neighbors':                    row[2],
+                    'have_initially_processed_data':    bool(row[3]),
+                    'currently_processing_data':        bool(row[4]),
+                    'num_puller_requests_made':         row[5],
+                    'num_puller_requests_finished':     row[6],
+                    'num_ingester_requests_made':       row[7],
+                    'num_ingester_requests_finished':   row[8]
                 }
 
         except Exception as e:

--- a/backend/common/flickrapiwrapper.py
+++ b/backend/common/flickrapiwrapper.py
@@ -89,6 +89,26 @@ class FlickrApiWrapper:
 
         return person_info
 
+    def get_group_info(self, group_id):
+        
+        lambda_to_call = lambda: self.unauth_flickr.groups.getInfo(group_id=group_id)
+
+        group_info = self._call_with_retries(lambda_to_call)
+
+        logging.info(f"Just called get_group_info for group {group_id}")
+
+        return group_info
+
+    def get_group_photos(self, group_id, num_photos):
+        
+        lambda_to_call = lambda: self.unauth_flickr.groups.pools.getPhotos(group_id=group_id, extras='url_l,url_m', per_page=num_photos, page=1) # Max per page is 500, and we'll always want way less than that
+
+        group_photos = self._call_with_retries(lambda_to_call)
+
+        logging.info(f"Just called get_group_photos for group {group_id}, with num photos {num_photos}")
+
+        return group_photos
+
     def get_favorites(self, user_id, max_favorites_per_call, max_favorites_to_get, max_calls_to_make):
 
         # We may want to put a limit on the number of pages that we request, because the Flickr API acts a bit weird.

--- a/frontend/src/components/GroupPhotos.vue
+++ b/frontend/src/components/GroupPhotos.vue
@@ -19,6 +19,7 @@
                 v-bind:imageUrl="photo.imageUrl"
                 v-bind:userAuthenticated="userAuthenticated"
                 v-bind:dismissButton="false"
+                v-on:added-favorite="onAddedFavorite()"
                 class="photorecommendation"
               >
               </PhotoRecommendation>
@@ -64,6 +65,30 @@ export default {
   async mounted() {
     await this.$store.dispatch('getGroupInfo', { groupId: this.groupId, numPhotos: this.numPhotos });
     this.groupInfo = this.$store.state.addfavorites.groupInfo[this.groupId];
+  },
+  methods: {
+    async onAddedFavorite() {
+      // Keep calling getUserInfo until the data for this latest favorite has been pulled, and thus our
+      // counts of how many faves & neighbors they have are updated
+
+      // TODO: Had to disble a lint error to get this to work, which seems to indicate that this is not the best approach.
+      // Need to do more googling.
+      // The lint error is intended to encourage better performance by having people await multiple things rather than one at a time.
+
+      async function delay(ms) {
+        return new Promise(resolve => setTimeout(resolve, ms));
+      }
+
+      while (this.$store.state.welcome.user.numRequestsCompleted < this.$store.state.welcome.user.numRequestsMade) {
+        await delay(1000); // eslint-disable-line no-await-in-loop
+
+        try {
+          await this.$store.dispatch('getUserInfo', this.userId); // eslint-disable-line no-await-in-loop
+        } catch (error) {
+          // TODO: Display an error message to the user saying the API server is unavailable
+        }
+      }
+    },
   },
 };
 </script>

--- a/frontend/src/components/GroupPhotos.vue
+++ b/frontend/src/components/GroupPhotos.vue
@@ -79,7 +79,9 @@ export default {
         return new Promise(resolve => setTimeout(resolve, ms));
       }
 
-      while (this.$store.state.welcome.user.numRequestsCompleted < this.$store.state.welcome.user.numRequestsMade) {
+      await this.$store.dispatch('getUserInfo', this.userId); // eslint-disable-line no-await-in-loop
+
+      while (this.$store.getters.numRequestsCompleted < this.$store.getters.numRequestsMade) {
         await delay(1000); // eslint-disable-line no-await-in-loop
 
         try {

--- a/frontend/src/components/GroupPhotos.vue
+++ b/frontend/src/components/GroupPhotos.vue
@@ -18,6 +18,7 @@
                 v-bind:imageOwner="photo.imageOwner"
                 v-bind:imageUrl="photo.imageUrl"
                 v-bind:userAuthenticated="userAuthenticated"
+                v-bind:dismissButton="false"
                 class="photorecommendation"
               >
               </PhotoRecommendation>

--- a/frontend/src/components/GroupPhotos.vue
+++ b/frontend/src/components/GroupPhotos.vue
@@ -1,28 +1,32 @@
 <template>
-  <b-collapse v-model="visible" id="recommendation-collapse">
-    <b-row class="groupname">
-      <b-col cols=10 lg=9>
-        <b-link :href="this.groupInfo.groupUrl">
+  <div role="tablist">
+    <b-card no-body class="mb-1">
+      <b-card-header header-tag="header" class="p-1" role="tab">
+        <b-button block href="#" v-b-toggle="`accordion-${this.groupId}`" variant="info">
           {{ this.groupInfo.groupName }}
-        </b-link>
-      </b-col>
-    </b-row>
-    <b-row>
-      <b-col>
-        <PhotoRecommendation
-          v-for="photo in this.groupInfo.groupPhotos"
-          v-bind:key="photo.imageId"
-          v-bind:userId="userId"
-          v-bind:imageId="photo.imageId"
-          v-bind:imageOwner="photo.imageOwner"
-          v-bind:imageUrl="photo.imageUrl"
-          v-bind:userAuthenticated="userAuthenticated"
-          class="photorecommendation"
-        >
-        </PhotoRecommendation>
-      </b-col>
-    </b-row>
-  </b-collapse>
+        </b-button>
+      </b-card-header>
+      <b-collapse :id="`accordion-${this.groupId}`" accordion="groups-accordion" role="tabpanel">
+        <b-card-body>
+          <b-row>
+            <b-col>
+              <PhotoRecommendation
+                v-for="photo in this.groupInfo.groupPhotos"
+                v-bind:key="photo.imageId"
+                v-bind:userId="userId"
+                v-bind:imageId="photo.imageId"
+                v-bind:imageOwner="photo.imageOwner"
+                v-bind:imageUrl="photo.imageUrl"
+                v-bind:userAuthenticated="userAuthenticated"
+                class="photorecommendation"
+              >
+              </PhotoRecommendation>
+            </b-col>
+          </b-row>
+        </b-card-body>
+      </b-collapse>
+    </b-card>
+  </div>
 </template>
 
 <style scoped>

--- a/frontend/src/components/GroupPhotos.vue
+++ b/frontend/src/components/GroupPhotos.vue
@@ -1,0 +1,68 @@
+<template>
+  <b-collapse v-model="visible" id="recommendation-collapse">
+    <b-row class="groupname">
+      <b-col cols=10 lg=9>
+        <b-link :href="this.groupInfo.groupUrl">
+          {{ this.groupInfo.groupName }}
+        </b-link>
+      </b-col>
+    </b-row>
+    <b-row>
+      <b-col>
+        <PhotoRecommendation
+          v-for="photo in this.groupInfo.groupPhotos"
+          v-bind:key="photo.imageId"
+          v-bind:userId="userId"
+          v-bind:imageId="photo.imageId"
+          v-bind:imageOwner="photo.imageOwner"
+          v-bind:imageUrl="photo.imageUrl"
+          v-bind:userAuthenticated="userAuthenticated"
+          class="photorecommendation"
+        >
+        </PhotoRecommendation>
+      </b-col>
+    </b-row>
+  </b-collapse>
+</template>
+
+<style scoped>
+
+.groupname {
+
+}
+
+.photorecommendation {
+  margin-bottom: 30px;
+}
+
+</style>
+
+<script>
+import PhotoRecommendation from './PhotoRecommendation.vue';
+
+export default {
+  components: {
+    PhotoRecommendation,
+  },
+  props: {
+    userId: String,
+    groupId: String,
+    numPhotos: Number,
+    userAuthenticated: Boolean,
+  },
+  data() {
+    return {
+      groupInfo: {
+        groupPhotos: [],
+        groupUrl: '',
+        groupName: '',
+      },
+      visible: true,
+    };
+  },
+  async mounted() {
+    await this.$store.dispatch('getGroupInfo', { groupId: this.groupId, numPhotos: this.numPhotos });
+    this.groupInfo = this.$store.state.addfavorites.groupInfo[this.groupId];
+  },
+};
+</script>

--- a/frontend/src/components/GroupPhotos.vue
+++ b/frontend/src/components/GroupPhotos.vue
@@ -31,10 +31,6 @@
 
 <style scoped>
 
-.groupname {
-
-}
-
 .photorecommendation {
   margin-bottom: 30px;
 }

--- a/frontend/src/components/PhotoRecommendation.vue
+++ b/frontend/src/components/PhotoRecommendation.vue
@@ -184,8 +184,13 @@ export default {
       // This call hides all popovers: there should be only one, just at the mouse cursor
       // https://github.com/bootstrap-vue/bootstrap-vue/issues/1161
       this.$root.$emit('bv::hide::popover');
-      await FlickrRepository.addFavorite(this.imageId, this.imageOwner, this.imageUrl);
+      try {
+        await FlickrRepository.addFavorite(this.imageId, this.imageOwner, this.imageUrl);
+      } catch (e) {
+        // TODO: Display a nice message saying we can't talk to the server
+      }
       this.photoFavedState = 'checked';
+      this.$emit('added-favorite');
     },
     async onAddComment() {
       this.commentAddedState = 'loading';

--- a/frontend/src/components/PhotoRecommendation.vue
+++ b/frontend/src/components/PhotoRecommendation.vue
@@ -8,16 +8,18 @@
       </b-col>
       <b-col cols=1>
         <div v-if="this.userAuthenticated">
-          <DismissButton
-            @click="onDismiss()"
-            :class="$mq | mq({
-              xs: 'dismissbutton-sm',
-              sm: 'dismissbutton-sm',
-              md: 'dismissbutton-sm',
-              lg: 'dismissbutton-lg',
-              xl: 'dismissbutton-lg',
-            })"
-          ></DismissButton>
+          <div v-if="this.dismissButton">
+            <DismissButton
+              @click="onDismiss()"
+              :class="$mq | mq({
+                xs: 'dismissbutton-sm',
+                sm: 'dismissbutton-sm',
+                md: 'dismissbutton-sm',
+                lg: 'dismissbutton-lg',
+                xl: 'dismissbutton-lg',
+              })"
+            ></DismissButton>
+          </div>
           <AddButton
             @click="onAddFavorite()"
             :class="$mq | mq({
@@ -152,6 +154,10 @@ export default {
     imageOwner: String,
     imageUrl: String,
     userAuthenticated: Boolean,
+    dismissButton: {
+      type: Boolean,
+      default: true,
+    },
   },
   data() {
     return {

--- a/frontend/src/config.js
+++ b/frontend/src/config.js
@@ -1,0 +1,6 @@
+const config = {
+  minNumNeighborsForRecommendations: 3,
+  minNumFavoritesForRecommendations: 5,
+};
+
+export default config;

--- a/frontend/src/config.js
+++ b/frontend/src/config.js
@@ -10,6 +10,7 @@ const config = {
     '16978849@N00', // Black and White: https://www.flickr.com/groups/blackandwhite/
     '94761711@N00', // Hardcore Street Photography: https://www.flickr.com/groups/onthestreet/
   ],
+  recommendedGroupsNumPhotosToShow: 20,
 };
 
 export default config;

--- a/frontend/src/config.js
+++ b/frontend/src/config.js
@@ -3,6 +3,13 @@ const config = {
   minNumFavoritesForRecommendations: 5,
   defaultNumPhotoRecommendations: 50,
   defaultNumUserRecommendations: 2,
+  recommendedGroupsToFindFavorites: [
+    '80641914@N00', // Flickr's 100 Best: https://www.flickr.com/groups/best100only/
+    '14673266@N22', // Print Boldly: https://www.flickr.com/groups/printboldly/
+    '34427469792@N01', // Flickr Central: https://www.flickr.com/groups/central/
+    '16978849@N00', // Black and White: https://www.flickr.com/groups/blackandwhite/
+    '94761711@N00', // Hardcore Street Photography: https://www.flickr.com/groups/onthestreet/
+  ],
 };
 
 export default config;

--- a/frontend/src/config.js
+++ b/frontend/src/config.js
@@ -1,6 +1,8 @@
 const config = {
   minNumNeighborsForRecommendations: 3,
   minNumFavoritesForRecommendations: 5,
+  defaultNumPhotoRecommendations: 50,
+  defaultNumUserRecommendations: 2,
 };
 
 export default config;

--- a/frontend/src/main.js
+++ b/frontend/src/main.js
@@ -7,8 +7,10 @@ import './plugins/mediaquery-vue';
 import App from './App.vue';
 import router from './router';
 import store from './store';
+import config from './config';
 
 Vue.config.productionTip = false;
+Vue.prototype.appConfig = config;
 
 new Vue({
   router,

--- a/frontend/src/plugins/bootstrap-vue.js
+++ b/frontend/src/plugins/bootstrap-vue.js
@@ -30,6 +30,7 @@ import {
   PopoverPlugin,
   CollapsePlugin,
   ProgressPlugin,
+  CardPlugin,
 } from 'bootstrap-vue';
 
 import 'bootstrap/dist/css/bootstrap.min.css';
@@ -49,3 +50,4 @@ Vue.use(LinkPlugin);
 Vue.use(PopoverPlugin);
 Vue.use(CollapsePlugin);
 Vue.use(ProgressPlugin);
+Vue.use(CardPlugin);

--- a/frontend/src/repositories/flickrRepository.js
+++ b/frontend/src/repositories/flickrRepository.js
@@ -97,13 +97,13 @@ export default {
   },
   async getCurrentlyLoggedInUser() {
     const response = await repository.post(
-      `${resource}/test/login`,
+      `${resource}/get-logged-in-user`,
       { 'oauth-token': vueAuth.getToken() },
     );
 
     return {
-      id: response.data.user.id,
-      name: response.data.user.username._content, // eslint-disable-line no-underscore-dangle
+      id: response.data.user_nsid,
+      name: response.data.username,
     };
   },
   async logoutUser() {

--- a/frontend/src/repositories/flickrRepository.js
+++ b/frontend/src/repositories/flickrRepository.js
@@ -71,7 +71,7 @@ export default {
       photo => ({
         imageId: photo.id,
         imageOwner: photo.owner,
-        imageUrl: photo.get('url_l', photo.get('url_m', '')),
+        imageUrl: 'url_l' in photo ? photo.url_l : ('url_m' in photo ? photo.url_m : ''),
       }),
     );
 

--- a/frontend/src/repositories/flickrRepository.js
+++ b/frontend/src/repositories/flickrRepository.js
@@ -9,6 +9,8 @@ import vueAuth from '../auth';
 
 const resource = '/flickr';
 
+const getProfileUrl = (userId) => `https://www.flickr.com/photos/${userId}/`;
+
 export default {
   async getUserIdFromUrl(userUrl) {
     const response = await repository.get(`${resource}/urls/lookup-user`, { params: { url: userUrl } });
@@ -41,7 +43,7 @@ export default {
       iconUrl = `https://farm${iconFarm}.staticflickr.com/${iconServer}/buddyicons/${nsId}.jpg`;
     }
 
-    const profileUrl = `https://www.flickr.com/photos/${nsId}/`;
+    const profileUrl = getProfileUrl(nsId);
 
     return {
       userId,
@@ -87,5 +89,8 @@ export default {
   },
   getPhotoUrl(imageOwner, imageId) {
     return `https://www.flickr.com/photos/${imageOwner}/${imageId}`;
+  },
+  getProfileUrl(userId) {
+    return getProfileUrl(userId);
   },
 };

--- a/frontend/src/repositories/flickrRepository.js
+++ b/frontend/src/repositories/flickrRepository.js
@@ -9,7 +9,7 @@ import vueAuth from '../auth';
 
 const resource = '/flickr';
 
-const getProfileUrl = (userId) => `https://www.flickr.com/photos/${userId}/`;
+const getProfileUrl = userId => `https://www.flickr.com/photos/${userId}/`;
 
 export default {
   async getUserIdFromUrl(userUrl) {
@@ -51,6 +51,31 @@ export default {
       iconUrl,
       profileUrl,
     };
+  },
+  async getGroupInfo(groupId) {
+    const response = await repository.get(`${resource}/groups/get-info`, { params: { 'group-id': groupId } });
+
+    const groupName = response.data.group.name._content; // eslint-disable-line no-underscore-dangle
+    const pathAlias = response.data.group.path_alias;
+    const groupUrl = `https://www.flickr.com/groups/${typeof pathAlias !== 'undefined' ? pathAlias : groupId}/`;
+
+    return {
+      groupName,
+      groupUrl,
+    };
+  },
+  async getGroupPhotos(groupId, numPhotos) {
+    const response = await repository.get(`${resource}/groups/pools/get-photos`, { params: { 'group-id': groupId, 'num-photos': numPhotos } });
+
+    const photos = response.data.photos.photo.map(
+      photo => ({
+        imageId: photo.id,
+        imageOwner: photo.owner,
+        imageUrl: photo.get('url_l', photo.get('url_m', '')),
+      }),
+    );
+
+    return photos;
   },
   async addComment(photoId, commentText) {
     await repository.post(

--- a/frontend/src/repositories/flickrRepository.js
+++ b/frontend/src/repositories/flickrRepository.js
@@ -71,7 +71,7 @@ export default {
       photo => ({
         imageId: photo.id,
         imageOwner: photo.owner,
-        imageUrl: 'url_l' in photo ? photo.url_l : ('url_m' in photo ? photo.url_m : ''),
+        imageUrl: 'url_l' in photo ? photo.url_l : ('url_m' in photo ? photo.url_m : ''), // eslint-disable-line no-nested-ternary
       }),
     );
 

--- a/frontend/src/router.js
+++ b/frontend/src/router.js
@@ -2,6 +2,9 @@ import Vue from 'vue';
 import Router from 'vue-router';
 import Welcome from './views/Welcome.vue';
 import Recommendations from './views/Recommendations.vue';
+import AddFavorites from './views/AddFavorites.vue';
+import store from './store';
+import config from './config';
 
 Vue.use(Router);
 
@@ -16,6 +19,37 @@ export default new Router({
       path: '/recommendations/:userId',
       name: 'recommendations',
       component: Recommendations,
+      beforeEnter: (to, from, next) => {
+        // Only go to our recommendations if the user has enough favorites and neighbors to
+        // be able to generate good recommendations. Otherwise take them to a page where they
+        // can add some favorites first
+        if ((store.state.welcome.user.numFavorites >= config.minNumFavoritesForRecommendations)
+          && (store.state.welcome.user.numNeighbors >= config.minNumNeighborsForRecommendations)) {
+          next();
+        } else {
+          next({
+            name: 'add-favorites',
+            params: { userId: to.params.userId },
+          });
+        }
+      },
+    },
+    {
+      path: '/add-favorites/:userId',
+      name: 'add-favorites',
+      component: AddFavorites,
+      beforeEnter: (to, from, next) => {
+        // Don't let someone go here if they have enough favorites to generate good recommendations
+        if ((store.state.welcome.user.numFavorites >= config.minNumFavoritesForRecommendations)
+          && (store.state.welcome.user.numNeighbors >= config.minNumNeighborsForRecommendations)) {
+          next({
+            name: 'recommendations',
+            params: { userId: to.params.userId }, // Just use default number of recommendations because there's no other numbers available here
+          });
+        } else {
+          next();
+        }
+      },
     },
   ],
 });

--- a/frontend/src/router.js
+++ b/frontend/src/router.js
@@ -3,8 +3,6 @@ import Router from 'vue-router';
 import Welcome from './views/Welcome.vue';
 import Recommendations from './views/Recommendations.vue';
 import AddFavorites from './views/AddFavorites.vue';
-import store from './store';
-import config from './config';
 
 Vue.use(Router);
 
@@ -19,37 +17,11 @@ export default new Router({
       path: '/recommendations/:userId',
       name: 'recommendations',
       component: Recommendations,
-      beforeEnter: (to, from, next) => {
-        // Only go to our recommendations if the user has enough favorites and neighbors to
-        // be able to generate good recommendations. Otherwise take them to a page where they
-        // can add some favorites first
-        if ((store.state.welcome.user.numFavorites >= config.minNumFavoritesForRecommendations)
-          && (store.state.welcome.user.numNeighbors >= config.minNumNeighborsForRecommendations)) {
-          next();
-        } else {
-          next({
-            name: 'add-favorites',
-            params: { userId: to.params.userId },
-          });
-        }
-      },
     },
     {
       path: '/add-favorites/:userId',
       name: 'add-favorites',
       component: AddFavorites,
-      beforeEnter: (to, from, next) => {
-        // Don't let someone go here if they have enough favorites to generate good recommendations
-        if ((store.state.welcome.user.numFavorites >= config.minNumFavoritesForRecommendations)
-          && (store.state.welcome.user.numNeighbors >= config.minNumNeighborsForRecommendations)) {
-          next({
-            name: 'recommendations',
-            params: { userId: to.params.userId }, // Just use default number of recommendations because there's no other numbers available here
-          });
-        } else {
-          next();
-        }
-      },
     },
   ],
 });

--- a/frontend/src/store.js
+++ b/frontend/src/store.js
@@ -4,6 +4,7 @@ import Vuex from 'vuex';
 import AuthModule from './stores/Auth';
 import WelcomeModule from './stores/Welcome';
 import RecommendationsModule from './stores/Recommendations';
+import AddFavoritesModule from './stores/AddFavorites';
 
 Vue.use(Vuex);
 
@@ -14,5 +15,6 @@ export default new Vuex.Store({
     auth: AuthModule,
     welcome: WelcomeModule,
     recommendations: RecommendationsModule,
+    addfavorites: AddFavoritesModule,
   },
 });

--- a/frontend/src/stores/AddFavorites.js
+++ b/frontend/src/stores/AddFavorites.js
@@ -1,0 +1,29 @@
+import RepositoryFactory from '../repositories/repositoryFactory';
+
+const FlickrRepository = RepositoryFactory.get('flickr');
+
+export default {
+  state: {
+    groupInfo: {},
+  },
+  mutations: {
+    setGroupInfo(state, { groupId, groupInfo }) {
+      state.groupInfo[groupId] = groupInfo;
+    },
+  },
+  actions: {
+    async getGroupInfo({ commit }, groupId) {
+      const results = await Promise.all([FlickrRepository.getGroupInfo(groupId), FlickrRepository.getGroupPhotos(groupId, numPhotos)]);
+
+      const groupInfo = results[0];
+      const groupPhotos = results[1];
+
+      const combinedGroupInfo = {
+        ...groupInfo,
+        photos: groupPhotos,
+      };
+
+      commit('setGroupInfo', { userId, combinedGroupInfo });
+    },
+  },
+};

--- a/frontend/src/stores/AddFavorites.js
+++ b/frontend/src/stores/AddFavorites.js
@@ -12,7 +12,7 @@ export default {
     },
   },
   actions: {
-    async getGroupInfo({ commit }, { groupId, numPhotos } ) {
+    async getGroupInfo({ commit }, { groupId, numPhotos }) {
       const results = await Promise.all([FlickrRepository.getGroupInfo(groupId), FlickrRepository.getGroupPhotos(groupId, numPhotos)]);
 
       const partialGroupInfo = results[0];

--- a/frontend/src/stores/AddFavorites.js
+++ b/frontend/src/stores/AddFavorites.js
@@ -12,18 +12,18 @@ export default {
     },
   },
   actions: {
-    async getGroupInfo({ commit }, groupId) {
+    async getGroupInfo({ commit }, { groupId, numPhotos } ) {
       const results = await Promise.all([FlickrRepository.getGroupInfo(groupId), FlickrRepository.getGroupPhotos(groupId, numPhotos)]);
 
-      const groupInfo = results[0];
+      const partialGroupInfo = results[0];
       const groupPhotos = results[1];
 
-      const combinedGroupInfo = {
-        ...groupInfo,
-        photos: groupPhotos,
+      const groupInfo = {
+        ...partialGroupInfo,
+        groupPhotos,
       };
 
-      commit('setGroupInfo', { userId, combinedGroupInfo });
+      commit('setGroupInfo', { groupId, groupInfo });
     },
   },
 };

--- a/frontend/src/stores/Welcome.js
+++ b/frontend/src/stores/Welcome.js
@@ -12,6 +12,8 @@ export default {
       name: '',
       currentlyProcessingData: false,
       haveInitiallyProcessedData: false,
+      numNeighbors: 0,
+      numFavorites: 0,
       numPullerRequestsMade: 0,
       numPullerRequestsFinished: 0,
       numIngesterRequestsMade: 0,
@@ -24,11 +26,13 @@ export default {
     },
     setProcessingStatus(state,
       {
-        currentlyProcessingData, haveInitiallyProcessedData, numPullerRequestsMade,
-        numPullerRequestsFinished, numIngesterRequestsMade, numIngesterRequestsFinished,
+        currentlyProcessingData, haveInitiallyProcessedData, numNeighbors, numFavorites,
+        numPullerRequestsMade, numPullerRequestsFinished, numIngesterRequestsMade, numIngesterRequestsFinished,
       }) {
       state.user.currentlyProcessingData = currentlyProcessingData;
       state.user.haveInitiallyProcessedData = haveInitiallyProcessedData;
+      state.user.numNeighbors = numNeighbors;
+      state.user.numFavorites = numFavorites;
       state.user.numPullerRequestsMade = numPullerRequestsMade;
       state.user.numPullerRequestsFinished = numPullerRequestsFinished;
       state.user.numIngesterRequestsMade = numIngesterRequestsMade;
@@ -45,6 +49,8 @@ export default {
         recommendations: [],
         currentlyProcessingData: false,
         haveInitiallyProcessedData: false,
+        numNeighbors: 0,
+        numFavorites: 0,
         numPullerRequestsMade: 0,
         numPullerRequestsFinished: 0,
         numIngesterRequestsMade: 0,
@@ -62,6 +68,8 @@ export default {
         recommendations: [],
         currentlyProcessingData: false,
         haveInitiallyProcessedData: false,
+        numNeighbors: 0,
+        numFavorites: 0,
         numPullerRequestsMade: 0,
         numPullerRequestsFinished: 0,
         numIngesterRequestsMade: 0,
@@ -76,6 +84,8 @@ export default {
       commit('setProcessingStatus', {
         currentlyProcessingData: userInfo.data.currently_processing_data,
         haveInitiallyProcessedData: userInfo.data.have_initially_processed_data,
+        numNeighbors: userInfo.data.num_neighbors,
+        numFavorites: userInfo.data.num_favorites,
         numPullerRequestsMade: userInfo.data.num_puller_requests_made,
         numPullerRequestsFinished: userInfo.data.num_puller_requests_finished,
         numIngesterRequestsMade: userInfo.data.num_ingester_requests_made,
@@ -88,6 +98,8 @@ export default {
       commit('setProcessingStatus', {
         currentlyProcessingData: userInfo.data.currently_processing_data,
         haveInitiallyProcessedData: userInfo.data.have_initially_processed_data,
+        numNeighbors: userInfo.data.num_neighbors,
+        numFavorites: userInfo.data.num_favorites,
         numPullerRequestsMade: userInfo.data.num_puller_requests_made,
         numPullerRequestsFinished: userInfo.data.num_puller_requests_finished,
         numIngesterRequestsMade: userInfo.data.num_ingester_requests_made,

--- a/frontend/src/stores/Welcome.js
+++ b/frontend/src/stores/Welcome.js
@@ -20,6 +20,20 @@ export default {
       numIngesterRequestsFinished: 0,
     },
   },
+  getters: {
+    // A request isn't completely finished until it's both been pulled from the external API and
+    // ingested into our database, so pick the minimum here.
+    numRequestsCompleted: state => Math.min(
+      state.user.numPullerRequestsFinished,
+      state.user.numIngesterRequestsFinished,
+    ),
+    // These 2 numbers should be the same (we have a one-to-one mapping of puller requests to
+    // ingester requests), but pick the max just to be safe.
+    numRequestsMade: state => Math.max(
+      state.user.numPullerRequestsMade,
+      state.user.numIngesterRequestsMade,
+    ),
+  },
   mutations: {
     setUser(state, user) {
       state.user = user;

--- a/frontend/src/stores/Welcome.js
+++ b/frontend/src/stores/Welcome.js
@@ -18,6 +18,7 @@ export default {
       numPullerRequestsFinished: 0,
       numIngesterRequestsMade: 0,
       numIngesterRequestsFinished: 0,
+      processingStatusIsDirty: true, // If true, then the above numbers are not reflective of the state of the database
     },
   },
   getters: {
@@ -51,6 +52,7 @@ export default {
       state.user.numPullerRequestsFinished = numPullerRequestsFinished;
       state.user.numIngesterRequestsMade = numIngesterRequestsMade;
       state.user.numIngesterRequestsFinished = numIngesterRequestsFinished;
+      state.user.processingStatusIsDirty = false
     },
   },
   actions: {
@@ -69,6 +71,7 @@ export default {
         numPullerRequestsFinished: 0,
         numIngesterRequestsMade: 0,
         numIngesterRequestsFinished: 0,
+        processingStatusIsDirty: true,
       };
 
       commit('setUser', user);
@@ -88,6 +91,7 @@ export default {
         numPullerRequestsFinished: 0,
         numIngesterRequestsMade: 0,
         numIngesterRequestsFinished: 0,
+        processingStatusIsDirty: true,
       };
 
       commit('setUser', user);

--- a/frontend/src/views/AddFavorites.vue
+++ b/frontend/src/views/AddFavorites.vue
@@ -11,7 +11,7 @@
       <b-row align-h="center">
         <b-col xs=12 sm=8 md=6 class="minnumfavorites">
           <h4>
-            They have {{ numFavorites }} favorites from {{ numNeighbors }} different users, but need at least
+            They have {{ this.numFavorites }} favorites from {{ this.numNeighbors }} different users, but need at least
             {{ appConfig.minNumFavoritesForRecommendations }} favorites from at least
             {{ appConfig.minNumNeighborsForRecommendations }} different users.
           </h4>
@@ -47,7 +47,7 @@
       <b-row align-h="center">
         <b-col xs=12 sm=8 md=6 class="minnumfavorites">
           <h4>
-            You have {{ numFavorites }} favorites from {{ numNeighbors }} different users, and need at least
+            You have {{ this.numFavorites }} favorites from {{ this.numNeighbors }} different users, and need at least
             {{ appConfig.minNumFavoritesForRecommendations }} favorites from at least
             {{ appConfig.minNumNeighborsForRecommendations }} different users.
           </h4>
@@ -115,13 +115,17 @@ export default {
       userId: '',
       profileUrl: '',
       userAuthenticated: false,
-      numFavorites: 0,
-      numNeighbors: 0,
       groupIds: [],
       numPhotosPerGroup: 0,
     };
   },
   computed: {
+    numFavorites() {
+      return this.$store.state.welcome.user.numFavorites;
+    },
+    numNeighbors() {
+      return this.$store.state.welcome.user.numNeighbors;
+    },
     hasEnoughRecommendations() {
       return (this.numFavorites >= this.appConfig.minNumFavoritesForRecommendations)
         && (this.numNeighbors >= this.appConfig.minNumNeighborsForRecommendations);
@@ -132,8 +136,6 @@ export default {
     this.userId = this.$route.params.userId;
     this.profileUrl = FlickrRepository.getProfileUrl(this.$route.params.userId);
     this.userAuthenticated = this.$store.getters.isAuthenticated();
-    this.numFavorites = this.$store.state.welcome.user.numFavorites;
-    this.numNeighbors = this.$store.state.welcome.user.numNeighbors;
     this.groupIds = this.appConfig.recommendedGroupsToFindFavorites;
     this.numPhotosPerGroup = this.appConfig.recommendedGroupsNumPhotosToShow;
   },

--- a/frontend/src/views/AddFavorites.vue
+++ b/frontend/src/views/AddFavorites.vue
@@ -16,10 +16,10 @@ export default {
     };
   },
   async mounted() {
-    console.log('Hello from add favorites');
+    // console.log('Hello from add favorites');
     // this.userId = this.$route.params.userId;
     // this.userAuthenticated = (this.$store.getters.isAuthenticated());
-    console.log('Finished mounting add favorites');
+    // console.log('Finished mounting add favorites');
   },
 };
 </script>

--- a/frontend/src/views/AddFavorites.vue
+++ b/frontend/src/views/AddFavorites.vue
@@ -1,29 +1,64 @@
 <template>
   <div>
-    <b-alert variant="danger" :show="true">
-      You need to add more favorites before we can give you recommendations!
-    </b-alert>
+    <div v-if="!userAuthenticated">
+      <b-row align-h="center">
+        <b-col xs=12 sm=8 md=6 class="notenoughfavorites">
+          <h3>
+            Sorry, {{ userName }} doesn't have enough favorites to generate any recommendations.
+          </h3>
+        </b-col>
+      </b-row>
+      <b-row align-h="center">
+        <b-col xs=12 sm=8 md=6 class="minnumfavorites">
+          <h4>
+            They have {{ numFavorites }} favorites from {{ numNeighbors }} different users, but need at least {{ appConfig.minNumFavoritesForRecommendations }} favorites from at least {{ appConfig.minNumNeighborsForRecommendations }} different users.
+          </h4>
+        </b-col>
+      </b-row>
+      <b-row align-h="center">
+        <b-col xs=12 sm=8 md=6 class="backtowelcome">
+          <h4>
+            <router-link to="/">Try someone else</router-link>
+          </h4>
+        </b-col>
+      </b-row>
+    </div>
+    <div v-else>
+      Dude you need some recommendations
+    </div>
   </div>
 </template>
+
+<style scoped>
+.notenoughfavorites {
+
+}
+
+.minnumfavorites {
+  margin-top: 30px;
+}
+
+.backtowelcome {
+  margin-top: 30px;
+}
+</style>
 
 <script>
 
 export default {
   data() {
     return {
-      userId: '',
+      userName: '',
       userAuthenticated: false,
+      numFavorites: 0,
+      numNeighbors: 0,
     };
   },
   async mounted() {
-    // console.log('Hello from add favorites');
-    // this.userId = this.$route.params.userId;
-    // this.userAuthenticated = (this.$store.getters.isAuthenticated());
-    // console.log('Finished mounting add favorites');
+    this.userName = this.$store.state.welcome.user.name;
+    this.userAuthenticated = this.$store.getters.isAuthenticated();
+    this.numFavorites = this.$store.state.welcome.user.numFavorites;
+    this.numNeighbors = this.$store.state.welcome.user.numNeighbors;
   },
 };
 </script>
-
-<style scoped>
-
-</style>

--- a/frontend/src/views/AddFavorites.vue
+++ b/frontend/src/views/AddFavorites.vue
@@ -11,7 +11,9 @@
       <b-row align-h="center">
         <b-col xs=12 sm=8 md=6 class="minnumfavorites">
           <h4>
-            They have {{ numFavorites }} favorites from {{ numNeighbors }} different users, but need at least {{ appConfig.minNumFavoritesForRecommendations }} favorites from at least {{ appConfig.minNumNeighborsForRecommendations }} different users.
+            They have {{ numFavorites }} favorites from {{ numNeighbors }} different users, but need at least
+            {{ appConfig.minNumFavoritesForRecommendations }} favorites from at least
+            {{ appConfig.minNumNeighborsForRecommendations }} different users.
           </h4>
         </b-col>
       </b-row>

--- a/frontend/src/views/AddFavorites.vue
+++ b/frontend/src/views/AddFavorites.vue
@@ -4,7 +4,7 @@
       <b-row align-h="center">
         <b-col xs=12 sm=8 md=6 class="notenoughfavorites">
           <h3>
-            Sorry, {{ userName }} doesn't have enough favorites to generate any recommendations.
+            Sorry, <b-link :href="profileUrl">{{ userName }}</b-link> doesn't have enough favorites to generate any recommendations.
           </h3>
         </b-col>
       </b-row>
@@ -45,10 +45,15 @@
 
 <script>
 
+import RepositoryFactory from '../repositories/repositoryFactory';
+
+const FlickrRepository = RepositoryFactory.get('flickr');
+
 export default {
   data() {
     return {
       userName: '',
+      profileUrl: '',
       userAuthenticated: false,
       numFavorites: 0,
       numNeighbors: 0,
@@ -56,6 +61,7 @@ export default {
   },
   async mounted() {
     this.userName = this.$store.state.welcome.user.name;
+    this.profileUrl = FlickrRepository.getProfileUrl(this.$route.params.userId);
     this.userAuthenticated = this.$store.getters.isAuthenticated();
     this.numFavorites = this.$store.state.welcome.user.numFavorites;
     this.numNeighbors = this.$store.state.welcome.user.numNeighbors;

--- a/frontend/src/views/AddFavorites.vue
+++ b/frontend/src/views/AddFavorites.vue
@@ -38,7 +38,7 @@
       <div v-else>
         <b-row align-h="center">
           <b-col cols=8>
-            <b-button block variant='primary' class="torecommendations" @click="torecommendations()">
+            <b-button block variant='primary' class="torecommendations" @click="toRecommendations()">
                 Take me to my recommendations
             </b-button>
           </b-col>
@@ -137,11 +137,13 @@ export default {
     this.groupIds = this.appConfig.recommendedGroupsToFindFavorites;
     this.numPhotosPerGroup = this.appConfig.recommendedGroupsNumPhotosToShow;
   },
-  torecommendations() {
-    this.$router.push({
-      name: 'recommendations',
-      params: { userId: this.$store.state.welcome.user.id },
-    }).catch(() => {});
+  methods: {
+    toRecommendations() {
+      this.$router.push({
+        name: 'recommendations',
+        params: { userId: this.$store.state.welcome.user.id },
+      }).catch(() => {}); // This might throw an error if the navigation "fails" because a router guard intercepts it
+    },
   },
 };
 </script>

--- a/frontend/src/views/AddFavorites.vue
+++ b/frontend/src/views/AddFavorites.vue
@@ -26,25 +26,63 @@
       </b-row>
     </div>
     <div v-else>
-      <b-container>
-        <GroupPhotos
-          v-for="groupId in this.groupIds"
-          v-bind:key="groupId"
-          v-bind:userId="userId"
-          v-bind:groupId="groupId"
-          v-bind:numPhotos="numPhotosPerGroup"
-          v-bind:userAuthenticated="userAuthenticated"
-          class="groupphoto"
-        >
-        </GroupPhotos>
-      </b-container>
+      <div v-if="!hasEnoughRecommendations">
+        <b-row align-h="center">
+          <b-col xs=12 sm=8 md=6 class="notenoughfavorites">
+            <h3>
+              Sorry, you don't have enough favorites to generate any recommendations.
+            </h3>
+          </b-col>
+        </b-row>
+      </div>
+      <div v-else>
+        <b-row align-h="center">
+          <b-col cols=8>
+            <b-button block variant='primary' class="torecommendations" @click="torecommendations()">
+                Take me to my recommendations
+            </b-button>
+          </b-col>
+        </b-row>
+      </div>
+      <b-row align-h="center">
+        <b-col xs=12 sm=8 md=6 class="minnumfavorites">
+          <h4>
+            You have {{ numFavorites }} favorites from {{ numNeighbors }} different users, and need at least
+            {{ appConfig.minNumFavoritesForRecommendations }} favorites from at least
+            {{ appConfig.minNumNeighborsForRecommendations }} different users.
+          </h4>
+        </b-col>
+      </b-row>
+      <b-row align-h="center">
+        <b-col xs=12 sm=8 md=6 class="minnumfavorites">
+          <h4>
+            Open the groups below to find some photos you like and add them as favorites.
+          </h4>
+        </b-col>
+      </b-row>
+      <GroupPhotos
+        v-for="groupId in this.groupIds"
+        v-bind:key="groupId"
+        v-bind:userId="userId"
+        v-bind:groupId="groupId"
+        v-bind:numPhotos="numPhotosPerGroup"
+        v-bind:userAuthenticated="userAuthenticated"
+        class="groupphoto"
+      >
+      </GroupPhotos>
     </div>
   </div>
 </template>
 
 <style scoped>
+
 .notenoughfavorites {
 
+}
+
+.torecommendations {
+  height: 75px;
+  line-height: 60px;
 }
 
 .minnumfavorites {
@@ -83,6 +121,12 @@ export default {
       numPhotosPerGroup: 0,
     };
   },
+  computed: {
+    hasEnoughRecommendations() {
+      return (this.numFavorites >= this.appConfig.minNumFavoritesForRecommendations)
+        && (this.numNeighbors >= this.appConfig.minNumNeighborsForRecommendations);
+    },
+  },
   async mounted() {
     this.userName = this.$store.state.welcome.user.name;
     this.userId = this.$route.params.userId;
@@ -92,6 +136,12 @@ export default {
     this.numNeighbors = this.$store.state.welcome.user.numNeighbors;
     this.groupIds = this.appConfig.recommendedGroupsToFindFavorites;
     this.numPhotosPerGroup = this.appConfig.recommendedGroupsNumPhotosToShow;
+  },
+  torecommendations() {
+    this.$router.push({
+      name: 'recommendations',
+      params: { userId: this.$store.state.welcome.user.id },
+    }).catch(() => {});
   },
 };
 </script>

--- a/frontend/src/views/AddFavorites.vue
+++ b/frontend/src/views/AddFavorites.vue
@@ -1,0 +1,29 @@
+<template>
+  <div>
+    <b-alert variant="danger" :show="true">
+      You need to add more favorites before we can give you recommendations!
+    </b-alert>
+  </div>
+</template>
+
+<script>
+
+export default {
+  data() {
+    return {
+      userId: '',
+      userAuthenticated: false,
+    };
+  },
+  async mounted() {
+    console.log('Hello from add favorites');
+    // this.userId = this.$route.params.userId;
+    // this.userAuthenticated = (this.$store.getters.isAuthenticated());
+    console.log('Finished mounting add favorites');
+  },
+};
+</script>
+
+<style scoped>
+
+</style>

--- a/frontend/src/views/AddFavorites.vue
+++ b/frontend/src/views/AddFavorites.vue
@@ -131,7 +131,7 @@ export default {
     this.userName = this.$store.state.welcome.user.name;
     this.userId = this.$route.params.userId;
     this.profileUrl = FlickrRepository.getProfileUrl(this.$route.params.userId);
-    this.userAuthenticated = true; // this.$store.getters.isAuthenticated();
+    this.userAuthenticated = this.$store.getters.isAuthenticated();
     this.numFavorites = this.$store.state.welcome.user.numFavorites;
     this.numNeighbors = this.$store.state.welcome.user.numNeighbors;
     this.groupIds = this.appConfig.recommendedGroupsToFindFavorites;

--- a/frontend/src/views/AddFavorites.vue
+++ b/frontend/src/views/AddFavorites.vue
@@ -8,15 +8,17 @@
           </h3>
         </b-col>
       </b-row>
-      <b-row align-h="center">
-        <b-col xs=12 sm=8 md=6 class="minnumfavorites">
-          <h4>
-            They have {{ this.numFavorites }} favorites from {{ this.numNeighbors }} different users, but need at least
-            {{ appConfig.minNumFavoritesForRecommendations }} favorites from at least
-            {{ appConfig.minNumNeighborsForRecommendations }} different users.
-          </h4>
-        </b-col>
-      </b-row>
+      <div v-if="!userProcessingStatusIsDirty">
+        <b-row align-h="center">
+          <b-col xs=12 sm=8 md=6 class="minnumfavorites">
+            <h4>
+              They have {{ this.numFavorites }} favorites from {{ this.numNeighbors }} different users, but need at least
+              {{ appConfig.minNumFavoritesForRecommendations }} favorites from at least
+              {{ appConfig.minNumNeighborsForRecommendations }} different users.
+            </h4>
+          </b-col>
+        </b-row>
+      </div>
       <b-row align-h="center">
         <b-col xs=12 sm=8 md=6 class="backtowelcome">
           <h4>
@@ -26,33 +28,35 @@
       </b-row>
     </div>
     <div v-else>
-      <div v-if="!hasEnoughRecommendations">
+      <div v-if="!userProcessingStatusIsDirty">
+        <div v-if="!hasEnoughRecommendations">
+          <b-row align-h="center">
+            <b-col xs=12 sm=8 md=6 class="notenoughfavorites">
+              <h3>
+                Sorry, you don't have enough favorites to generate any recommendations.
+              </h3>
+            </b-col>
+          </b-row>
+        </div>
+        <div v-else>
+          <b-row align-h="center">
+            <b-col cols=8>
+              <b-button block variant='primary' class="torecommendations" @click="toRecommendations()">
+                  Take me to my recommendations
+              </b-button>
+            </b-col>
+          </b-row>
+        </div>
         <b-row align-h="center">
-          <b-col xs=12 sm=8 md=6 class="notenoughfavorites">
-            <h3>
-              Sorry, you don't have enough favorites to generate any recommendations.
-            </h3>
+          <b-col xs=12 sm=8 md=6 class="minnumfavorites">
+            <h4>
+              You have {{ this.numFavorites }} favorites from {{ this.numNeighbors }} different users, and need at least
+              {{ appConfig.minNumFavoritesForRecommendations }} favorites from at least
+              {{ appConfig.minNumNeighborsForRecommendations }} different users.
+            </h4>
           </b-col>
         </b-row>
       </div>
-      <div v-else>
-        <b-row align-h="center">
-          <b-col cols=8>
-            <b-button block variant='primary' class="torecommendations" @click="toRecommendations()">
-                Take me to my recommendations
-            </b-button>
-          </b-col>
-        </b-row>
-      </div>
-      <b-row align-h="center">
-        <b-col xs=12 sm=8 md=6 class="minnumfavorites">
-          <h4>
-            You have {{ this.numFavorites }} favorites from {{ this.numNeighbors }} different users, and need at least
-            {{ appConfig.minNumFavoritesForRecommendations }} favorites from at least
-            {{ appConfig.minNumNeighborsForRecommendations }} different users.
-          </h4>
-        </b-col>
-      </b-row>
       <b-row align-h="center">
         <b-col xs=12 sm=8 md=6 class="minnumfavorites">
           <h4>
@@ -130,6 +134,9 @@ export default {
       return (this.numFavorites >= this.appConfig.minNumFavoritesForRecommendations)
         && (this.numNeighbors >= this.appConfig.minNumNeighborsForRecommendations);
     },
+    userProcessingStatusIsDirty() {
+      return this.$store.state.welcome.user.processingStatusIsDirty;
+    }
   },
   async mounted() {
     this.userName = this.$store.state.welcome.user.name;
@@ -138,6 +145,9 @@ export default {
     this.userAuthenticated = this.$store.getters.isAuthenticated();
     this.groupIds = this.appConfig.recommendedGroupsToFindFavorites;
     this.numPhotosPerGroup = this.appConfig.recommendedGroupsNumPhotosToShow;
+
+    // Refresh our store so we know how many favorites/neighbors we have
+    await this.$store.dispatch('getUserInfo', this.userId); // eslint-disable-line no-await-in-loop
   },
   methods: {
     toRecommendations() {

--- a/frontend/src/views/AddFavorites.vue
+++ b/frontend/src/views/AddFavorites.vue
@@ -26,7 +26,18 @@
       </b-row>
     </div>
     <div v-else>
-      Dude you need some recommendations
+      <b-container>
+        <GroupPhotos
+          v-for="groupId in this.groupIds"
+          v-bind:key="groupId"
+          v-bind:userId="userId"
+          v-bind:groupId="groupId"
+          v-bind:numPhotos="numPhotosPerGroup"
+          v-bind:userAuthenticated="userAuthenticated"
+          class="groupphoto"
+        >
+        </GroupPhotos>
+      </b-container>
     </div>
   </div>
 </template>
@@ -43,30 +54,44 @@
 .backtowelcome {
   margin-top: 30px;
 }
+
+.groupphoto {
+
+}
 </style>
 
 <script>
 
+import GroupPhotos from '../components/GroupPhotos.vue';
 import RepositoryFactory from '../repositories/repositoryFactory';
 
 const FlickrRepository = RepositoryFactory.get('flickr');
 
 export default {
+  components: {
+    GroupPhotos,
+  },
   data() {
     return {
       userName: '',
+      userId: '',
       profileUrl: '',
       userAuthenticated: false,
       numFavorites: 0,
       numNeighbors: 0,
+      groupIds: [],
+      numPhotosPerGroup: 0,
     };
   },
   async mounted() {
     this.userName = this.$store.state.welcome.user.name;
+    this.userId = this.$route.params.userId;
     this.profileUrl = FlickrRepository.getProfileUrl(this.$route.params.userId);
-    this.userAuthenticated = this.$store.getters.isAuthenticated();
+    this.userAuthenticated = true; // this.$store.getters.isAuthenticated();
     this.numFavorites = this.$store.state.welcome.user.numFavorites;
     this.numNeighbors = this.$store.state.welcome.user.numNeighbors;
+    this.groupIds = this.appConfig.recommendedGroupsToFindFavorites;
+    this.numPhotosPerGroup = this.appConfig.recommendedGroupsNumPhotosToShow;
   },
 };
 </script>

--- a/frontend/src/views/Recommendations.vue
+++ b/frontend/src/views/Recommendations.vue
@@ -57,8 +57,12 @@ export default {
   async mounted() {
     this.userId = this.$route.params.userId;
     this.userAuthenticated = (this.$store.getters.isAuthenticated());// && (this.userId === this.$store.state.welcome.user.id)); // Make sure that our route matches the user we authenticated with. Otherwise, if someone cheeky entered a different user into the URL bar just show the unauthenticated view
-    const numPhotos = this.$route.query && this.$route.query['num-photos'] ? this.$route.query['num-photos'] : this.appConfig.defaultNumPhotoRecommendations;
-    const numUsers = this.$route.query && this.$route.query['num-users'] ? this.$route.query['num-users'] : this.appConfig.defaultNumUserRecommendations;
+    const numPhotos = this.$route.query && this.$route.query['num-photos']
+      ? this.$route.query['num-photos']
+      : this.appConfig.defaultNumPhotoRecommendations;
+    const numUsers = this.$route.query && this.$route.query['num-users']
+      ? this.$route.query['num-users']
+      : this.appConfig.defaultNumUserRecommendations;
 
     try {
       await this.$store.dispatch('getRecommendationsForUser', { userId: this.userId, numPhotos, numUsers });

--- a/frontend/src/views/Recommendations.vue
+++ b/frontend/src/views/Recommendations.vue
@@ -57,8 +57,8 @@ export default {
   async mounted() {
     this.userId = this.$route.params.userId;
     this.userAuthenticated = (this.$store.getters.isAuthenticated());// && (this.userId === this.$store.state.welcome.user.id)); // Make sure that our route matches the user we authenticated with. Otherwise, if someone cheeky entered a different user into the URL bar just show the unauthenticated view
-    const numPhotos = this.$route.query && this.$route.query['num-photos'] ? this.$route.query['num-photos'] : 50;
-    const numUsers = this.$route.query && this.$route.query['num-users'] ? this.$route.query['num-users'] : 5;
+    const numPhotos = this.$route.query && this.$route.query['num-photos'] ? this.$route.query['num-photos'] : this.appConfig.defaultNumPhotoRecommendations;
+    const numUsers = this.$route.query && this.$route.query['num-users'] ? this.$route.query['num-users'] : this.appConfig.defaultNumUserRecommendations;
 
     try {
       await this.$store.dispatch('getRecommendationsForUser', { userId: this.userId, numPhotos, numUsers });

--- a/frontend/src/views/Welcome.vue
+++ b/frontend/src/views/Welcome.vue
@@ -324,16 +324,16 @@ export default {
       }
 
       // We have their data, so display their recommendations.
-      // If the router takes us to the add-favorites screen instead, the navigation will "fail" 
-      // and so this promise returned here will reject. We don't care in this case, so 
-      // just ignore the exception. 
+      // If the router takes us to the add-favorites screen instead, the navigation will "fail"
+      // and so this promise returned here will reject. We don't care in this case, so
+      // just ignore the exception.
       // See https://github.com/vuejs/vue-router/issues/2881#issuecomment-520554378
 
       this.$router.push({
         name: 'recommendations',
         params: { userId: this.$store.state.welcome.user.id },
         query: { 'num-photos': this.numPhotos, 'num-users': this.numUsers },
-      }).catch(err => {}); 
+      }).catch(() => {});
     },
     dismissPopovers() {
       // When we disable the button it won't receive mouse events anymore and so its popover will stay forever.

--- a/frontend/src/views/Welcome.vue
+++ b/frontend/src/views/Welcome.vue
@@ -180,10 +180,10 @@ export default {
         return 0;
       }
 
-      return this.$store.state.welcome.numRequestsCompleted;
+      return this.$store.getters.numRequestsCompleted;
     },
     processingInitialDataProgressMaxValue() {
-      return this.$store.state.welcome.numRequestsMade;
+      return this.$store.getters.numRequestsMade;
     },
   },
   validations: {

--- a/frontend/src/views/Welcome.vue
+++ b/frontend/src/views/Welcome.vue
@@ -149,7 +149,6 @@
 <script>
 import { validationMixin } from 'vuelidate';
 import { required, url, numeric } from 'vuelidate/lib/validators';
-import vueAuth from '../auth';
 
 export default {
   mixins: [validationMixin],
@@ -210,7 +209,7 @@ export default {
         // Refreshing can empty our store but leave our local storage with the token, so we still need to refresh our
         // store by calling getUserIdCurrentlyLoggedIn, even if we've already authenticated
 
-        if (!vueAuth.isAuthenticated()) {
+        if (!this.$store.getters.isAuthenticated()) {
           await this.$store.dispatch('login');
         }
 

--- a/frontend/src/views/Welcome.vue
+++ b/frontend/src/views/Welcome.vue
@@ -250,7 +250,6 @@ export default {
 
       // Before do anything, log out our current user (if any) because we want to be in
       // unauthenticated mode to display our results
-
       try {
         await this.$store.dispatch('logout');
       } catch (error) {
@@ -324,13 +323,17 @@ export default {
         }
       }
 
-      // We have their data, so display their recommendations
+      // We have their data, so display their recommendations.
+      // If the router takes us to the add-favorites screen instead, the navigation will "fail" 
+      // and so this promise returned here will reject. We don't care in this case, so 
+      // just ignore the exception. 
+      // See https://github.com/vuejs/vue-router/issues/2881#issuecomment-520554378
 
       this.$router.push({
         name: 'recommendations',
         params: { userId: this.$store.state.welcome.user.id },
         query: { 'num-photos': this.numPhotos, 'num-users': this.numUsers },
-      });
+      }).catch(err => {}); 
     },
     dismissPopovers() {
       // When we disable the button it won't receive mouse events anymore and so its popover will stay forever.

--- a/frontend/src/views/Welcome.vue
+++ b/frontend/src/views/Welcome.vue
@@ -171,13 +171,6 @@ export default {
         && (this.currentState !== 'none');
     },
     processingInitialDataProgressCurrentValue() {
-      // A request isn't completely finished until it's both been pulled from the external API and
-      // ingested into our database, so pick the minimum here.
-      const numRequestsCompleted = Math.min(
-        this.$store.state.welcome.user.numPullerRequestsFinished,
-        this.$store.state.welcome.user.numIngesterRequestsFinished,
-      );
-
       if (this.processingInitialDataProgressMaxValue <= 2) {
         // We initially make 2 requests for a given user: for their favorites and for their contacts.
         // Once the initial request for their favorites comes back, we know how many neighbors they
@@ -188,15 +181,10 @@ export default {
         return 0;
       }
 
-      return numRequestsCompleted;
+      return this.$store.state.welcome.numRequestsCompleted;
     },
     processingInitialDataProgressMaxValue() {
-      // These 2 numbers should be the same (we have a one-to-one mapping of puller requests to
-      // ingester requests), but pick the max just to be safe.
-      return Math.max(
-        this.$store.state.welcome.user.numPullerRequestsMade,
-        this.$store.state.welcome.user.numIngesterRequestsMade,
-      );
+      return this.$store.state.welcome.numRequestsMade;
     },
   },
   validations: {

--- a/frontend/vue.config.js
+++ b/frontend/vue.config.js
@@ -7,6 +7,7 @@ module.exports = {
         target: 'http://localhost:4445',
       },
     },
+    https: true, // vue-authenticate seems to always redirect us to https even when we explicitly specify http in the redirect url. So we need to serve https always, which will mean adding a security exception for localhost
   },
 
   pluginOptions: {

--- a/terraform/dev/main.tf
+++ b/terraform/dev/main.tf
@@ -33,9 +33,9 @@ module "elastic_container_service" {
     extra_security_groups = ["${module.api_server.security_group_id}"]
 
     instance_type = "t2.micro"#"c5.large"#"t2.micro"
-    cluster_desired_size = 0#2#20
+    cluster_desired_size = 2#0#2#20
     cluster_min_size = 0
-    cluster_max_size = 0#2#20
+    cluster_max_size = 2#0#2#20
     instances_log_retention_days = 1
 }
 
@@ -330,7 +330,7 @@ module "frontend" {
     retain_frontend_access_logs_after_destroy = "false" # For dev, we don't care about retaining these logs after doing a terraform destroy
     days_to_keep_frontend_access_logs = 1
 
-    use_https                   = "false"
+    use_custom_domain           = "false"
     ssl_certificate_body        = "${var.ssl_certificate_body}"
     ssl_certificate_private_key = "${var.ssl_certificate_private_key}"
     ssl_certificate_chain       = "${var.ssl_certificate_chain}"

--- a/terraform/dev/main.tf
+++ b/terraform/dev/main.tf
@@ -305,6 +305,7 @@ module "api_server" {
 
     default_num_photo_recommendations = 10
     default_num_user_recommendations = 5
+    default_num_photos_from_group = 20
 }
 
 module "frontend" {

--- a/terraform/modules/api-server/parameter-store.tf
+++ b/terraform/modules/api-server/parameter-store.tf
@@ -163,6 +163,13 @@ resource "aws_ssm_parameter" "default_num_user_recommendations" {
     value       = "${var.default_num_user_recommendations}"
 }
 
+resource "aws_ssm_parameter" "default_num_photos_from_group" {
+    name        = "/${var.environment}/api-server/default-num-photos-from-group"
+    description = "Number of photos from a group we return if the caller doesn't specify"
+    type        = "String"
+    value       = "${var.default_num_photos_from_group}"
+}
+
 resource "aws_ssm_parameter" "puller_queue_url" {
     name        = "/${var.environment}/api-server/puller-queue-url"
     description = "URL of the queue to put requests for data to be pulled"

--- a/terraform/modules/api-server/variables.tf
+++ b/terraform/modules/api-server/variables.tf
@@ -31,6 +31,7 @@ variable "bucketname_user_string" {}
 variable "retain_load_balancer_access_logs_after_destroy" {}
 variable "default_num_photo_recommendations" {}
 variable "default_num_user_recommendations" {}
+variable "default_num_photos_from_group" {}
 variable "flickr_api_key" {}
 variable "flickr_secret_key" {}
 variable "flickr_api_retries" {}

--- a/terraform/modules/frontend/cloudfront.tf
+++ b/terraform/modules/frontend/cloudfront.tf
@@ -23,7 +23,7 @@ provider "aws" {
 
 resource "aws_acm_certificate" "cert" {
     provider            = "aws.use1"
-    count               = "${var.use_https == "true" ? 1 : 0}"
+    count               = "${var.use_custom_domain == "true" ? 1 : 0}"
     certificate_body    = "${var.ssl_certificate_body}"
     private_key         = "${var.ssl_certificate_private_key}"
     certificate_chain   = "${var.ssl_certificate_chain}"
@@ -33,7 +33,7 @@ resource "aws_cloudfront_distribution" "application" {
     
     enabled = true
     default_root_object = "index.html"
-    aliases = "${slice(local.application_domains, 0, var.use_https == "true" ? length(local.application_domains) : 0)}" # Needs to optionally be an empty list. Workaround from: https://github.com/hashicorp/terraform/issues/18259
+    aliases = "${slice(local.application_domains, 0, var.use_custom_domain == "true" ? length(local.application_domains) : 0)}" # Needs to optionally be an empty list. Workaround from: https://github.com/hashicorp/terraform/issues/18259
 
     # Our S3 bucket
     origin {
@@ -78,7 +78,7 @@ resource "aws_cloudfront_distribution" "application" {
             }
         }
 
-        viewer_protocol_policy = "${var.use_https == "true" ? "redirect-to-https" : "allow-all"}"
+        viewer_protocol_policy = "redirect-to-https"
         min_ttl                = 0
         default_ttl            = 0
         max_ttl                = 0
@@ -98,7 +98,7 @@ resource "aws_cloudfront_distribution" "application" {
             }
         }
 
-        viewer_protocol_policy = "${var.use_https == "true" ? "redirect-to-https" : "allow-all"}"
+        viewer_protocol_policy = "redirect-to-https"
         min_ttl                = 0
         default_ttl            = 3600
         max_ttl                = 86400
@@ -119,8 +119,8 @@ resource "aws_cloudfront_distribution" "application" {
     }
 
     viewer_certificate {
-        cloudfront_default_certificate = "${var.use_https != "true"}" # In dev, for now, we can just visit our site through cloudfront directly rather than through a domain
+        cloudfront_default_certificate = "${var.use_custom_domain != "true"}" # In dev, for now, we can just visit our site through cloudfront directly rather than through a domain
         acm_certificate_arn = "${element(concat(aws_acm_certificate.cert.*.arn, list("")), 0)}" # There's either 1 or 0 certs, so the 0th element is either the cert or empty string
-        ssl_support_method = "${var.use_https == "true" ? "sni-only" : ""}" # If cloudfront_default_certificate is set then this won't be set. But terraform will try to set it everytime it runs, which takes a good 15 minutes each time
+        ssl_support_method = "${var.use_custom_domain == "true" ? "sni-only" : ""}" # If cloudfront_default_certificate is set then this won't be set. But terraform will try to set it everytime it runs, which takes a good 15 minutes each time
     }
 }

--- a/terraform/modules/frontend/variables.tf
+++ b/terraform/modules/frontend/variables.tf
@@ -11,7 +11,7 @@ variable "frontend_access_logs_bucket" {}
 variable "retain_frontend_access_logs_after_destroy" {}
 variable "days_to_keep_frontend_access_logs" {}
 variable "bucketname_user_string" {}
-variable "use_https" {}
+variable "use_custom_domain" {}
 variable "ssl_certificate_body" {}
 variable "ssl_certificate_private_key" {}
 variable "ssl_certificate_chain" {}

--- a/terraform/prod/main.tf
+++ b/terraform/prod/main.tf
@@ -305,6 +305,7 @@ module "api_server" {
 
     default_num_photo_recommendations = 10
     default_num_user_recommendations = 5
+    default_num_photos_from_group = 20
 }
 
 module "frontend" {

--- a/terraform/prod/main.tf
+++ b/terraform/prod/main.tf
@@ -330,7 +330,7 @@ module "frontend" {
     retain_frontend_access_logs_after_destroy = "false" # For dev, we don't care about retaining these logs after doing a terraform destroy
     days_to_keep_frontend_access_logs = 30
 
-    use_https                   = "true"
+    use_custom_domain           = "true"
     ssl_certificate_body        = "${var.ssl_certificate_body}"
     ssl_certificate_private_key = "${var.ssl_certificate_private_key}"
     ssl_certificate_chain       = "${var.ssl_certificate_chain}"


### PR DESCRIPTION
If a user only has a couple of favorites, or their favorites are only from a small number of users then it's hard to generate meaningful recommendations. So if such a user tries the system then we take them to a separate screen where they can add some favorites from a selection of Flickr groups, and then once they've picked enough we can take them to their recommendations.

- Added AddFavorites screen when not enough favorites
- Switched dev (both desktop and cloudfront) to https because there seems to be a browser behavior change that wants to redirect to https even when the redirect URL is http
- Changed add favorite API function to not die if the user already had that favorite
- Workaround for bug in the Flickr API where the login test function sometimes returns the wrong user, seemingly when > 1 user is using the same machine