### PR TITLE
Add 404 handler to API server to eliminate spurious exceptions

### DIFF
--- a/backend/api-server/api-server.py
+++ b/backend/api-server/api-server.py
@@ -683,6 +683,10 @@ def get_favicon():
 def user_not_specified(error=None):
     return "User not specified", status.HTTP_400_BAD_REQUEST
 
+@application.errorhandler(status.HTTP_404_NOT_FOUND)
+def path_not_found(error=None):
+    return "404 not found", status.HTTP_404_NOT_FOUND
+
 @application.errorhandler(status.HTTP_400_BAD_REQUEST)
 def parameter_not_specified(param_name, error=None):
     return f"Parameter {param_name} not specified", status.HTTP_400_BAD_REQUEST


### PR DESCRIPTION
From time to time, someone scanning the Internet will happen upon our API server and request `/` which gives a 404, which throws an unhandled exception, which triggers an alarm.

This adds a 404 handler so the exception is no longer thrown.