### PR TITLE
Upgrade to python 3.8

### DIFF
--- a/README.md
+++ b/README.md
@@ -245,4 +245,3 @@ Point your browser there and enjoy!
 - Investigate why puller-flickr often has such a long max time to process a single user
 - Remove already-favorited images from the AddFavorites screen
 - Add logout to the navigation bar
-- Upgrade to Python 3.8 (especially updating the unhandled exception handler)

--- a/backend/api-server/Dockerfile
+++ b/backend/api-server/Dockerfile
@@ -1,4 +1,6 @@
-FROM python:3.7.4-alpine
+# https://pythonspeed.com/articles/base-image-python-docker-images/
+# slim-buster makes our images approx 100MB larger than alpine
+FROM python:3.8.2-alpine
 ADD api-server/api-server.py /api-server/
 ADD api-server/photorecommendation.py /api-server/
 ADD api-server/favoritesstoredatabase.py /api-server/
@@ -14,9 +16,10 @@ ADD common/queuewriter.py /common/
 # Our OAuth lib needs the C compiler to install itself
 # https://stackoverflow.com/a/58028091
 # Cleanup taken from: https://spectrum.chat/zeit/now/best-dockerfile-for-building-a-python-container-with-compiled-dependencies~308b60c7-77fc-43de-b42a-8d14f9956ccd
-RUN apk add --no-cache --virtual .build-deps gcc=8.3.0-r0 musl-dev=1.1.22-r3 libffi-dev=3.2.1-r6 openssl-dev=1.1.1d-r2
+RUN apk add --no-cache --virtual .build-deps gcc=9.2.0-r4 musl-dev=1.1.24-r2 libffi-dev=3.2.1-r6 openssl-dev=1.1.1g-r0
 # Take advantage of layer cacheing, so that everything referenced by this file is cached if the file doesn't change:
 # https://blog.realkinetic.com/building-minimal-docker-containers-for-python-applications-37d0272c52f3
+# In practice I don't observe this happening though?
 COPY api-server/requirements.txt /
 RUN pip install -r /requirements.txt
 RUN apk del .build-deps

--- a/backend/api-server/requirements.txt
+++ b/backend/api-server/requirements.txt
@@ -1,7 +1,7 @@
 flask==1.1.1
 flask_api==1.1
 gunicorn==19.9.0
-mysql-connector-python==8.0.17
+mysql-connector-python==8.0.19
 boto3==1.9.214
 jsonpickle==1.2
 pymemcache==2.2.2

--- a/backend/ingester-database/Dockerfile
+++ b/backend/ingester-database/Dockerfile
@@ -1,4 +1,6 @@
-FROM python:3.7.4-alpine
+# https://pythonspeed.com/articles/base-image-python-docker-images/
+# slim-buster makes our images approx 100MB larger than alpine
+FROM python:3.8.2-alpine
 ADD ingester-database/ingester-database.py /ingester-database/
 ADD ingester-database/databasebatchwriter.py /ingester-database/
 ADD ingester-database/contactitem.py /ingester-database/
@@ -13,6 +15,7 @@ ADD common/unhandledexceptionhelper.py /common/
 ADD common/loop_command.sh /common/
 # Take advantage of layer cacheing, so that everything referenced by this file is cached if the file doesn't change:
 # https://blog.realkinetic.com/building-minimal-docker-containers-for-python-applications-37d0272c52f3
+# In practice I don't observe this happening though?
 COPY ingester-database/requirements.txt /
 RUN pip install -r /requirements.txt
 CMD [ "./common/loop_command.sh", "./ingester-database/ingester-database.py", "2" ]

--- a/backend/ingester-database/requirements.txt
+++ b/backend/ingester-database/requirements.txt
@@ -1,5 +1,5 @@
 boto3==1.9.214
 jsonpickle==1.2
-mysql-connector-python==8.0.17
+mysql-connector-python==8.0.19
 pymemcache==2.2.2
 diskcache==4.0.0

--- a/backend/ingester-response-reader/Dockerfile
+++ b/backend/ingester-response-reader/Dockerfile
@@ -1,4 +1,6 @@
-FROM python:3.7.4-alpine
+# https://pythonspeed.com/articles/base-image-python-docker-images/
+# slim-buster makes our images approx 100MB larger than alpine
+FROM python:3.8.2-alpine
 ADD ingester-response-reader/ingester-response-reader.py /ingester-response-reader/
 ADD common/usersstoreapiserver.py /common/
 ADD common/usersstoreexception.py /common/
@@ -10,6 +12,7 @@ ADD common/unhandledexceptionhelper.py /common/
 ADD common/loop_command.sh /common/
 # Take advantage of layer cacheing, so that everything referenced by this file is cached if the file doesn't change:
 # https://blog.realkinetic.com/building-minimal-docker-containers-for-python-applications-37d0272c52f3
+# In practice I don't observe this happening though?
 COPY ingester-response-reader/requirements.txt /
 RUN pip install -r /requirements.txt
 WORKDIR ingester-response-reader/

--- a/backend/puller-flickr/Dockerfile
+++ b/backend/puller-flickr/Dockerfile
@@ -1,4 +1,6 @@
-FROM python:3.7.4-alpine
+# https://pythonspeed.com/articles/base-image-python-docker-images/
+# slim-buster makes our images approx 100MB larger than alpine
+FROM python:3.8.2-alpine
 ADD puller-flickr/puller-flickr.py /puller-flickr/
 ADD common/flickrapiwrapper.py /puller-flickr/
 ADD common/ingesterqueuefavorite.py /common/
@@ -13,6 +15,7 @@ ADD common/unhandledexceptionhelper.py /common/
 ADD common/loop_command.sh /common/
 # Take advantage of layer cacheing, so that everything referenced by this file is cached if the file doesn't change:
 # https://blog.realkinetic.com/building-minimal-docker-containers-for-python-applications-37d0272c52f3
+# In practice I don't observe this happening though?
 COPY puller-flickr/requirements.txt /
 RUN pip install -r /requirements.txt
 CMD [ "./common/loop_command.sh", "./puller-flickr/puller-flickr.py", "2" ]

--- a/backend/puller-response-reader/Dockerfile
+++ b/backend/puller-response-reader/Dockerfile
@@ -1,4 +1,6 @@
-FROM python:3.7.4-alpine
+# https://pythonspeed.com/articles/base-image-python-docker-images/
+# slim-buster makes our images approx 100MB larger than alpine
+FROM python:3.8.2-alpine
 ADD puller-response-reader/puller-response-reader.py /puller-response-reader/
 ADD common/usersstoreapiserver.py /common/
 ADD common/usersstoreexception.py /common/
@@ -12,6 +14,7 @@ ADD common/unhandledexceptionhelper.py /common/
 ADD common/loop_command.sh /common/
 # Take advantage of layer cacheing, so that everything referenced by this file is cached if the file doesn't change:
 # https://blog.realkinetic.com/building-minimal-docker-containers-for-python-applications-37d0272c52f3
+# In practice I don't observe this happening though?
 COPY puller-response-reader/requirements.txt /
 RUN pip install -r /requirements.txt
 WORKDIR puller-response-reader/

--- a/backend/scheduler/Dockerfile
+++ b/backend/scheduler/Dockerfile
@@ -1,4 +1,6 @@
-FROM python:3.7.4-alpine
+# https://pythonspeed.com/articles/base-image-python-docker-images/
+# slim-buster makes our images approx 100MB larger than alpine
+FROM python:3.8.2-alpine
 ADD scheduler/scheduler.py /scheduler/
 ADD common/usersstoreapiserver.py /common/
 ADD common/usersstoreexception.py /common/
@@ -13,6 +15,7 @@ ADD common/executionenvironmenthelper.py /common/
 ADD common/loop_command.sh /common/
 # Take advantage of layer cacheing, so that everything referenced by this file is cached if the file doesn't change:
 # https://blog.realkinetic.com/building-minimal-docker-containers-for-python-applications-37d0272c52f3
+# In practice I don't observe this happening though?
 COPY scheduler/requirements.txt /
 RUN pip install -r /requirements.txt
 WORKDIR scheduler/


### PR DESCRIPTION
Upgrade the backend processes to use python 3.8 so we can take advantage of its thread exception handler hook.

- Upgrade all processes to python 3.8
- Update some dependencies that didn't work with python 3.8
- Remove our hack from the unhandled exception handler in favour of python 3.8's new hook