### PR TITLE
Made the Scheduler ask how long until the next user needs to be updated

### DIFF
--- a/README.md
+++ b/README.md
@@ -235,9 +235,6 @@ Point your browser there and enjoy!
 - Make batch messages for both types of response readers, rather than sending each message individually
 - Have dismissed photos + users feed back into recommendations with negative scores
 - Make visualization of how many instances of each process are doing work at a given time - send task ID to metics and get a count of distinct IDs?
-- Have Scheduler ask for the number of seconds until the next user needs updating, then sleep for that long
-  - Note that would miss new users that get added in the meantime
-  - We can have the API server request data for a new user when it is created
 - Need to have the browser authenticate with the API server to prevent API abuse of users whose tokens we have 
   - Same as CSRF prevention or different?
   - AWS API Gateway?
@@ -248,3 +245,4 @@ Point your browser there and enjoy!
 - Investigate why puller-flickr often has such a long max time to process a single user
 - Remove already-favorited images from the AddFavorites screen
 - Add logout to the navigation bar
+- Upgrade to Python 3.8 (especially updating the unhandled exception handler)

--- a/backend/api-server/api-server.py
+++ b/backend/api-server/api-server.py
@@ -163,7 +163,7 @@ def flickr_auth():
         return_value = {
             'oauth_token': request_token['oauth_token']
             # The example shows passing back the secret as well, but it's ignored
-            # by the vue-authenticate library
+            # by the vue-authenticate library. Plus we really don't want to be passing around secrets to the user
         }
 
         return jsonify(return_value)
@@ -200,7 +200,7 @@ def flickr_auth():
         return_value = {
             'access_token': flickr_auth_wrapper.get_flickr_access_token_as_string_no_secret(access_token) # Return a version of the token that doesn't include the secret. We'll fill it in from the database on subsequent calls
             # The example shows passing back the secret as well, but it's ignored
-            # by the vue-authenticate library
+            # by the vue-authenticate library. Plus we really don't want to be passing around secrets to the user
         }
 
         return jsonify(return_value)
@@ -370,6 +370,17 @@ def create_user(user_id=None):
 
     favorites_store.create_user(user_id)
 
+    # Request the puller get all favorites data for this user right away rather than waiting for the Scheduler to wake up and ask for us.
+    # This allows us to let the Scheduler sleep for long periods of time rather than constantly polling for new users.
+
+    logging.info(f"About to make a puller request to {puller_queue_url} to get the favorites of the favorited image {image_owner}")
+
+    puller_requests_for_user = PullerQueueItem.get_messages_to_request_all_data_for_user(user_id)
+
+    flickr_puller_queue.send_messages(objects=puller_requests_for_user, to_string=lambda queue_item : queue_item.to_json())
+
+    favorites_store.data_requested(user_id, len(puller_requests_for_user))
+
     user_info = favorites_store.get_user_info(user_id)
 
     resp = jsonify(user_info)
@@ -446,6 +457,18 @@ def get_users_that_need_update():
     users = favorites_store.get_users_that_need_updated(int(num_seconds_between_updates))
 
     resp = jsonify(users)
+    resp.status_code = status.HTTP_200_OK
+
+    return resp
+
+# Gets the number of seconds since the least recent user had their data refreshed
+@application.route("/api/users/max-seconds-since-last-update", methods = ['GET'])
+def get_max_seconds_since_last_update():
+    num_seconds = favorites_store.get_max_seconds_since_last_update()
+
+    resp = jsonify({
+        'max-seconds-since-last-update': num_seconds
+    })
     resp.status_code = status.HTTP_200_OK
 
     return resp

--- a/backend/api-server/api-server.py
+++ b/backend/api-server/api-server.py
@@ -373,13 +373,13 @@ def create_user(user_id=None):
     # Request the puller get all favorites data for this user right away rather than waiting for the Scheduler to wake up and ask for us.
     # This allows us to let the Scheduler sleep for long periods of time rather than constantly polling for new users.
 
-    logging.info(f"About to make a puller request to {puller_queue_url} to get the favorites of the favorited image {image_owner}")
+    logging.info(f"About to make a puller request to {puller_queue_url} to get the favorites of new user {user_id}")
 
     puller_requests_for_user = PullerQueueItem.get_messages_to_request_all_data_for_user(user_id)
 
     flickr_puller_queue.send_messages(objects=puller_requests_for_user, to_string=lambda queue_item : queue_item.to_json())
 
-    favorites_store.data_requested(user_id, len(puller_requests_for_user))
+    favorites_store.user_data_requested(user_id, len(puller_requests_for_user))
 
     user_info = favorites_store.get_user_info(user_id)
 

--- a/backend/api-server/favoritesstoredatabase.py
+++ b/backend/api-server/favoritesstoredatabase.py
@@ -437,6 +437,36 @@ class FavoritesStoreDatabase:
             cursor.close()
             cnx.close()            
 
+    def get_max_seconds_since_last_update(self):
+        cnx = self.cnxpool.get_connection()
+
+        cursor = cnx.cursor() 
+
+        try:
+            cursor.execute("""
+                SELECT
+                    MAX(TIMESTAMPDIFF(SECOND, IFNULL(data_last_requested_at, TIMESTAMP('1970-01-01')), NOW())) AS seconds 
+                FROM
+                    registered_users;
+                ;
+            """)
+
+            seconds = -1
+
+            row = self._get_first_row(cursor)
+
+            if row is not None:
+                seconds = int(row[0])
+
+            return seconds
+
+        except Exception as e:
+            raise FavoritesStoreException from e
+
+        finally:
+            cursor.close()
+            cnx.close()   
+
     def get_users_that_are_currently_updating(self):
         cnx = self.cnxpool.get_connection()
 

--- a/backend/api-server/favoritesstoredatabase.py
+++ b/backend/api-server/favoritesstoredatabase.py
@@ -455,7 +455,7 @@ class FavoritesStoreDatabase:
 
             row = self._get_first_row(cursor)
 
-            if row is not None:
+            if (row is not None) and (row[0] is not None):
                 seconds = int(row[0])
 
             return seconds

--- a/backend/common/flickrapiwrapper.py
+++ b/backend/common/flickrapiwrapper.py
@@ -292,16 +292,18 @@ class FlickrApiWrapper:
 
             except flickrapi.exceptions.FlickrError as e:
 
-                # For known error numbers, the caller needs to deal with the exception because
-                # the same number can mean something different depending on what the original call was.
-                # 
-                # For example, error code 1 usually means "<user|grouop|photo|etc> ID not found", except
-                # for flickr.contacts.getList() where it means "Invalid sort parameter".
-                # Note that we instead call flickr.contacts.getPublicList() where it *does* in fact mean
-                # "user ID not found", but it seems like a frustrating gotcha to assume it always means
-                # that for every call. Better to force the programmer to check each time a new call is added.
-                if e.code <= 116:
-                    raise e
+                if e.code is not None: # For some calls that are returned status 500, the error code is not set
+
+                    # For known error numbers, the caller needs to deal with the exception because
+                    # the same number can mean something different depending on what the original call was.
+                    # 
+                    # For example, error code 1 usually means "<user|grouop|photo|etc> ID not found", except
+                    # for flickr.contacts.getList() where it means "Invalid sort parameter".
+                    # Note that we instead call flickr.contacts.getPublicList() where it *does* in fact mean
+                    # "user ID not found", but it seems like a frustrating gotcha to assume it always means
+                    # that for every call. Better to force the programmer to check each time a new call is added.
+                    if e.code <= 116:
+                        raise e
 
                 # You get random 502s when making lots of calls to this API, which apparently indicate rate limiting: 
                 # https://www.flickr.com/groups/51035612836@N01/discuss/72157646430151464/ 

--- a/backend/common/flickrapiwrapper.py
+++ b/backend/common/flickrapiwrapper.py
@@ -169,8 +169,13 @@ class FlickrApiWrapper:
         while not got_all_favorites and (len(favorites) < max_favorites_to_get) and (current_page <= max_calls_to_make):
             favorites_subset = self._get_favorites_page(user_id, current_page, max_favorites_per_call)
 
-            if len(favorites_subset['photos']['photo']) > 0: # We can't just check if the number we got back == the number we requested, because frequently we can get back < the number we requested but there's still more available. This is likely due to not having permission to be able to view all of the ones we requested
-                favorites.extend(favorites_subset['photos']['photo'])
+            favorites_subset_found = []
+
+            if 'photo' in favorites_subset['photos']:
+                favorites_subset_found = favorites_subset['photos']['photo']
+
+            if len(favorites_subset_found) > 0: # We can't just check if the number we got back == the number we requested, because frequently we can get back < the number we requested but there's still more available. This is likely due to not having permission to be able to view all of the ones we requested
+                favorites.extend(favorites_subset_found)
             else:
                 got_all_favorites = True
 

--- a/backend/common/pullerqueueitem.py
+++ b/backend/common/pullerqueueitem.py
@@ -46,3 +46,15 @@ class PullerQueueItem:
     def from_json(json):
         return jsonpickle.decode(json)
         
+    @staticmethod
+    def get_messages_to_request_all_data_for_user(user_id):
+        # We can't necessarily fit a user's favorites + their contacts in a single message to the ingester queue, so split them up. 
+        # A user's favorites barely fit as is, and also that'll let us request the two datasets concurrently in 2 processes, 
+        # rather than one then the other in a single process
+
+        puller_requests_for_user = []
+
+        puller_requests_for_user.append(PullerQueueItem(user_id=user_id, initial_requesting_user_id=user_id, request_favorites=True, request_contacts=False, request_neighbor_list=True))
+        puller_requests_for_user.append(PullerQueueItem(user_id=user_id, initial_requesting_user_id=user_id, request_favorites=False, request_contacts=True, request_neighbor_list=False))
+
+        return puller_requests_for_user

--- a/backend/common/usersstoreapiserver.py
+++ b/backend/common/usersstoreapiserver.py
@@ -26,6 +26,22 @@ class UsersStoreAPIServer:
         except HTTPError as http_err:
             raise UsersStoreException from http_err
 
+    def get_max_seconds_since_last_update(self):
+
+        try:
+            response = requests.get(f"{self.url_prefix}/users/max-seconds-since-last-update")
+
+            response.raise_for_status()
+
+            response.encoding = "utf-8"
+
+            response_object = response.json()
+
+            return int(response_object['max-seconds-since-last-update'])
+
+        except HTTPError as http_err:
+            raise UsersStoreException from http_err
+
     def get_users_that_are_currently_updating(self):
 
         try:

--- a/backend/ingester-response-reader/ingester-response-reader.py
+++ b/backend/ingester-response-reader/ingester-response-reader.py
@@ -92,7 +92,7 @@ try:
 
         if processing_status['finished_processing']:
             time_in_seconds = users_store.get_time_to_update_all_data(initial_requesting_user_id)
-            logging.info(f"We have finished processing user {initial_requesting_user_id}. It took {time_in_seconds}")
+            logging.info(f"We have finished processing user {initial_requesting_user_id}. It took {time_in_seconds} seconds")
             metrics_helper.send_time("time_to_get_all_data", time_in_seconds)
 
 except UsersStoreException as e:

--- a/frontend/src/main.js
+++ b/frontend/src/main.js
@@ -15,5 +15,5 @@ Vue.prototype.appConfig = config;
 new Vue({
   router,
   store,
-  render: h => h(App),
+  render: (h) => h(App),
 }).$mount('#app');

--- a/frontend/src/repositories/flickrRepository.js
+++ b/frontend/src/repositories/flickrRepository.js
@@ -9,7 +9,7 @@ import vueAuth from '../auth';
 
 const resource = '/flickr';
 
-const getProfileUrl = userId => `https://www.flickr.com/photos/${userId}/`;
+const getProfileUrl = (userId) => `https://www.flickr.com/photos/${userId}/`;
 
 export default {
   async getUserIdFromUrl(userUrl) {
@@ -68,7 +68,7 @@ export default {
     const response = await repository.get(`${resource}/groups/pools/get-photos`, { params: { 'group-id': groupId, 'num-photos': numPhotos } });
 
     const photos = response.data.photos.photo.map(
-      photo => ({
+      (photo) => ({
         imageId: photo.id,
         imageOwner: photo.owner,
         imageUrl: 'url_l' in photo ? photo.url_l : ('url_m' in photo ? photo.url_m : ''), // eslint-disable-line no-nested-ternary

--- a/frontend/src/repositories/repositoryFactory.js
+++ b/frontend/src/repositories/repositoryFactory.js
@@ -7,5 +7,5 @@ const repositories = {
 };
 
 export default {
-  get: name => repositories[name],
+  get: (name) => repositories[name],
 };

--- a/frontend/src/stores/Welcome.js
+++ b/frontend/src/stores/Welcome.js
@@ -24,13 +24,13 @@ export default {
   getters: {
     // A request isn't completely finished until it's both been pulled from the external API and
     // ingested into our database, so pick the minimum here.
-    numRequestsCompleted: state => Math.min(
+    numRequestsCompleted: (state) => Math.min(
       state.user.numPullerRequestsFinished,
       state.user.numIngesterRequestsFinished,
     ),
     // These 2 numbers should be the same (we have a one-to-one mapping of puller requests to
     // ingester requests), but pick the max just to be safe.
-    numRequestsMade: state => Math.max(
+    numRequestsMade: (state) => Math.max(
       state.user.numPullerRequestsMade,
       state.user.numIngesterRequestsMade,
     ),

--- a/frontend/src/views/AddFavorites.vue
+++ b/frontend/src/views/AddFavorites.vue
@@ -172,7 +172,7 @@ export default {
       // The lint error is intended to encourage better performance by having people await multiple things rather than one at a time.
 
       async function delay(ms) {
-        return new Promise(resolve => setTimeout(resolve, ms));
+        return new Promise((resolve) => setTimeout(resolve, ms));
       }
 
       await this.getUserInfo();

--- a/frontend/src/views/Welcome.vue
+++ b/frontend/src/views/Welcome.vue
@@ -295,7 +295,7 @@ export default {
       // The lint error is intended to encourage better performance by having people await multiple things rather than one at a time.
 
       async function delay(ms) {
-        return new Promise(resolve => setTimeout(resolve, ms));
+        return new Promise((resolve) => setTimeout(resolve, ms));
       }
 
       while (!this.$store.state.welcome.user.haveInitiallyProcessedData) {

--- a/terraform/dev/main.tf
+++ b/terraform/dev/main.tf
@@ -92,7 +92,7 @@ module "memcached" {
     vpc_cidr                = "${module.vpc.vpc_cidr_block}"
 
     memcached_node_type = "cache.t2.micro"
-    memcached_num_cache_nodes = 1 # Set to 0 to disable memcached in dev to save billing charges
+    memcached_num_cache_nodes = 0 # Set to 0 to disable memcached in dev to save billing charges
     memcached_az_mode = "single-az" # Single az in dev to save billing charges
 }
 

--- a/terraform/dev/main.tf
+++ b/terraform/dev/main.tf
@@ -49,9 +49,9 @@ module "elastic_container_service" {
     extra_security_groups = ["${module.api_server.security_group_id}"]
 
     instance_type = "t2.micro"#"c5.large"#"t2.micro"
-    cluster_desired_size = 0#2#20
+    cluster_desired_size = 2#0#2#20
     cluster_min_size = 0
-    cluster_max_size = 0#2#20
+    cluster_max_size = 2#0#2#20
     instances_log_retention_days = 1
 }
 
@@ -107,7 +107,7 @@ module "scheduler" {
 
     ecs_cluster_id = "${module.elastic_container_service.cluster_id}"
     ecs_instances_role_name = "${module.elastic_container_service.instance_role_name}"
-    ecs_instances_desired_count = 0
+    ecs_instances_desired_count = 1
     ecs_instances_memory = 64
     ecs_instances_cpu = 200
     ecs_instances_log_configuration = "${module.elastic_container_service.cluster_log_configuration}"
@@ -127,7 +127,7 @@ module "scheduler" {
     puller_response_queue_long_polling_seconds = 1 # Don't do long polling for too long: we can only write out our batches to the API server after we find no more new messages
 
     max_iterations_before_exit = 1000
-    sleep_ms_between_iterations = 500
+    min_sleep_ms_between_iterations = 500
 
     duration_to_request_lock_seconds = 10
 

--- a/terraform/modules/scheduler/parameter-store.tf
+++ b/terraform/modules/scheduler/parameter-store.tf
@@ -54,11 +54,11 @@ resource "aws_ssm_parameter" "max_iterations_before_exit" {
     value       = "${var.max_iterations_before_exit}"
 }
 
-resource "aws_ssm_parameter" "sleep_ms_between_iterations" {
-    name        = "/${var.environment}/scheduler/sleep-ms-between-iterations"
-    description = "Number of milliseconds we sleep between iterations"
+resource "aws_ssm_parameter" "min_sleep_ms_between_iterations" {
+    name        = "/${var.environment}/scheduler/min-sleep-ms-between-iterations"
+    description = "Minimum number of milliseconds we sleep between iterations"
     type        = "String"
-    value       = "${var.sleep_ms_between_iterations}"
+    value       = "${var.min_sleep_ms_between_iterations}"
 }
 
 resource "aws_ssm_parameter" "duration_to_request_lock_seconds" {

--- a/terraform/modules/scheduler/variables.tf
+++ b/terraform/modules/scheduler/variables.tf
@@ -16,7 +16,7 @@ variable "scheduler_seconds_between_user_data_updates" {}
 variable "ingester_database_queue_url" {}
 variable "ingester_database_queue_arn" {}
 variable "max_iterations_before_exit" {}
-variable "sleep_ms_between_iterations" {}
+variable "min_sleep_ms_between_iterations" {}
 variable "duration_to_request_lock_seconds" {}
 variable "puller_queue_long_polling_seconds" {}
 variable "puller_response_queue_long_polling_seconds" {}


### PR DESCRIPTION
Then it can sleep for that many seconds, rather than constantly spamming the API server asking if anyone needs to be updated.

Correspondingly, changed the API server to request data for a new user when it's created rather than relying on the Scheduler to do that. This should also improve performance a little bit for new users, since that small delay won't happen anymore.

Other random fixes:

- Flickr seems to have changed how its API calls respond in some cases, so updated the corresponding code to remove some assumptions that no longer hold true
- Turned off memcached to save billing charges now that I'm past the 1 year free tier. Made some fixes to the `config-helper` to account for an invalid memcached address. Now it falls back to the disc cache properly and doesn't crash the process if it's unable to read/write to memcached
- Fixed some lint errors in the frontend caused by upgrading our linting rules earlier.