### PR TITLE
Fixed typo in API server that caused race condition

### DIFF
--- a/backend/api-server/favoritesstoredatabase.py
+++ b/backend/api-server/favoritesstoredatabase.py
@@ -656,7 +656,7 @@ class FavoritesStoreDatabase:
             num_ingester_requests_made      = row[2]
             num_ingester_requests_finished  = row[3]
 
-            if (num_puller_requests_made >= num_puller_requests_finished) and (num_ingester_requests_finished >= num_ingester_requests_made):
+            if (num_puller_requests_finished >= num_puller_requests_made) and (num_ingester_requests_finished >= num_ingester_requests_made):
                 
                 finished_processing = True
 


### PR DESCRIPTION
Sometimes a user's data would be reported as having been updated very early. This would manifest as seeing the front end jump to the results page almost immediately after requesting recommendations for a new user, despite the processing continuing on the back end.

Due to the nature of the typo, it would manifest depending on which messages were processed first: puller response messages or ingester response messages.