### PR TITLE
Upgrade to terraform 0.12

### DIFF
--- a/README.md
+++ b/README.md
@@ -221,7 +221,7 @@ Point your browser there and enjoy!
 
 ## To do
 
-- Upgrade to terraform v0.12
+- Upgrade to terraform from v0.11.14 -> v0.12.26: https://blog.gruntwork.io/installing-multiple-versions-of-terraform-with-homebrew-899f6d124ff9
 - Consider moving MySQL passwords into config files rather than passing on command line from terraform script
 - Add tests
 - Look into how to lock versions of python dependencies of our dependencies (rather than just the packages we explicitly reference)

--- a/README.md
+++ b/README.md
@@ -221,7 +221,6 @@ Point your browser there and enjoy!
 
 ## To do
 
-- Upgrade to terraform from v0.11.14 -> v0.12.26: https://blog.gruntwork.io/installing-multiple-versions-of-terraform-with-homebrew-899f6d124ff9
 - Consider moving MySQL passwords into config files rather than passing on command line from terraform script
 - Add tests
 - Look into how to lock versions of python dependencies of our dependencies (rather than just the packages we explicitly reference)

--- a/terraform/dev/main.tf
+++ b/terraform/dev/main.tf
@@ -1,485 +1,486 @@
 module "vpc" {
-    source = "../modules/vpc"
+  source = "../modules/vpc"
 
-    vpc_name = "photo-recommender"
-    environment = "${var.environment}"
+  vpc_name    = "photo-recommender"
+  environment = var.environment
 
-    cidr_block = "10.10.0.0/16"
+  cidr_block = "10.10.0.0/16"
 
-    public_subnets = {
-        us-west-2a = "10.10.1.0/24"
-        us-west-2b = "10.10.2.0/24"
-    }
+  public_subnets = {
+    us-west-2a = "10.10.1.0/24"
+    us-west-2b = "10.10.2.0/24"
+  }
 
-    private_subnets = {
-        us-west-2a = "10.10.3.0/24"
-        us-west-2b = "10.10.4.0/24"
-    }
+  private_subnets = {
+    us-west-2a = "10.10.3.0/24"
+    us-west-2b = "10.10.4.0/24"
+  }
 }
 
 module "encryption" {
-    source = "../modules/encryption"
+  source = "../modules/encryption"
 
-    environment = "${var.environment}"
+  environment = var.environment
 }
 
 module "build-common-infrastructure" {
-    source = "../modules/build-common-infrastructure"
+  source = "../modules/build-common-infrastructure"
 
-    environment = "${var.environment}"
-    environment_long_name = "${var.environment_long_name}"
-    region = "${var.region}"
+  environment           = var.environment
+  environment_long_name = var.environment_long_name
+  region                = var.region
 
-    project_github_location = "${var.project_github_location}"
-    s3_deployment_bucket_arn = "${module.frontend.s3_deployment_bucket_arn}"
+  project_github_location  = var.project_github_location
+  s3_deployment_bucket_arn = module.frontend.s3_deployment_bucket_arn
 
-    build_logs_bucket = "build-logs"
-    bucketname_user_string  = "${var.bucketname_user_string}"
-    retain_build_logs_after_destroy = "false" # For dev, we don't care about retaining these logs after doing a terraform destroy
-    days_to_keep_build_logs = 1
+  build_logs_bucket               = "build-logs"
+  bucketname_user_string          = var.bucketname_user_string
+  retain_build_logs_after_destroy = "false" # For dev, we don't care about retaining these logs after doing a terraform destroy
+  days_to_keep_build_logs         = 1
 }
 
 module "elastic_container_service" {
-    source = "../modules/elastic-container-service"
+  source = "../modules/elastic-container-service"
 
-    environment = "${var.environment}"
-    region = "${var.region}"
-    cluster_name = "photo-recommender"
+  environment  = var.environment
+  region       = var.region
+  cluster_name = "photo-recommender"
 
-    vpc_id = "${module.vpc.vpc_id}"
-    vpc_public_subnet_ids = "${module.vpc.vpc_public_subnet_ids}"
+  vpc_id                = module.vpc.vpc_id
+  vpc_public_subnet_ids = module.vpc.vpc_public_subnet_ids
 
-    local_machine_cidr = "${var.local_machine_cidr}"
-    local_machine_public_key = "${var.local_machine_public_key}"
+  local_machine_cidr       = var.local_machine_cidr
+  local_machine_public_key = var.local_machine_public_key
 
-    extra_security_groups = ["${module.api_server.security_group_id}"]
+  extra_security_groups = [module.api_server.security_group_id]
 
-    instance_type = "t2.micro"#"c5.large"#"t2.micro"
-    cluster_desired_size = 2#0#2#20
-    cluster_min_size = 0
-    cluster_max_size = 2#0#2#20
-    instances_log_retention_days = 1
+  instance_type                = "t2.micro" #"c5.large"#"t2.micro"
+  cluster_desired_size         = 2          #0#2#20
+  cluster_min_size             = 0
+  cluster_max_size             = 2 #0#2#20
+  instances_log_retention_days = 1
 }
 
 module "database" {
-    source = "../modules/database"
+  source = "../modules/database"
 
-    environment = "${var.environment}"
-    region = "${var.region}"
+  environment = var.environment
+  region      = var.region
 
-    vpc_id                  = "${module.vpc.vpc_id}"
-    vpc_public_subnet_ids   = "${module.vpc.vpc_public_subnet_ids}"
-    vpc_cidr                = "${module.vpc.vpc_cidr_block}"
-    local_machine_cidr      = "${var.local_machine_cidr}"
+  vpc_id                = module.vpc.vpc_id
+  vpc_public_subnet_ids = module.vpc.vpc_public_subnet_ids
+  vpc_cidr              = module.vpc.vpc_cidr_block
+  local_machine_cidr    = var.local_machine_cidr
 
-    mysql_database_name     = "photorecommender"
-    mysql_instance_type     = "db.t2.micro"#"db.m5.large"#"db.t2.micro" 
-    mysql_storage_encrypted = false # db.t2.micro doesn't support encryption at rest -- needs to be at least db.t2.small
-    mysql_storage_type      = "gp2" # General purpose SSD
-    mysql_database_size_gb  = 5
-    mysql_multi_az          = false # Disable database multi-AZ in dev to save billing charges
-    mysql_backup_retention_period_days = 3
-    mysql_deletion_protection = false # No need for deletion protection in dev
+  mysql_database_name                = "photorecommender"
+  mysql_instance_type                = "db.t2.micro" #"db.m5.large"#"db.t2.micro" 
+  mysql_storage_encrypted            = false         # db.t2.micro doesn't support encryption at rest -- needs to be at least db.t2.small
+  mysql_storage_type                 = "gp2"         # General purpose SSD
+  mysql_database_size_gb             = 5
+  mysql_multi_az                     = false # Disable database multi-AZ in dev to save billing charges
+  mysql_backup_retention_period_days = 3
+  mysql_deletion_protection          = false # No need for deletion protection in dev
 
-    mysql_database_password = "${var.database_password_dev}"
-    kms_key_arn             = "${module.encryption.kms_key_arn}"
+  mysql_database_password = var.database_password_dev
+  kms_key_arn             = module.encryption.kms_key_arn
 }
 
 module "memcached" {
-    source = "../modules/memcached"
+  source = "../modules/memcached"
 
-    # Note that some sensitive info can get stored here, such as temporary tokens during the flickr auth process.
-    # Thus, this instance isn't accessible publicly.
+  # Note that some sensitive info can get stored here, such as temporary tokens during the flickr auth process.
+  # Thus, this instance isn't accessible publicly.
 
-    environment = "${var.environment}"
-    region = "${var.region}"
+  environment = var.environment
+  region      = var.region
 
-    vpc_id                  = "${module.vpc.vpc_id}"
-    vpc_public_subnet_ids   = "${module.vpc.vpc_private_subnet_ids}"
-    vpc_cidr                = "${module.vpc.vpc_cidr_block}"
+  vpc_id                = module.vpc.vpc_id
+  vpc_public_subnet_ids = module.vpc.vpc_private_subnet_ids
+  vpc_cidr              = module.vpc.vpc_cidr_block
 
-    memcached_node_type = "cache.t2.micro"
-    memcached_num_cache_nodes = 0 # Set to 0 to disable memcached in dev to save billing charges
-    memcached_az_mode = "single-az" # Single az in dev to save billing charges
+  memcached_node_type       = "cache.t2.micro"
+  memcached_num_cache_nodes = 0           # Set to 0 to disable memcached in dev to save billing charges
+  memcached_az_mode         = "single-az" # Single az in dev to save billing charges
 }
 
 module "scheduler" {
-    source = "../modules/scheduler"
+  source = "../modules/scheduler"
 
-    environment = "${var.environment}"
-    region = "${var.region}"
-    metrics_namespace = "${var.metrics_namespace}"
+  environment       = var.environment
+  region            = var.region
+  metrics_namespace = var.metrics_namespace
 
-    parameter_memcached_location = "${module.memcached.location}"
+  parameter_memcached_location = module.memcached.location
 
-    ecs_cluster_id = "${module.elastic_container_service.cluster_id}"
-    ecs_instances_role_name = "${module.elastic_container_service.instance_role_name}"
-    ecs_instances_desired_count = 1
-    ecs_instances_memory = 64
-    ecs_instances_cpu = 200
-    ecs_instances_log_configuration = "${module.elastic_container_service.cluster_log_configuration}"
-    ecs_days_to_keep_images = 1#0
+  ecs_cluster_id                  = module.elastic_container_service.cluster_id
+  ecs_instances_role_name         = module.elastic_container_service.instance_role_name
+  ecs_instances_desired_count     = 1
+  ecs_instances_memory            = 64
+  ecs_instances_cpu               = 200
+  ecs_instances_log_configuration = module.elastic_container_service.cluster_log_configuration
+  ecs_days_to_keep_images         = 1 #0
 
-    api_server_host = "${module.api_server.load_balancer_dns_name}"
-    api_server_port = "${module.api_server.load_balancer_port}"
+  api_server_host = module.api_server.load_balancer_dns_name
+  api_server_port = module.api_server.load_balancer_port
 
-    scheduler_seconds_between_user_data_updates = 7200
+  scheduler_seconds_between_user_data_updates = 7200
 
-    puller_queue_batch_size = 10
+  puller_queue_batch_size = 10
 
-    ingester_database_queue_url = "${module.ingester_database.ingester_queue_url}"
-    ingester_database_queue_arn = "${module.ingester_database.ingester_queue_arn}"
+  ingester_database_queue_url = module.ingester_database.ingester_queue_url
+  ingester_database_queue_arn = module.ingester_database.ingester_queue_arn
 
-    puller_queue_long_polling_seconds = 10 # We can poll as long as we want, because nothing happens when we find no more new messages other than we restart
-    puller_response_queue_long_polling_seconds = 1 # Don't do long polling for too long: we can only write out our batches to the API server after we find no more new messages
+  puller_queue_long_polling_seconds          = 10 # We can poll as long as we want, because nothing happens when we find no more new messages other than we restart
+  puller_response_queue_long_polling_seconds = 1  # Don't do long polling for too long: we can only write out our batches to the API server after we find no more new messages
 
-    max_iterations_before_exit = 1000
-    min_sleep_ms_between_iterations = 500
+  max_iterations_before_exit      = 1000
+  min_sleep_ms_between_iterations = 500
 
-    duration_to_request_lock_seconds = 10
+  duration_to_request_lock_seconds = 10
 
-    process_name                = "scheduler"
-    project_github_location     = "${var.project_github_location}"
-    build_logs_bucket_id        = "${module.build-common-infrastructure.build_logs_bucket_id}"
-    buildspec_location          = "backend/buildspec.yml"
-    file_path                   = "backend/scheduler/*"
-    file_path_common            = "backend/common/*"
-    build_service_role_arn      = "${module.build-common-infrastructure.build_service_role_arn}"
+  process_name            = "scheduler"
+  project_github_location = var.project_github_location
+  build_logs_bucket_id    = module.build-common-infrastructure.build_logs_bucket_id
+  buildspec_location      = "backend/buildspec.yml"
+  file_path               = "backend/scheduler/*"
+  file_path_common        = "backend/common/*"
+  build_service_role_arn  = module.build-common-infrastructure.build_service_role_arn
 }
 
 module "puller-response-reader" {
-    source = "../modules/puller-response-reader"
+  source = "../modules/puller-response-reader"
 
-    environment = "${var.environment}"
-    region = "${var.region}"
-    metrics_namespace = "${var.metrics_namespace}"
+  environment       = var.environment
+  region            = var.region
+  metrics_namespace = var.metrics_namespace
 
-    parameter_memcached_location = "${module.memcached.location}"
+  parameter_memcached_location = module.memcached.location
 
-    ecs_cluster_id = "${module.elastic_container_service.cluster_id}"
-    ecs_instances_role_name = "${module.elastic_container_service.instance_role_name}"
-    ecs_instances_desired_count = 1#0#1#20
-    ecs_instances_memory = 64
-    ecs_instances_cpu = 200
-    ecs_instances_log_configuration = "${module.elastic_container_service.cluster_log_configuration}"
-    ecs_days_to_keep_images = 1
+  ecs_cluster_id                  = module.elastic_container_service.cluster_id
+  ecs_instances_role_name         = module.elastic_container_service.instance_role_name
+  ecs_instances_desired_count     = 1 #0#1#20
+  ecs_instances_memory            = 64
+  ecs_instances_cpu               = 200
+  ecs_instances_log_configuration = module.elastic_container_service.cluster_log_configuration
+  ecs_days_to_keep_images         = 1
 
-    api_server_host = "${module.api_server.load_balancer_dns_name}"
-    api_server_port = "${module.api_server.load_balancer_port}"
+  api_server_host = module.api_server.load_balancer_dns_name
+  api_server_port = module.api_server.load_balancer_port
 
-    puller_queue_url = "${module.scheduler.puller_queue_url}"
-    puller_queue_arn = "${module.scheduler.puller_queue_arn}"
-    puller_response_queue_url = "${module.scheduler.puller_response_queue_url}"
-    puller_response_queue_arn = "${module.scheduler.puller_response_queue_arn}"
+  puller_queue_url          = module.scheduler.puller_queue_url
+  puller_queue_arn          = module.scheduler.puller_queue_arn
+  puller_response_queue_url = module.scheduler.puller_response_queue_url
+  puller_response_queue_arn = module.scheduler.puller_response_queue_arn
 
-    puller_queue_batch_size = 10
+  puller_queue_batch_size = 10
 
-    puller_response_queue_batch_size = 1 # Each message takes a while to process, so hoarding a bunch of messages in an individual instance means that other instances may be underutilized
-    puller_response_queue_max_items_to_process = 10000
+  puller_response_queue_batch_size           = 1 # Each message takes a while to process, so hoarding a bunch of messages in an individual instance means that other instances may be underutilized
+  puller_response_queue_max_items_to_process = 10000
 
-    process_name                = "puller-response-reader"
-    project_github_location     = "${var.project_github_location}"
-    build_logs_bucket_id        = "${module.build-common-infrastructure.build_logs_bucket_id}"
-    buildspec_location          = "backend/buildspec.yml"
-    file_path                   = "backend/puller-response-reader/*"
-    file_path_common            = "backend/common/*"
-    build_service_role_arn      = "${module.build-common-infrastructure.build_service_role_arn}"
+  process_name            = "puller-response-reader"
+  project_github_location = var.project_github_location
+  build_logs_bucket_id    = module.build-common-infrastructure.build_logs_bucket_id
+  buildspec_location      = "backend/buildspec.yml"
+  file_path               = "backend/puller-response-reader/*"
+  file_path_common        = "backend/common/*"
+  build_service_role_arn  = module.build-common-infrastructure.build_service_role_arn
 }
 
 module "ingester_response_reader" {
-    source = "../modules/ingester-response-reader"
+  source = "../modules/ingester-response-reader"
 
-    environment = "${var.environment}"
-    region = "${var.region}"
-    metrics_namespace = "${var.metrics_namespace}"
+  environment       = var.environment
+  region            = var.region
+  metrics_namespace = var.metrics_namespace
 
-    parameter_memcached_location = "${module.memcached.location}"
+  parameter_memcached_location = module.memcached.location
 
-    ecs_cluster_id = "${module.elastic_container_service.cluster_id}"
-    ecs_instances_role_name = "${module.elastic_container_service.instance_role_name}"
-    ecs_instances_desired_count = 1#0#1#20
-    ecs_instances_memory = 64
-    ecs_instances_cpu = 200
-    ecs_instances_log_configuration = "${module.elastic_container_service.cluster_log_configuration}"
-    ecs_days_to_keep_images = 1
+  ecs_cluster_id                  = module.elastic_container_service.cluster_id
+  ecs_instances_role_name         = module.elastic_container_service.instance_role_name
+  ecs_instances_desired_count     = 1 #0#1#20
+  ecs_instances_memory            = 64
+  ecs_instances_cpu               = 200
+  ecs_instances_log_configuration = module.elastic_container_service.cluster_log_configuration
+  ecs_days_to_keep_images         = 1
 
-    api_server_host = "${module.api_server.load_balancer_dns_name}"
-    api_server_port = "${module.api_server.load_balancer_port}"
+  api_server_host = module.api_server.load_balancer_dns_name
+  api_server_port = module.api_server.load_balancer_port
 
-    ingester_response_queue_url = "${module.ingester_database.ingester_response_queue_url}"
-    ingester_response_queue_arn = "${module.ingester_database.ingester_response_queue_arn}"
+  ingester_response_queue_url = module.ingester_database.ingester_response_queue_url
+  ingester_response_queue_arn = module.ingester_database.ingester_response_queue_arn
 
-    ingester_response_queue_batch_size = 1 # Each message takes a while to process, so hoarding a bunch of messages in an individual instance means that other instances may be underutilized
-    ingester_response_queue_max_items_to_process = 10000
+  ingester_response_queue_batch_size           = 1 # Each message takes a while to process, so hoarding a bunch of messages in an individual instance means that other instances may be underutilized
+  ingester_response_queue_max_items_to_process = 10000
 
-    process_name                = "ingester-response-reader"
-    project_github_location     = "${var.project_github_location}"
-    build_logs_bucket_id        = "${module.build-common-infrastructure.build_logs_bucket_id}"
-    buildspec_location          = "backend/buildspec.yml"
-    file_path                   = "backend/ingester-response-reader/*"
-    file_path_common            = "backend/common/*"
-    build_service_role_arn      = "${module.build-common-infrastructure.build_service_role_arn}"
+  process_name            = "ingester-response-reader"
+  project_github_location = var.project_github_location
+  build_logs_bucket_id    = module.build-common-infrastructure.build_logs_bucket_id
+  buildspec_location      = "backend/buildspec.yml"
+  file_path               = "backend/ingester-response-reader/*"
+  file_path_common        = "backend/common/*"
+  build_service_role_arn  = module.build-common-infrastructure.build_service_role_arn
 }
 
 module "puller_flickr" {
-    source = "../modules/puller-flickr"
+  source = "../modules/puller-flickr"
 
-    environment = "${var.environment}"
-    region = "${var.region}"
-    metrics_namespace = "${var.metrics_namespace}"
+  environment       = var.environment
+  region            = var.region
+  metrics_namespace = var.metrics_namespace
 
-    parameter_memcached_location = "${module.memcached.location}"
-    kms_key_id              = "${module.encryption.kms_key_id}"
-    kms_key_arn             = "${module.encryption.kms_key_arn}"
+  parameter_memcached_location = module.memcached.location
+  kms_key_id                   = module.encryption.kms_key_id
+  kms_key_arn                  = module.encryption.kms_key_arn
 
-    memcached_location = "localhost:11211" # Disable cacheing Flickr API responses for now, so we can test performance
-    memcached_ttl = 7200
+  memcached_location = "localhost:11211" # Disable cacheing Flickr API responses for now, so we can test performance
+  memcached_ttl      = 7200
 
-    ecs_cluster_id = "${module.elastic_container_service.cluster_id}"
-    ecs_instances_role_name = "${module.elastic_container_service.instance_role_name}"
-    ecs_instances_desired_count = 1#0#1#150
-    ecs_instances_memory = 64
-    ecs_instances_cpu = 100
-    ecs_instances_log_configuration = "${module.elastic_container_service.cluster_log_configuration}"
-    ecs_days_to_keep_images = 1
+  ecs_cluster_id                  = module.elastic_container_service.cluster_id
+  ecs_instances_role_name         = module.elastic_container_service.instance_role_name
+  ecs_instances_desired_count     = 1 #0#1#150
+  ecs_instances_memory            = 64
+  ecs_instances_cpu               = 100
+  ecs_instances_log_configuration = module.elastic_container_service.cluster_log_configuration
+  ecs_days_to_keep_images         = 1
 
-    flickr_api_key = "${var.flickr_api_key}"
-    flickr_secret_key = "${var.flickr_secret_key}"
-    flickr_api_retries = 3
-    flickr_api_favorites_max_per_call = 500
-    flickr_api_favorites_max_to_get = 1000
-    flickr_api_favorites_max_calls_to_make = 1
-    flickr_api_contacts_max_per_call = 1000
+  flickr_api_key                         = var.flickr_api_key
+  flickr_secret_key                      = var.flickr_secret_key
+  flickr_api_retries                     = 3
+  flickr_api_favorites_max_per_call      = 500
+  flickr_api_favorites_max_to_get        = 1000
+  flickr_api_favorites_max_calls_to_make = 1
+  flickr_api_contacts_max_per_call       = 1000
 
-    output_queue_url = "${module.ingester_database.ingester_queue_url}"
-    output_queue_arn = "${module.ingester_database.ingester_queue_arn}"
-    output_queue_batch_size = 10
+  output_queue_url        = module.ingester_database.ingester_queue_url
+  output_queue_arn        = module.ingester_database.ingester_queue_arn
+  output_queue_batch_size = 10
 
-    puller_queue_url = "${module.scheduler.puller_queue_url}"
-    puller_queue_arn = "${module.scheduler.puller_queue_arn}"
-    puller_queue_batch_size = 1 # Each message takes a while to process, so hoarding a bunch of messages in an individual instance means that other instances may be underutilized
-    puller_queue_max_items_to_process = 1000
+  puller_queue_url                  = module.scheduler.puller_queue_url
+  puller_queue_arn                  = module.scheduler.puller_queue_arn
+  puller_queue_batch_size           = 1 # Each message takes a while to process, so hoarding a bunch of messages in an individual instance means that other instances may be underutilized
+  puller_queue_max_items_to_process = 1000
 
-    puller_response_queue_url = "${module.scheduler.puller_response_queue_url}"
-    puller_response_queue_arn = "${module.scheduler.puller_response_queue_arn}"
-    puller_response_queue_batch_size = 10
+  puller_response_queue_url        = module.scheduler.puller_response_queue_url
+  puller_response_queue_arn        = module.scheduler.puller_response_queue_arn
+  puller_response_queue_batch_size = 10
 
-    process_name                = "puller-flickr"
-    project_github_location     = "${var.project_github_location}"
-    build_logs_bucket_id        = "${module.build-common-infrastructure.build_logs_bucket_id}"
-    buildspec_location          = "backend/buildspec.yml"
-    file_path                   = "backend/puller-flickr/*"
-    file_path_common            = "backend/common/*"
-    build_service_role_arn      = "${module.build-common-infrastructure.build_service_role_arn}"
+  process_name            = "puller-flickr"
+  project_github_location = var.project_github_location
+  build_logs_bucket_id    = module.build-common-infrastructure.build_logs_bucket_id
+  buildspec_location      = "backend/buildspec.yml"
+  file_path               = "backend/puller-flickr/*"
+  file_path_common        = "backend/common/*"
+  build_service_role_arn  = module.build-common-infrastructure.build_service_role_arn
 }
 
 module "ingester_database" {
-    source = "../modules/ingester-database"
+  source = "../modules/ingester-database"
 
-    environment             = "${var.environment}"
-    region                  = "${var.region}"
-    metrics_namespace       = "${var.metrics_namespace}"
+  environment       = var.environment
+  region            = var.region
+  metrics_namespace = var.metrics_namespace
 
-    parameter_memcached_location = "${module.memcached.location}"
-    kms_key_id              = "${module.encryption.kms_key_id}"
-    kms_key_arn             = "${module.encryption.kms_key_arn}"
+  parameter_memcached_location = module.memcached.location
+  kms_key_id                   = module.encryption.kms_key_id
+  kms_key_arn                  = module.encryption.kms_key_arn
 
-    ecs_cluster_id          = "${module.elastic_container_service.cluster_id}"
-    ecs_instances_role_name = "${module.elastic_container_service.instance_role_name}"
-    ecs_instances_desired_count = 1#0#1#100
-    ecs_instances_memory    = 64
-    ecs_instances_cpu       = 100
-    ecs_instances_log_configuration = "${module.elastic_container_service.cluster_log_configuration}"
-    ecs_days_to_keep_images = 1
+  ecs_cluster_id                  = module.elastic_container_service.cluster_id
+  ecs_instances_role_name         = module.elastic_container_service.instance_role_name
+  ecs_instances_desired_count     = 1 #0#1#100
+  ecs_instances_memory            = 64
+  ecs_instances_cpu               = 100
+  ecs_instances_log_configuration = module.elastic_container_service.cluster_log_configuration
+  ecs_days_to_keep_images         = 1
 
-    mysql_database_host     = "${module.database.database_host}"
-    mysql_database_port     = "${module.database.database_port}"
-    mysql_database_username = "${module.database.database_username}"
-    mysql_database_password = "${var.database_password_dev}"
-    mysql_database_name     = "${module.database.database_name}"
-    mysql_database_min_batch_size = 100 # Counter-intuitively, the best overall system performance is gained by batching these the least. It's so that the process can flush as quickly as possible rather than storing up and flushing while everything else is waiting around
-    mysql_database_maxretries = 3
+  mysql_database_host           = module.database.database_host
+  mysql_database_port           = module.database.database_port
+  mysql_database_username       = module.database.database_username
+  mysql_database_password       = var.database_password_dev
+  mysql_database_name           = module.database.database_name
+  mysql_database_min_batch_size = 100 # Counter-intuitively, the best overall system performance is gained by batching these the least. It's so that the process can flush as quickly as possible rather than storing up and flushing while everything else is waiting around
+  mysql_database_maxretries     = 3
 
-    input_queue_batch_size  = 1 # Each message takes a while to process because it contains many individual items, so only get one at a time so that we're not blocking other instances from picking them up
-    input_queue_max_items_to_process = 10000
-    input_queue_long_polling_seconds = 1 # Don't do long polling for too long: we can only commit after we find no more new messages
+  input_queue_batch_size           = 1 # Each message takes a while to process because it contains many individual items, so only get one at a time so that we're not blocking other instances from picking them up
+  input_queue_max_items_to_process = 10000
+  input_queue_long_polling_seconds = 1 # Don't do long polling for too long: we can only commit after we find no more new messages
 
-    output_queue_long_polling_seconds = 1 # Don't do long polling for too long: the ingester response reader can only write to the API server after finding no more new messages
-    output_queue_batch_size = 10
+  output_queue_long_polling_seconds = 1 # Don't do long polling for too long: the ingester response reader can only write to the API server after finding no more new messages
+  output_queue_batch_size           = 10
 
-    process_name                = "ingester-database"
-    project_github_location     = "${var.project_github_location}"
-    build_logs_bucket_id        = "${module.build-common-infrastructure.build_logs_bucket_id}"
-    buildspec_location          = "backend/buildspec.yml"
-    file_path                   = "backend/ingester-database/*"
-    file_path_common            = "backend/common/*"
-    build_service_role_arn      = "${module.build-common-infrastructure.build_service_role_arn}"
+  process_name            = "ingester-database"
+  project_github_location = var.project_github_location
+  build_logs_bucket_id    = module.build-common-infrastructure.build_logs_bucket_id
+  buildspec_location      = "backend/buildspec.yml"
+  file_path               = "backend/ingester-database/*"
+  file_path_common        = "backend/common/*"
+  build_service_role_arn  = module.build-common-infrastructure.build_service_role_arn
 }
 
 module "api_server" {
-    source = "../modules/api-server"
+  source = "../modules/api-server"
 
-    environment             = "${var.environment}"
-    region                  = "${var.region}"
-    metrics_namespace       = "${var.metrics_namespace}"
+  environment       = var.environment
+  region            = var.region
+  metrics_namespace = var.metrics_namespace
 
-    parameter_memcached_location = "${module.memcached.location}"
-    kms_key_id              = "${module.encryption.kms_key_id}"
-    kms_key_arn             = "${module.encryption.kms_key_arn}"
+  parameter_memcached_location = module.memcached.location
+  kms_key_id                   = module.encryption.kms_key_id
+  kms_key_arn                  = module.encryption.kms_key_arn
 
-    vpc_id                  = "${module.vpc.vpc_id}"
-    vpc_public_subnet_ids   = "${module.vpc.vpc_public_subnet_ids}"
-    vpc_cidr                = "${module.vpc.vpc_cidr_block}"
+  vpc_id                = module.vpc.vpc_id
+  vpc_public_subnet_ids = module.vpc.vpc_public_subnet_ids
+  vpc_cidr              = module.vpc.vpc_cidr_block
 
-    load_balancer_port      = 4444
-    api_server_port         = 4445
+  load_balancer_port = 4444
+  api_server_port    = 4445
 
-    session_encryption_key     = "${var.api_server_session_encryption_key_dev}"
+  session_encryption_key = var.api_server_session_encryption_key_dev
 
-    flickr_api_key = "${var.flickr_api_key}"
-    flickr_secret_key = "${var.flickr_secret_key}"
-    flickr_api_retries = 3
-    flickr_api_memcached_location = "localhost:11211" # Disable cacheing Flickr API responses for now
-    flickr_api_memcached_ttl = 7200
-    flickr_auth_memcached_location = "${module.memcached.location}"
+  flickr_api_key                 = var.flickr_api_key
+  flickr_secret_key              = var.flickr_secret_key
+  flickr_api_retries             = 3
+  flickr_api_memcached_location  = "localhost:11211" # Disable cacheing Flickr API responses for now
+  flickr_api_memcached_ttl       = 7200
+  flickr_auth_memcached_location = module.memcached.location
 
-    retain_load_balancer_access_logs_after_destroy = "false" # For dev, we don't care about retaining these logs after doing a terraform destroy
-    load_balancer_days_to_keep_access_logs = 1
-    load_balancer_access_logs_bucket = "load-balancer-access-logs"
-    load_balancer_access_logs_prefix = "api-server-lb"
-    bucketname_user_string  = "${var.bucketname_user_string}"
+  retain_load_balancer_access_logs_after_destroy = "false" # For dev, we don't care about retaining these logs after doing a terraform destroy
+  load_balancer_days_to_keep_access_logs         = 1
+  load_balancer_access_logs_bucket               = "load-balancer-access-logs"
+  load_balancer_access_logs_prefix               = "api-server-lb"
+  bucketname_user_string                         = var.bucketname_user_string
 
-    local_machine_cidr      = "${var.local_machine_cidr}"
+  local_machine_cidr = var.local_machine_cidr
 
-    mysql_database_host     = "${module.database.database_host}"
-    mysql_database_port     = "${module.database.database_port}"
-    mysql_database_username = "${module.database.database_username}"
-    mysql_database_password = "${var.database_password_dev}"
-    mysql_database_name     = "${module.database.database_name}"
-    mysql_database_fetch_batch_size = 10000
-    mysql_database_connection_pool_size = 20
-    mysql_database_user_data_encryption_key = "${var.database_user_data_encryption_key_dev}"
+  mysql_database_host                     = module.database.database_host
+  mysql_database_port                     = module.database.database_port
+  mysql_database_username                 = module.database.database_username
+  mysql_database_password                 = var.database_password_dev
+  mysql_database_name                     = module.database.database_name
+  mysql_database_fetch_batch_size         = 10000
+  mysql_database_connection_pool_size     = 20
+  mysql_database_user_data_encryption_key = var.database_user_data_encryption_key_dev
 
-    puller_queue_url = "${module.scheduler.puller_queue_url}"
-    puller_queue_arn = "${module.scheduler.puller_queue_arn}"
-    puller_queue_batch_size = 1 # We're always going to make requests one at a time as users add their favorites
+  puller_queue_url        = module.scheduler.puller_queue_url
+  puller_queue_arn        = module.scheduler.puller_queue_arn
+  puller_queue_batch_size = 1 # We're always going to make requests one at a time as users add their favorites
 
-    ecs_cluster_id          = "${module.elastic_container_service.cluster_id}"
-    ecs_instances_role_name = "${module.elastic_container_service.instance_role_name}"
-    ecs_instances_desired_count = 1#15
-    ecs_instances_memory    = 256
-    ecs_instances_cpu       = 100
-    ecs_instances_log_configuration = "${module.elastic_container_service.cluster_log_configuration}"
-    ecs_days_to_keep_images = 1
+  ecs_cluster_id                  = module.elastic_container_service.cluster_id
+  ecs_instances_role_name         = module.elastic_container_service.instance_role_name
+  ecs_instances_desired_count     = 1 #15
+  ecs_instances_memory            = 256
+  ecs_instances_cpu               = 100
+  ecs_instances_log_configuration = module.elastic_container_service.cluster_log_configuration
+  ecs_days_to_keep_images         = 1
 
-    default_num_photo_recommendations = 10
-    default_num_user_recommendations = 5
-    default_num_photos_from_group = 20
+  default_num_photo_recommendations = 10
+  default_num_user_recommendations  = 5
+  default_num_photos_from_group     = 20
 
-    process_name                = "api-server"
-    project_github_location     = "${var.project_github_location}"
-    build_logs_bucket_id        = "${module.build-common-infrastructure.build_logs_bucket_id}"
-    buildspec_location          = "backend/buildspec.yml"
-    file_path                   = "backend/api-server/*"
-    file_path_common            = "backend/common/*"
-    build_service_role_arn      = "${module.build-common-infrastructure.build_service_role_arn}"
+  process_name            = "api-server"
+  project_github_location = var.project_github_location
+  build_logs_bucket_id    = module.build-common-infrastructure.build_logs_bucket_id
+  buildspec_location      = "backend/buildspec.yml"
+  file_path               = "backend/api-server/*"
+  file_path_common        = "backend/common/*"
+  build_service_role_arn  = module.build-common-infrastructure.build_service_role_arn
 }
 
 module "frontend" {
-    source = "../modules/frontend"
+  source = "../modules/frontend"
 
-    environment             = "${var.environment}"
-    environment_long_name   = "${var.environment_long_name}"
-    region                  = "${var.region}"
+  environment           = var.environment
+  environment_long_name = var.environment_long_name
+  region                = var.region
 
-    bucketname_user_string  = "${var.bucketname_user_string}"
+  bucketname_user_string = var.bucketname_user_string
 
-    application_domain      = "dev.${var.dns_address}"
-    application_name        = "photo-recommender"
+  application_domain = "dev.${var.dns_address}"
+  application_name   = "photo-recommender"
 
-    days_to_keep_old_versions = 1
+  days_to_keep_old_versions = 1
 
-    load_balancer_arn       = "${module.api_server.load_balancer_arn}"
-    load_balancer_dns_name  = "${module.api_server.load_balancer_dns_name}"
-    load_balancer_port      = "${module.api_server.load_balancer_port}"
-    load_balancer_zone_id   = "${module.api_server.load_balancer_zone_id}"
+  load_balancer_arn      = module.api_server.load_balancer_arn
+  load_balancer_dns_name = module.api_server.load_balancer_dns_name
+  load_balancer_port     = module.api_server.load_balancer_port
+  load_balancer_zone_id  = module.api_server.load_balancer_zone_id
 
-    frontend_access_logs_bucket = "frontend-access-logs"
-    retain_frontend_access_logs_after_destroy = "false" # For dev, we don't care about retaining these logs after doing a terraform destroy
-    days_to_keep_frontend_access_logs = 1
+  frontend_access_logs_bucket               = "frontend-access-logs"
+  retain_frontend_access_logs_after_destroy = "false" # For dev, we don't care about retaining these logs after doing a terraform destroy
+  days_to_keep_frontend_access_logs         = 1
 
-    use_custom_domain           = "false"
-    ssl_certificate_body        = "${var.ssl_certificate_body}"
-    ssl_certificate_private_key = "${var.ssl_certificate_private_key}"
-    ssl_certificate_chain       = "${var.ssl_certificate_chain}"
+  use_custom_domain           = "false"
+  ssl_certificate_body        = var.ssl_certificate_body
+  ssl_certificate_private_key = var.ssl_certificate_private_key
+  ssl_certificate_chain       = var.ssl_certificate_chain
 
-    project_github_location     = "${var.project_github_location}"
-    build_logs_bucket_id        = "${module.build-common-infrastructure.build_logs_bucket_id}"
-    buildspec_location          = "frontend/buildspec.yml"
-    file_path                   = "frontend/*"
-    build_service_role_arn      = "${module.build-common-infrastructure.build_service_role_arn}"
+  project_github_location = var.project_github_location
+  build_logs_bucket_id    = module.build-common-infrastructure.build_logs_bucket_id
+  buildspec_location      = "frontend/buildspec.yml"
+  file_path               = "frontend/*"
+  build_service_role_arn  = module.build-common-infrastructure.build_service_role_arn
 }
 
 module "dashboard" {
-    source = "../modules/dashboard"
+  source = "../modules/dashboard"
 
-    environment = "${var.environment}"
-    region      = "${var.region}"
-    metrics_namespace = "${var.metrics_namespace}"
+  environment       = var.environment
+  region            = var.region
+  metrics_namespace = var.metrics_namespace
 
-    puller_queue_base_name               = "${module.scheduler.puller_queue_base_name}"
-    puller_queue_full_name               = "${module.scheduler.puller_queue_full_name}"
-    puller_queue_dead_letter_full_name   = "${module.scheduler.puller_queue_dead_letter_full_name}"
+  puller_queue_base_name             = module.scheduler.puller_queue_base_name
+  puller_queue_full_name             = module.scheduler.puller_queue_full_name
+  puller_queue_dead_letter_full_name = module.scheduler.puller_queue_dead_letter_full_name
 
-    puller_response_queue_base_name              = "${module.scheduler.puller_response_queue_base_name}"
-    puller_response_queue_full_name              = "${module.scheduler.puller_response_queue_full_name}"
-    puller_response_queue_dead_letter_full_name  = "${module.scheduler.puller_response_queue_dead_letter_full_name}"
+  puller_response_queue_base_name             = module.scheduler.puller_response_queue_base_name
+  puller_response_queue_full_name             = module.scheduler.puller_response_queue_full_name
+  puller_response_queue_dead_letter_full_name = module.scheduler.puller_response_queue_dead_letter_full_name
 
-    ingester_queue_base_name                = "${module.ingester_database.ingester_queue_base_name}"
-    ingester_queue_full_name                = "${module.ingester_database.ingester_queue_full_name}"
-    ingester_queue_dead_letter_full_name    = "${module.ingester_database.ingester_queue_dead_letter_full_name}"
+  ingester_queue_base_name             = module.ingester_database.ingester_queue_base_name
+  ingester_queue_full_name             = module.ingester_database.ingester_queue_full_name
+  ingester_queue_dead_letter_full_name = module.ingester_database.ingester_queue_dead_letter_full_name
 
-    ingester_response_queue_base_name                = "${module.ingester_database.ingester_response_queue_base_name}"
-    ingester_response_queue_full_name                = "${module.ingester_database.ingester_response_queue_full_name}"
-    ingester_response_queue_dead_letter_full_name    = "${module.ingester_database.ingester_response_queue_dead_letter_full_name}"
+  ingester_response_queue_base_name             = module.ingester_database.ingester_response_queue_base_name
+  ingester_response_queue_full_name             = module.ingester_database.ingester_response_queue_full_name
+  ingester_response_queue_dead_letter_full_name = module.ingester_database.ingester_response_queue_dead_letter_full_name
 
-    database_identifier                     = "${module.database.database_instance_identifier}"
+  database_identifier = module.database.database_instance_identifier
 
-    ecs_autoscaling_group_name              = "${module.elastic_container_service.autoscaling_group_name}"
-    ecs_cluster_name                        = "${module.elastic_container_service.cluster_full_name}"
+  ecs_autoscaling_group_name = module.elastic_container_service.autoscaling_group_name
+  ecs_cluster_name           = module.elastic_container_service.cluster_full_name
 }
 
 module "alarms" {
-    source = "../modules/alarms"
+  source = "../modules/alarms"
 
-    environment     = "${var.environment}"
-    region          = "${var.region}"
+  environment = var.environment
+  region      = var.region
 
-    enable_alarms   = "true"
+  enable_alarms = "true"
 
-    metrics_namespace = "${var.metrics_namespace}"
-    topic_name      = "photo-recommender"
-    alarms_email    = "${var.alarms_email}"
+  metrics_namespace = var.metrics_namespace
+  topic_name        = "photo-recommender"
+  alarms_email      = var.alarms_email
 
-    unhandled_exceptions_threshold = 1
+  unhandled_exceptions_threshold = 1
 
-    queue_names = [ "${module.scheduler.puller_queue_full_name}", "${module.scheduler.puller_response_queue_full_name}", "${module.ingester_database.ingester_queue_full_name}", "${module.ingester_database.ingester_response_queue_full_name}"]
-    queue_item_size_threshold = 235520 # 230kB -- 256kB is the absolute max
-    queue_item_age_threshold = 900 # 15 minutes: it can take a long time to process stuff in dev, with a limited numbers of workers
-    queue_reader_error_threshold = 1
-    queue_writer_error_threshold = 1
+  queue_names                  = [module.scheduler.puller_queue_full_name, module.scheduler.puller_response_queue_full_name, module.ingester_database.ingester_queue_full_name, module.ingester_database.ingester_response_queue_full_name]
+  queue_item_size_threshold    = 235520 # 230kB -- 256kB is the absolute max
+  queue_item_age_threshold     = 900    # 15 minutes: it can take a long time to process stuff in dev, with a limited numbers of workers
+  queue_reader_error_threshold = 1
+  queue_writer_error_threshold = 1
 
-    dead_letter_queue_names = [ "${module.scheduler.puller_queue_dead_letter_full_name}", "${module.scheduler.puller_response_queue_dead_letter_full_name}", "${module.ingester_database.ingester_queue_dead_letter_full_name}", "${module.ingester_database.ingester_response_queue_dead_letter_full_name}"]
-    dead_letter_queue_items_threshold = 1
+  dead_letter_queue_names           = [module.scheduler.puller_queue_dead_letter_full_name, module.scheduler.puller_response_queue_dead_letter_full_name, module.ingester_database.ingester_queue_dead_letter_full_name, module.ingester_database.ingester_response_queue_dead_letter_full_name]
+  dead_letter_queue_items_threshold = 1
 
-    users_store_exception_threshold = 1
+  users_store_exception_threshold = 1
 
-    api_server_favorites_store_exception_threshold = 1
-    api_server_generic_exception_threshold = 1
-    
-    ingester_database_batch_writer_exception_threshold = 1
-    
-    puller_flickr_max_batch_size_exceeded_error_threshold = 1
-    puller_flickr_max_neighbors_exceeded_error_threshold = 1
-    puller_flickr_max_flickr_api_exceptions_threshold = 1
+  api_server_favorites_store_exception_threshold = 1
+  api_server_generic_exception_threshold         = 1
+
+  ingester_database_batch_writer_exception_threshold = 1
+
+  puller_flickr_max_batch_size_exceeded_error_threshold = 1
+  puller_flickr_max_neighbors_exceeded_error_threshold  = 1
+  puller_flickr_max_flickr_api_exceptions_threshold     = 1
 }
+

--- a/terraform/dev/main.tf
+++ b/terraform/dev/main.tf
@@ -33,7 +33,7 @@ module "build-common-infrastructure" {
   project_github_location  = var.project_github_location
   s3_deployment_bucket_arn = module.frontend.s3_deployment_bucket_arn
 
-  build_logs_bucket               = "build-logs"
+  build_logs_bucket               = "photo-recommender-build-logs"
   bucketname_user_string          = var.bucketname_user_string
   retain_build_logs_after_destroy = "false" # For dev, we don't care about retaining these logs after doing a terraform destroy
   days_to_keep_build_logs         = 1
@@ -345,7 +345,7 @@ module "api_server" {
 
   retain_load_balancer_access_logs_after_destroy = "false" # For dev, we don't care about retaining these logs after doing a terraform destroy
   load_balancer_days_to_keep_access_logs         = 1
-  load_balancer_access_logs_bucket               = "load-balancer-access-logs"
+  load_balancer_access_logs_bucket               = "photo-recommender-load-balancer-access-logs"
   load_balancer_access_logs_prefix               = "api-server-lb"
   bucketname_user_string                         = var.bucketname_user_string
 
@@ -404,7 +404,7 @@ module "frontend" {
   load_balancer_port     = module.api_server.load_balancer_port
   load_balancer_zone_id  = module.api_server.load_balancer_zone_id
 
-  frontend_access_logs_bucket               = "frontend-access-logs"
+  frontend_access_logs_bucket               = "photo-recommender-frontend-access-logs"
   retain_frontend_access_logs_after_destroy = "false" # For dev, we don't care about retaining these logs after doing a terraform destroy
   days_to_keep_frontend_access_logs         = 1
 

--- a/terraform/dev/provider.tf
+++ b/terraform/dev/provider.tf
@@ -1,4 +1,5 @@
 provider "aws" {
-    shared_credentials_file = "../aws_credentials"
-    region = "${var.region}"
+  shared_credentials_file = "../aws_credentials"
+  region                  = var.region
 }
+

--- a/terraform/dev/variables.tf
+++ b/terraform/dev/variables.tf
@@ -1,18 +1,58 @@
-variable "region" { default = "us-west-2" }
-variable "environment" { default = "dev" }
-variable "environment_long_name" { default = "development" }
-variable "alarms_email" {}
-variable "metrics_namespace" { default = "Photo Recommender" }
-variable "local_machine_cidr" {}
-variable "local_machine_public_key" {}
-variable "flickr_api_key" {}
-variable "flickr_secret_key" {}
-variable "database_password_dev" {}
-variable "dns_address" {}
-variable "bucketname_user_string" {}
-variable "database_user_data_encryption_key_dev" {}
-variable "api_server_session_encryption_key_dev" {}
-variable "ssl_certificate_body" {}
-variable "ssl_certificate_private_key" {}
-variable "ssl_certificate_chain" {}
-variable "project_github_location" {}
+variable "region" {
+  default = "us-west-2"
+}
+
+variable "environment" {
+  default = "dev"
+}
+
+variable "environment_long_name" {
+  default = "development"
+}
+
+variable "alarms_email" {
+}
+
+variable "metrics_namespace" {
+  default = "Photo Recommender"
+}
+
+variable "local_machine_cidr" {
+}
+
+variable "local_machine_public_key" {
+}
+
+variable "flickr_api_key" {
+}
+
+variable "flickr_secret_key" {
+}
+
+variable "database_password_dev" {
+}
+
+variable "dns_address" {
+}
+
+variable "bucketname_user_string" {
+}
+
+variable "database_user_data_encryption_key_dev" {
+}
+
+variable "api_server_session_encryption_key_dev" {
+}
+
+variable "ssl_certificate_body" {
+}
+
+variable "ssl_certificate_private_key" {
+}
+
+variable "ssl_certificate_chain" {
+}
+
+variable "project_github_location" {
+}
+

--- a/terraform/dev/variables.tf
+++ b/terraform/dev/variables.tf
@@ -32,6 +32,9 @@ variable "flickr_secret_key" {
 variable "database_password_dev" {
 }
 
+variable "database_password_prod" {
+}
+
 variable "dns_address" {
 }
 
@@ -42,6 +45,12 @@ variable "database_user_data_encryption_key_dev" {
 }
 
 variable "api_server_session_encryption_key_dev" {
+}
+
+variable "database_user_data_encryption_key_prod" {
+}
+
+variable "api_server_session_encryption_key_prod" {
 }
 
 variable "ssl_certificate_body" {

--- a/terraform/dev/versions.tf
+++ b/terraform/dev/versions.tf
@@ -1,0 +1,4 @@
+
+terraform {
+  required_version = ">= 0.12"
+}

--- a/terraform/modules/alarms/exceptions.tf
+++ b/terraform/modules/alarms/exceptions.tf
@@ -1,229 +1,230 @@
 resource "aws_cloudwatch_metric_alarm" "unhandled_exceptions" {
-    count                     = "${var.enable_alarms == "true" ? length(var.process_names) : 0}" # Don't create this if we turn off alarms (e.g. for dev)
+  count = var.enable_alarms == "true" ? length(var.process_names) : 0 # Don't create this if we turn off alarms (e.g. for dev)
 
-    alarm_name                = "Unhandled exceptions in ${element(var.process_names, count.index)} ${var.environment}" # Need to have a different name for each one, or else we only see one in the UI
-    comparison_operator       = "GreaterThanOrEqualToThreshold"
-    evaluation_periods        = "1"
-    metric_name               = "UnhandledException"
-    namespace                 = "${var.metrics_namespace}"
-    period                    = "300"
-    statistic                 = "Sum"
-    threshold                 = "${var.unhandled_exceptions_threshold}"
-    treat_missing_data        = "notBreaching" # No news is good news for exceptions
-    alarm_description         = "Alerts if a process encounters unhandled exceptions"
-    alarm_actions             = [ "${aws_sns_topic.alarms.arn}" ]
-    insufficient_data_actions = [ "${aws_sns_topic.alarms.arn}" ]
-    ok_actions                = [ "${aws_sns_topic.alarms.arn}" ]
+  alarm_name                = "Unhandled exceptions in ${element(var.process_names, count.index)} ${var.environment}" # Need to have a different name for each one, or else we only see one in the UI
+  comparison_operator       = "GreaterThanOrEqualToThreshold"
+  evaluation_periods        = "1"
+  metric_name               = "UnhandledException"
+  namespace                 = var.metrics_namespace
+  period                    = "300"
+  statistic                 = "Sum"
+  threshold                 = var.unhandled_exceptions_threshold
+  treat_missing_data        = "notBreaching" # No news is good news for exceptions
+  alarm_description         = "Alerts if a process encounters unhandled exceptions"
+  alarm_actions             = [aws_sns_topic.alarms.arn]
+  insufficient_data_actions = [aws_sns_topic.alarms.arn]
+  ok_actions                = [aws_sns_topic.alarms.arn]
 
-    dimensions {
-        Environment = "${var.environment}"
-        Process     = "${element(var.process_names, count.index)}" # Taken from https://github.com/hashicorp/terraform/issues/8600
-    }
+  dimensions = {
+    Environment = var.environment
+    Process     = element(var.process_names, count.index) # Taken from https://github.com/hashicorp/terraform/issues/8600
+  }
 }
 
 resource "aws_cloudwatch_metric_alarm" "queue_reader_error" {
-    count                     = "${var.enable_alarms == "true" ? length(var.process_names_that_read_from_queues) : 0}" # Don't create this if we turn off alarms (e.g. for dev)
+  count = var.enable_alarms == "true" ? length(var.process_names_that_read_from_queues) : 0 # Don't create this if we turn off alarms (e.g. for dev)
 
-    alarm_name                = "QueueReaderError in ${element(var.process_names_that_read_from_queues, count.index)} ${var.environment}" # Need to have a different name for each one, or else we only see one in the UI
-    comparison_operator       = "GreaterThanOrEqualToThreshold"
-    evaluation_periods        = "1"
-    metric_name               = "QueueReaderError"
-    namespace                 = "${var.metrics_namespace}"
-    period                    = "300"
-    statistic                 = "Sum"
-    threshold                 = "${var.queue_reader_error_threshold}"
-    treat_missing_data        = "notBreaching" # No news is good news for exceptions
-    alarm_description         = "Alerts if a process encounters an error reading from a queue"
-    alarm_actions             = [ "${aws_sns_topic.alarms.arn}" ]
-    insufficient_data_actions = [ "${aws_sns_topic.alarms.arn}" ]
-    ok_actions                = [ "${aws_sns_topic.alarms.arn}" ]
+  alarm_name                = "QueueReaderError in ${element(var.process_names_that_read_from_queues, count.index)} ${var.environment}" # Need to have a different name for each one, or else we only see one in the UI
+  comparison_operator       = "GreaterThanOrEqualToThreshold"
+  evaluation_periods        = "1"
+  metric_name               = "QueueReaderError"
+  namespace                 = var.metrics_namespace
+  period                    = "300"
+  statistic                 = "Sum"
+  threshold                 = var.queue_reader_error_threshold
+  treat_missing_data        = "notBreaching" # No news is good news for exceptions
+  alarm_description         = "Alerts if a process encounters an error reading from a queue"
+  alarm_actions             = [aws_sns_topic.alarms.arn]
+  insufficient_data_actions = [aws_sns_topic.alarms.arn]
+  ok_actions                = [aws_sns_topic.alarms.arn]
 
-    dimensions {
-        Environment = "${var.environment}"
-        Process     = "${element(var.process_names_that_read_from_queues, count.index)}" # Taken from https://github.com/hashicorp/terraform/issues/8600
-    }
+  dimensions = {
+    Environment = var.environment
+    Process     = element(var.process_names_that_read_from_queues, count.index) # Taken from https://github.com/hashicorp/terraform/issues/8600
+  }
 }
 
 resource "aws_cloudwatch_metric_alarm" "queue_writer_error" {
-    count                     = "${var.enable_alarms == "true" ? length(var.process_names_that_write_to_queues) : 0}" # Don't create this if we turn off alarms (e.g. for dev)
+  count = var.enable_alarms == "true" ? length(var.process_names_that_write_to_queues) : 0 # Don't create this if we turn off alarms (e.g. for dev)
 
-    alarm_name                = "QueueWriterError in ${element(var.process_names_that_write_to_queues, count.index)} ${var.environment}" # Need to have a different name for each one, or else we only see one in the UI
-    comparison_operator       = "GreaterThanOrEqualToThreshold"
-    evaluation_periods        = "1"
-    metric_name               = "QueueWriterError"
-    namespace                 = "${var.metrics_namespace}"
-    period                    = "300"
-    statistic                 = "Sum"
-    threshold                 = "${var.queue_writer_error_threshold}"
-    treat_missing_data        = "notBreaching" # No news is good news for exceptions
-    alarm_description         = "Alerts if a process encounters an error writing to a queue"
-    alarm_actions             = [ "${aws_sns_topic.alarms.arn}" ]
-    insufficient_data_actions = [ "${aws_sns_topic.alarms.arn}" ]
-    ok_actions                = [ "${aws_sns_topic.alarms.arn}" ]
+  alarm_name                = "QueueWriterError in ${element(var.process_names_that_write_to_queues, count.index)} ${var.environment}" # Need to have a different name for each one, or else we only see one in the UI
+  comparison_operator       = "GreaterThanOrEqualToThreshold"
+  evaluation_periods        = "1"
+  metric_name               = "QueueWriterError"
+  namespace                 = var.metrics_namespace
+  period                    = "300"
+  statistic                 = "Sum"
+  threshold                 = var.queue_writer_error_threshold
+  treat_missing_data        = "notBreaching" # No news is good news for exceptions
+  alarm_description         = "Alerts if a process encounters an error writing to a queue"
+  alarm_actions             = [aws_sns_topic.alarms.arn]
+  insufficient_data_actions = [aws_sns_topic.alarms.arn]
+  ok_actions                = [aws_sns_topic.alarms.arn]
 
-    dimensions {
-        Environment = "${var.environment}"
-        Process     = "${element(var.process_names_that_write_to_queues, count.index)}" # Taken from https://github.com/hashicorp/terraform/issues/8600
-    }
+  dimensions = {
+    Environment = var.environment
+    Process     = element(var.process_names_that_write_to_queues, count.index) # Taken from https://github.com/hashicorp/terraform/issues/8600
+  }
 }
 
 resource "aws_cloudwatch_metric_alarm" "users_store_exception" {
-    count                     = "${var.enable_alarms == "true" ? length(var.process_names_that_use_api_server) : 0}" # Don't create this if we turn off alarms (e.g. for dev)
+  count = var.enable_alarms == "true" ? length(var.process_names_that_use_api_server) : 0 # Don't create this if we turn off alarms (e.g. for dev)
 
-    alarm_name                = "UsersStoreException in ${element(var.process_names_that_use_api_server, count.index)} ${var.environment}" # Need to have a different name for each one, or else we only see one in the UI
-    comparison_operator       = "GreaterThanOrEqualToThreshold"
-    evaluation_periods        = "1"
-    metric_name               = "UsersStoreException"
-    namespace                 = "${var.metrics_namespace}"
-    period                    = "300"
-    statistic                 = "Sum"
-    threshold                 = "${var.users_store_exception_threshold}"
-    treat_missing_data        = "notBreaching" # No news is good news for exceptions
-    alarm_description         = "Alerts if a process is unable to talk to the API server"
-    alarm_actions             = [ "${aws_sns_topic.alarms.arn}" ]
-    insufficient_data_actions = [ "${aws_sns_topic.alarms.arn}" ]
-    ok_actions                = [ "${aws_sns_topic.alarms.arn}" ]
+  alarm_name                = "UsersStoreException in ${element(var.process_names_that_use_api_server, count.index)} ${var.environment}" # Need to have a different name for each one, or else we only see one in the UI
+  comparison_operator       = "GreaterThanOrEqualToThreshold"
+  evaluation_periods        = "1"
+  metric_name               = "UsersStoreException"
+  namespace                 = var.metrics_namespace
+  period                    = "300"
+  statistic                 = "Sum"
+  threshold                 = var.users_store_exception_threshold
+  treat_missing_data        = "notBreaching" # No news is good news for exceptions
+  alarm_description         = "Alerts if a process is unable to talk to the API server"
+  alarm_actions             = [aws_sns_topic.alarms.arn]
+  insufficient_data_actions = [aws_sns_topic.alarms.arn]
+  ok_actions                = [aws_sns_topic.alarms.arn]
 
-    dimensions {
-        Environment = "${var.environment}"
-        Process     = "${element(var.process_names_that_use_api_server, count.index)}" # Taken from https://github.com/hashicorp/terraform/issues/8600
-    }
+  dimensions = {
+    Environment = var.environment
+    Process     = element(var.process_names_that_use_api_server, count.index) # Taken from https://github.com/hashicorp/terraform/issues/8600
+  }
 }
 
 resource "aws_cloudwatch_metric_alarm" "favorites_store_exception" {
-    count                     = "${var.enable_alarms == "true" ? 1 : 0}" # Don't create this if we turn off alarms (e.g. for dev)
+  count = var.enable_alarms == "true" ? 1 : 0 # Don't create this if we turn off alarms (e.g. for dev)
 
-    alarm_name                = "API server encountered FavoritesStoreException ${var.environment}"
-    comparison_operator       = "GreaterThanOrEqualToThreshold"
-    evaluation_periods        = "1"
-    metric_name               = "FavoritesStoreException"
-    namespace                 = "${var.metrics_namespace}"
-    period                    = "300"
-    statistic                 = "Sum"
-    threshold                 = "${var.api_server_favorites_store_exception_threshold}"
-    treat_missing_data        = "notBreaching" # No news is good news for exceptions
-    alarm_description         = "Alerts if the API server is unable to talk to the database"
-    alarm_actions             = [ "${aws_sns_topic.alarms.arn}" ]
-    insufficient_data_actions = [ "${aws_sns_topic.alarms.arn}" ]
-    ok_actions                = [ "${aws_sns_topic.alarms.arn}" ]
+  alarm_name                = "API server encountered FavoritesStoreException ${var.environment}"
+  comparison_operator       = "GreaterThanOrEqualToThreshold"
+  evaluation_periods        = "1"
+  metric_name               = "FavoritesStoreException"
+  namespace                 = var.metrics_namespace
+  period                    = "300"
+  statistic                 = "Sum"
+  threshold                 = var.api_server_favorites_store_exception_threshold
+  treat_missing_data        = "notBreaching" # No news is good news for exceptions
+  alarm_description         = "Alerts if the API server is unable to talk to the database"
+  alarm_actions             = [aws_sns_topic.alarms.arn]
+  insufficient_data_actions = [aws_sns_topic.alarms.arn]
+  ok_actions                = [aws_sns_topic.alarms.arn]
 
-    dimensions {
-        Environment = "${var.environment}"
-        Process     = "api-server"
-    }
+  dimensions = {
+    Environment = var.environment
+    Process     = "api-server"
+  }
 }
 
 resource "aws_cloudwatch_metric_alarm" "api_server_exception" {
-    count                     = "${var.enable_alarms == "true" ? 1 : 0}" # Don't create this if we turn off alarms (e.g. for dev)
+  count = var.enable_alarms == "true" ? 1 : 0 # Don't create this if we turn off alarms (e.g. for dev)
 
-    alarm_name                = "API server encountered a generic Exception ${var.environment}"
-    comparison_operator       = "GreaterThanOrEqualToThreshold"
-    evaluation_periods        = "1"
-    metric_name               = "Exception"
-    namespace                 = "${var.metrics_namespace}"
-    period                    = "300"
-    statistic                 = "Sum"
-    threshold                 = "${var.api_server_generic_exception_threshold}"
-    treat_missing_data        = "notBreaching" # No news is good news for exceptions
-    alarm_description         = "Alerts if the API server encounters a generic Exception"
-    alarm_actions             = [ "${aws_sns_topic.alarms.arn}" ]
-    insufficient_data_actions = [ "${aws_sns_topic.alarms.arn}" ]
-    ok_actions                = [ "${aws_sns_topic.alarms.arn}" ]
+  alarm_name                = "API server encountered a generic Exception ${var.environment}"
+  comparison_operator       = "GreaterThanOrEqualToThreshold"
+  evaluation_periods        = "1"
+  metric_name               = "Exception"
+  namespace                 = var.metrics_namespace
+  period                    = "300"
+  statistic                 = "Sum"
+  threshold                 = var.api_server_generic_exception_threshold
+  treat_missing_data        = "notBreaching" # No news is good news for exceptions
+  alarm_description         = "Alerts if the API server encounters a generic Exception"
+  alarm_actions             = [aws_sns_topic.alarms.arn]
+  insufficient_data_actions = [aws_sns_topic.alarms.arn]
+  ok_actions                = [aws_sns_topic.alarms.arn]
 
-    dimensions {
-        Environment = "${var.environment}"
-        Process     = "api-server"
-    }
+  dimensions = {
+    Environment = var.environment
+    Process     = "api-server"
+  }
 }
 
 resource "aws_cloudwatch_metric_alarm" "database_batch_writer_exception" {
-    count                     = "${var.enable_alarms == "true" ? 1 : 0}" # Don't create this if we turn off alarms (e.g. for dev)
+  count = var.enable_alarms == "true" ? 1 : 0 # Don't create this if we turn off alarms (e.g. for dev)
 
-    alarm_name                = "ingester-database encountered a DatabaseBatchWriterException ${var.environment}"
-    comparison_operator       = "GreaterThanOrEqualToThreshold"
-    evaluation_periods        = "1"
-    metric_name               = "DatabaseBatchWriterException"
-    namespace                 = "${var.metrics_namespace}"
-    period                    = "300"
-    statistic                 = "Sum"
-    threshold                 = "${var.ingester_database_batch_writer_exception_threshold}"
-    treat_missing_data        = "notBreaching" # No news is good news for exceptions
-    alarm_description         = "Alerts if ingester-database encounters an error writing to the database"
-    alarm_actions             = [ "${aws_sns_topic.alarms.arn}" ]
-    insufficient_data_actions = [ "${aws_sns_topic.alarms.arn}" ]
-    ok_actions                = [ "${aws_sns_topic.alarms.arn}" ]
+  alarm_name                = "ingester-database encountered a DatabaseBatchWriterException ${var.environment}"
+  comparison_operator       = "GreaterThanOrEqualToThreshold"
+  evaluation_periods        = "1"
+  metric_name               = "DatabaseBatchWriterException"
+  namespace                 = var.metrics_namespace
+  period                    = "300"
+  statistic                 = "Sum"
+  threshold                 = var.ingester_database_batch_writer_exception_threshold
+  treat_missing_data        = "notBreaching" # No news is good news for exceptions
+  alarm_description         = "Alerts if ingester-database encounters an error writing to the database"
+  alarm_actions             = [aws_sns_topic.alarms.arn]
+  insufficient_data_actions = [aws_sns_topic.alarms.arn]
+  ok_actions                = [aws_sns_topic.alarms.arn]
 
-    dimensions {
-        Environment = "${var.environment}"
-        Process     = "ingester-database"
-    }
+  dimensions = {
+    Environment = var.environment
+    Process     = "ingester-database"
+  }
 }
 
 resource "aws_cloudwatch_metric_alarm" "puller_flickr_max_batch_size_exceeded" {
-    count                     = "${var.enable_alarms == "true" ? 1 : 0}" # Don't create this if we turn off alarms (e.g. for dev)
+  count = var.enable_alarms == "true" ? 1 : 0 # Don't create this if we turn off alarms (e.g. for dev)
 
-    alarm_name                = "puller-flickr encountered a MaxBatchSizeExceeded error ${var.environment}"
-    comparison_operator       = "GreaterThanOrEqualToThreshold"
-    evaluation_periods        = "1"
-    metric_name               = "MaxBatchSizeExceeded"
-    namespace                 = "${var.metrics_namespace}"
-    period                    = "300"
-    statistic                 = "Sum"
-    threshold                 = "${var.puller_flickr_max_batch_size_exceeded_error_threshold}"
-    treat_missing_data        = "notBreaching" # No news is good news for exceptions
-    alarm_description         = "Alerts if puller-flickr tries to write too many favorite photos in a single batch"
-    alarm_actions             = [ "${aws_sns_topic.alarms.arn}" ]
-    insufficient_data_actions = [ "${aws_sns_topic.alarms.arn}" ]
-    ok_actions                = [ "${aws_sns_topic.alarms.arn}" ]
+  alarm_name                = "puller-flickr encountered a MaxBatchSizeExceeded error ${var.environment}"
+  comparison_operator       = "GreaterThanOrEqualToThreshold"
+  evaluation_periods        = "1"
+  metric_name               = "MaxBatchSizeExceeded"
+  namespace                 = var.metrics_namespace
+  period                    = "300"
+  statistic                 = "Sum"
+  threshold                 = var.puller_flickr_max_batch_size_exceeded_error_threshold
+  treat_missing_data        = "notBreaching" # No news is good news for exceptions
+  alarm_description         = "Alerts if puller-flickr tries to write too many favorite photos in a single batch"
+  alarm_actions             = [aws_sns_topic.alarms.arn]
+  insufficient_data_actions = [aws_sns_topic.alarms.arn]
+  ok_actions                = [aws_sns_topic.alarms.arn]
 
-    dimensions {
-        Environment = "${var.environment}"
-        Process     = "puller-flickr"
-    }
+  dimensions = {
+    Environment = var.environment
+    Process     = "puller-flickr"
+  }
 }
 
 resource "aws_cloudwatch_metric_alarm" "puller_flickr_max_neighbors_exceeded" {
-    count                     = "${var.enable_alarms == "true" ? 1 : 0}" # Don't create this if we turn off alarms (e.g. for dev)
+  count = var.enable_alarms == "true" ? 1 : 0 # Don't create this if we turn off alarms (e.g. for dev)
 
-    alarm_name                = "puller-flickr encountered a MaxNeighborsExceeded error ${var.environment}"
-    comparison_operator       = "GreaterThanOrEqualToThreshold"
-    evaluation_periods        = "1"
-    metric_name               = "MaxNeighborsExceeded"
-    namespace                 = "${var.metrics_namespace}"
-    period                    = "300"
-    statistic                 = "Sum"
-    threshold                 = "${var.puller_flickr_max_neighbors_exceeded_error_threshold}"
-    treat_missing_data        = "notBreaching" # No news is good news for exceptions
-    alarm_description         = "Alerts if puller-flickr tries to write too many neighbors to a single scheduler response item"
-    alarm_actions             = [ "${aws_sns_topic.alarms.arn}" ]
-    insufficient_data_actions = [ "${aws_sns_topic.alarms.arn}" ]
-    ok_actions                = [ "${aws_sns_topic.alarms.arn}" ]
+  alarm_name                = "puller-flickr encountered a MaxNeighborsExceeded error ${var.environment}"
+  comparison_operator       = "GreaterThanOrEqualToThreshold"
+  evaluation_periods        = "1"
+  metric_name               = "MaxNeighborsExceeded"
+  namespace                 = var.metrics_namespace
+  period                    = "300"
+  statistic                 = "Sum"
+  threshold                 = var.puller_flickr_max_neighbors_exceeded_error_threshold
+  treat_missing_data        = "notBreaching" # No news is good news for exceptions
+  alarm_description         = "Alerts if puller-flickr tries to write too many neighbors to a single scheduler response item"
+  alarm_actions             = [aws_sns_topic.alarms.arn]
+  insufficient_data_actions = [aws_sns_topic.alarms.arn]
+  ok_actions                = [aws_sns_topic.alarms.arn]
 
-    dimensions {
-        Environment = "${var.environment}"
-        Process     = "puller-flickr"
-    }
+  dimensions = {
+    Environment = var.environment
+    Process     = "puller-flickr"
+  }
 }
 
 resource "aws_cloudwatch_metric_alarm" "puller_flickr_max_flickr_api_exceptions_exceeded" {
-    count                     = "${var.enable_alarms == "true" ? 1 : 0}" # Don't create this if we turn off alarms (e.g. for dev)
+  count = var.enable_alarms == "true" ? 1 : 0 # Don't create this if we turn off alarms (e.g. for dev)
 
-    alarm_name                = "puller-flickr encountered a FlickrApiException error ${var.environment}"
-    comparison_operator       = "GreaterThanOrEqualToThreshold"
-    evaluation_periods        = "1"
-    metric_name               = "FlickrApiException"
-    namespace                 = "${var.metrics_namespace}"
-    period                    = "300"
-    statistic                 = "Sum"
-    threshold                 = "${var.puller_flickr_max_flickr_api_exceptions_threshold}"
-    treat_missing_data        = "notBreaching" # No news is good news for exceptions
-    alarm_description         = "Alerts if puller-flickr is unable to contact the Flickr API"
-    alarm_actions             = [ "${aws_sns_topic.alarms.arn}" ]
-    insufficient_data_actions = [ "${aws_sns_topic.alarms.arn}" ]
-    ok_actions                = [ "${aws_sns_topic.alarms.arn}" ]
+  alarm_name                = "puller-flickr encountered a FlickrApiException error ${var.environment}"
+  comparison_operator       = "GreaterThanOrEqualToThreshold"
+  evaluation_periods        = "1"
+  metric_name               = "FlickrApiException"
+  namespace                 = var.metrics_namespace
+  period                    = "300"
+  statistic                 = "Sum"
+  threshold                 = var.puller_flickr_max_flickr_api_exceptions_threshold
+  treat_missing_data        = "notBreaching" # No news is good news for exceptions
+  alarm_description         = "Alerts if puller-flickr is unable to contact the Flickr API"
+  alarm_actions             = [aws_sns_topic.alarms.arn]
+  insufficient_data_actions = [aws_sns_topic.alarms.arn]
+  ok_actions                = [aws_sns_topic.alarms.arn]
 
-    dimensions {
-        Environment = "${var.environment}"
-        Process     = "puller-flickr"
-    }
+  dimensions = {
+    Environment = var.environment
+    Process     = "puller-flickr"
+  }
 }
+

--- a/terraform/modules/alarms/queues.tf
+++ b/terraform/modules/alarms/queues.tf
@@ -1,65 +1,66 @@
 resource "aws_cloudwatch_metric_alarm" "dead_letter_queue_items" {
-    count                     = "${var.enable_alarms == "true" ? length(var.dead_letter_queue_names) : 0}" # Don't create this if we turn off alarms (e.g. for dev)
+  count = var.enable_alarms == "true" ? length(var.dead_letter_queue_names) : 0 # Don't create this if we turn off alarms (e.g. for dev)
 
-    alarm_name                = "${element(var.dead_letter_queue_names, count.index)} items" # Need to have a different name for each one, or else we only see one in the UI
-    comparison_operator       = "GreaterThanOrEqualToThreshold"
-    evaluation_periods        = "1"
-    metric_name               = "ApproximateNumberOfMessagesVisible"
-    namespace                 = "AWS/SQS"
-    period                    = "300"
-    statistic                 = "Sum"
-    threshold                 = "${var.dead_letter_queue_items_threshold}"
-    treat_missing_data        = "ignore" # Maintain alarm state on missing data - sometimes data will just be missing for queues for some reason
-    alarm_description         = "Alerts if a dead-letter queue has items in it"
-    alarm_actions             = [ "${aws_sns_topic.alarms.arn}" ]
-    insufficient_data_actions = [ "${aws_sns_topic.alarms.arn}" ]
-    ok_actions                = [ "${aws_sns_topic.alarms.arn}" ]
+  alarm_name                = "${element(var.dead_letter_queue_names, count.index)} items" # Need to have a different name for each one, or else we only see one in the UI
+  comparison_operator       = "GreaterThanOrEqualToThreshold"
+  evaluation_periods        = "1"
+  metric_name               = "ApproximateNumberOfMessagesVisible"
+  namespace                 = "AWS/SQS"
+  period                    = "300"
+  statistic                 = "Sum"
+  threshold                 = var.dead_letter_queue_items_threshold
+  treat_missing_data        = "ignore" # Maintain alarm state on missing data - sometimes data will just be missing for queues for some reason
+  alarm_description         = "Alerts if a dead-letter queue has items in it"
+  alarm_actions             = [aws_sns_topic.alarms.arn]
+  insufficient_data_actions = [aws_sns_topic.alarms.arn]
+  ok_actions                = [aws_sns_topic.alarms.arn]
 
-    dimensions {
-        QueueName   = "${element(var.dead_letter_queue_names, count.index)}" # Taken from https://github.com/hashicorp/terraform/issues/8600
-    }
+  dimensions = {
+    QueueName = element(var.dead_letter_queue_names, count.index) # Taken from https://github.com/hashicorp/terraform/issues/8600
+  }
 }
 
 resource "aws_cloudwatch_metric_alarm" "queue_item_size" {
-    count                     = "${var.enable_alarms == "true" ? length(var.queue_names) : 0}" # Don't create this if we turn off alarms (e.g. for dev)
+  count = var.enable_alarms == "true" ? length(var.queue_names) : 0 # Don't create this if we turn off alarms (e.g. for dev)
 
-    alarm_name                = "${element(var.queue_names, count.index)} item size" # Need to have a different name for each one, or else we only see one in the UI
-    comparison_operator       = "GreaterThanOrEqualToThreshold"
-    evaluation_periods        = "1"
-    metric_name               = "SentMessageSize"
-    namespace                 = "AWS/SQS"
-    period                    = "300"
-    statistic                 = "Maximum"
-    threshold                 = "${var.queue_item_size_threshold}"
-    treat_missing_data        = "ignore" # Maintain alarm state on missing data - sometimes data will just be missing for queues for some reason
-    alarm_description         = "Alerts if a queue has items that are too large"
-    alarm_actions             = [ "${aws_sns_topic.alarms.arn}" ]
-    insufficient_data_actions = [ "${aws_sns_topic.alarms.arn}" ]
-    ok_actions                = [ "${aws_sns_topic.alarms.arn}" ]
+  alarm_name                = "${element(var.queue_names, count.index)} item size" # Need to have a different name for each one, or else we only see one in the UI
+  comparison_operator       = "GreaterThanOrEqualToThreshold"
+  evaluation_periods        = "1"
+  metric_name               = "SentMessageSize"
+  namespace                 = "AWS/SQS"
+  period                    = "300"
+  statistic                 = "Maximum"
+  threshold                 = var.queue_item_size_threshold
+  treat_missing_data        = "ignore" # Maintain alarm state on missing data - sometimes data will just be missing for queues for some reason
+  alarm_description         = "Alerts if a queue has items that are too large"
+  alarm_actions             = [aws_sns_topic.alarms.arn]
+  insufficient_data_actions = [aws_sns_topic.alarms.arn]
+  ok_actions                = [aws_sns_topic.alarms.arn]
 
-    dimensions {
-        QueueName   = "${element(var.queue_names, count.index)}" # Taken from https://github.com/hashicorp/terraform/issues/8600
-    }
+  dimensions = {
+    QueueName = element(var.queue_names, count.index) # Taken from https://github.com/hashicorp/terraform/issues/8600
+  }
 }
 
 resource "aws_cloudwatch_metric_alarm" "queue_item_age" {
-    count                     = "${var.enable_alarms == "true" ? length(var.queue_names) : 0}" # Don't create this if we turn off alarms (e.g. for dev)
+  count = var.enable_alarms == "true" ? length(var.queue_names) : 0 # Don't create this if we turn off alarms (e.g. for dev)
 
-    alarm_name                = "${element(var.queue_names, count.index)} item age" # Need to have a different name for each one, or else we only see one in the UI
-    comparison_operator       = "GreaterThanOrEqualToThreshold"
-    evaluation_periods        = "1"
-    metric_name               = "ApproximateAgeOfOldestMessage"
-    namespace                 = "AWS/SQS"
-    period                    = "300"
-    statistic                 = "Maximum"
-    threshold                 = "${var.queue_item_age_threshold}"
-    treat_missing_data        = "ignore" # Maintain alarm state on missing data - sometimes data will just be missing for queues for some reason
-    alarm_description         = "Alerts if a queue has items that are too old. Has the process that consumes them stopped?"
-    alarm_actions             = [ "${aws_sns_topic.alarms.arn}" ]
-    insufficient_data_actions = [ "${aws_sns_topic.alarms.arn}" ]
-    ok_actions                = [ "${aws_sns_topic.alarms.arn}" ]
+  alarm_name                = "${element(var.queue_names, count.index)} item age" # Need to have a different name for each one, or else we only see one in the UI
+  comparison_operator       = "GreaterThanOrEqualToThreshold"
+  evaluation_periods        = "1"
+  metric_name               = "ApproximateAgeOfOldestMessage"
+  namespace                 = "AWS/SQS"
+  period                    = "300"
+  statistic                 = "Maximum"
+  threshold                 = var.queue_item_age_threshold
+  treat_missing_data        = "ignore" # Maintain alarm state on missing data - sometimes data will just be missing for queues for some reason
+  alarm_description         = "Alerts if a queue has items that are too old. Has the process that consumes them stopped?"
+  alarm_actions             = [aws_sns_topic.alarms.arn]
+  insufficient_data_actions = [aws_sns_topic.alarms.arn]
+  ok_actions                = [aws_sns_topic.alarms.arn]
 
-    dimensions {
-        QueueName   = "${element(var.queue_names, count.index)}" # Taken from https://github.com/hashicorp/terraform/issues/8600
-    }
+  dimensions = {
+    QueueName = element(var.queue_names, count.index) # Taken from https://github.com/hashicorp/terraform/issues/8600
+  }
 }
+

--- a/terraform/modules/alarms/sns-topic.tf
+++ b/terraform/modules/alarms/sns-topic.tf
@@ -1,8 +1,8 @@
 # Based on https://stephenmann.io/post/setting-up-monitoring-and-alerting-on-amazon-aws-with-terraform/
 
 resource "aws_sns_topic" "alarms" {
-    name = "${var.topic_name}-${var.environment}"
-    delivery_policy = <<EOF
+  name            = "${var.topic_name}-${var.environment}"
+  delivery_policy = <<EOF
 {
   "http": {
     "defaultHealthyRetryPolicy": {
@@ -22,7 +22,9 @@ resource "aws_sns_topic" "alarms" {
 }
 EOF
 
-    provisioner "local-exec" {
-        command = "aws sns subscribe --topic-arn ${self.arn} --protocol email --notification-endpoint ${var.alarms_email} --region ${var.region}"
-    }
+
+  provisioner "local-exec" {
+    command = "aws sns subscribe --topic-arn ${self.arn} --protocol email --notification-endpoint ${var.alarms_email} --region ${var.region}"
+  }
 }
+

--- a/terraform/modules/alarms/variables.tf
+++ b/terraform/modules/alarms/variables.tf
@@ -1,37 +1,85 @@
-variable "environment" {}
-variable "region" {}
-variable "metrics_namespace" {}
-variable "topic_name" {}
-variable "alarms_email" {}
-variable "enable_alarms" {}
-variable "unhandled_exceptions_threshold" {}
-variable "dead_letter_queue_items_threshold" {}
-variable "users_store_exception_threshold" {}
-variable "api_server_favorites_store_exception_threshold" {}
-variable "api_server_generic_exception_threshold" {}
-variable "queue_item_size_threshold" {}
-variable "queue_item_age_threshold" {}
-variable "queue_reader_error_threshold" {}
-variable "queue_writer_error_threshold" {}
-variable "ingester_database_batch_writer_exception_threshold" {}
-variable "puller_flickr_max_batch_size_exceeded_error_threshold" {}
-variable "puller_flickr_max_neighbors_exceeded_error_threshold" {}
-variable "puller_flickr_max_flickr_api_exceptions_threshold" {}
-variable "process_names" { 
-    type = "list" 
-    default = ["api-server", "scheduler", "puller-flickr", "ingester-database", "puller-response-reader", "ingester-response-reader"]
+variable "environment" {
 }
-variable "process_names_that_read_from_queues" { 
-    type = "list" 
-    default = ["scheduler", "puller-flickr", "ingester-database", "puller-response-reader", "ingester-response-reader"]
+
+variable "region" {
 }
-variable "process_names_that_write_to_queues" { 
-    type = "list" 
-    default = ["scheduler", "puller-flickr", "puller-response-reader", "api-server"]
+
+variable "metrics_namespace" {
 }
+
+variable "topic_name" {
+}
+
+variable "alarms_email" {
+}
+
+variable "enable_alarms" {
+}
+
+variable "unhandled_exceptions_threshold" {
+}
+
+variable "dead_letter_queue_items_threshold" {
+}
+
+variable "users_store_exception_threshold" {
+}
+
+variable "api_server_favorites_store_exception_threshold" {
+}
+
+variable "api_server_generic_exception_threshold" {
+}
+
+variable "queue_item_size_threshold" {
+}
+
+variable "queue_item_age_threshold" {
+}
+
+variable "queue_reader_error_threshold" {
+}
+
+variable "queue_writer_error_threshold" {
+}
+
+variable "ingester_database_batch_writer_exception_threshold" {
+}
+
+variable "puller_flickr_max_batch_size_exceeded_error_threshold" {
+}
+
+variable "puller_flickr_max_neighbors_exceeded_error_threshold" {
+}
+
+variable "puller_flickr_max_flickr_api_exceptions_threshold" {
+}
+
+variable "process_names" {
+  type    = list(string)
+  default = ["api-server", "scheduler", "puller-flickr", "ingester-database", "puller-response-reader", "ingester-response-reader"]
+}
+
+variable "process_names_that_read_from_queues" {
+  type    = list(string)
+  default = ["scheduler", "puller-flickr", "ingester-database", "puller-response-reader", "ingester-response-reader"]
+}
+
+variable "process_names_that_write_to_queues" {
+  type    = list(string)
+  default = ["scheduler", "puller-flickr", "puller-response-reader", "api-server"]
+}
+
 variable "process_names_that_use_api_server" {
-    type = "list"
-    default = ["scheduler", "puller-response-reader", "ingester-response-reader"]
+  type    = list(string)
+  default = ["scheduler", "puller-response-reader", "ingester-response-reader"]
 }
-variable "queue_names" { type = "list" }
-variable "dead_letter_queue_names" { type = "list" }
+
+variable "queue_names" {
+  type = list(string)
+}
+
+variable "dead_letter_queue_names" {
+  type = list(string)
+}
+

--- a/terraform/modules/alarms/versions.tf
+++ b/terraform/modules/alarms/versions.tf
@@ -1,0 +1,4 @@
+
+terraform {
+  required_version = ">= 0.12"
+}

--- a/terraform/modules/api-server/build.tf
+++ b/terraform/modules/api-server/build.tf
@@ -1,14 +1,15 @@
 module "build" {
   source = "../build-pipeline-backend"
 
-  environment               = "${var.environment}"
-  region                    = "${var.region}"
-  process_name              = "${var.process_name}"
-  project_github_location   = "${var.project_github_location}"
-  build_logs_bucket_id      = "${var.build_logs_bucket_id}"
-  buildspec_location        = "${var.buildspec_location}"
-  file_path                 = "${var.file_path}"
-  file_path_common          = "${var.file_path_common}"
-  build_service_role_arn    = "${var.build_service_role_arn}"
-  container_repository_name = "${module.container_repository.repository_name}"
+  environment               = var.environment
+  region                    = var.region
+  process_name              = var.process_name
+  project_github_location   = var.project_github_location
+  build_logs_bucket_id      = var.build_logs_bucket_id
+  buildspec_location        = var.buildspec_location
+  file_path                 = var.file_path
+  file_path_common          = var.file_path_common
+  build_service_role_arn    = var.build_service_role_arn
+  container_repository_name = module.container_repository.repository_name
 }
+

--- a/terraform/modules/api-server/container-repository.tf
+++ b/terraform/modules/api-server/container-repository.tf
@@ -1,7 +1,8 @@
 module "container_repository" {
-    source = "../container-repository"
+  source = "../container-repository"
 
-    name = "api-server"
-    environment = "${var.environment}"
-    num_days_to_keep_images = "${var.ecs_days_to_keep_images}"
+  name                    = "api-server"
+  environment             = var.environment
+  num_days_to_keep_images = var.ecs_days_to_keep_images
 }
+

--- a/terraform/modules/api-server/load-balancer.tf
+++ b/terraform/modules/api-server/load-balancer.tf
@@ -1,97 +1,99 @@
 resource "aws_lb" "api_server" {
-    name               = "api-server-lb-${var.environment}"
-    internal           = false
-    load_balancer_type = "application"
-    security_groups    = ["${aws_security_group.load_balancer.id}"]
-    subnets            = ["${var.vpc_public_subnet_ids}"]
-    idle_timeout       = 60
-    ip_address_type    = "ipv4"
+  name               = "api-server-lb-${var.environment}"
+  internal           = false
+  load_balancer_type = "application"
+  security_groups    = [aws_security_group.load_balancer.id]
+  subnets            = var.vpc_public_subnet_ids
+  idle_timeout       = 60
+  ip_address_type    = "ipv4"
 
-    access_logs {
-        bucket  = "${aws_s3_bucket.load_balancer_access_logs.id}"
-        prefix  = "${var.load_balancer_access_logs_prefix}-${var.environment}"
-        enabled = true
-    }
+  access_logs {
+    bucket  = aws_s3_bucket.load_balancer_access_logs.id
+    prefix  = "${var.load_balancer_access_logs_prefix}-${var.environment}"
+    enabled = true
+  }
 
-    tags = {
-        Environment = "${var.environment}"
-    }
+  tags = {
+    Environment = var.environment
+  }
 }
 
 resource "aws_lb_target_group" "load_balancer" {
-    name                    = "api-server-lb-tg-${var.environment}"
-    port                    = "${var.api_server_port}"
-    protocol                = "HTTP"
-    vpc_id                  = "${var.vpc_id}"
-    deregistration_delay    = 300
-    slow_start              = 0
+  name                 = "api-server-lb-tg-${var.environment}"
+  port                 = var.api_server_port
+  protocol             = "HTTP"
+  vpc_id               = var.vpc_id
+  deregistration_delay = 300
+  slow_start           = 0
 
-    health_check {
-        interval            = 30
-        path                = "/healthcheck"
-        port                = "${var.api_server_port}"
-        protocol            = "HTTP"
-        timeout             = 6
-        healthy_threshold   = 3
-        unhealthy_threshold = 3
-        matcher             = "200"
-    }
+  health_check {
+    interval            = 30
+    path                = "/healthcheck"
+    port                = var.api_server_port
+    protocol            = "HTTP"
+    timeout             = 6
+    healthy_threshold   = 3
+    unhealthy_threshold = 3
+    matcher             = "200"
+  }
 
-    depends_on              = ["aws_lb.api_server"] # https://github.com/cds-snc/aws-ecs-fargate/issues/1
+  depends_on = [aws_lb.api_server] # https://github.com/cds-snc/aws-ecs-fargate/issues/1
 }
 
-resource "aws_lb_listener" "api_server" {  
-    load_balancer_arn = "${aws_lb.api_server.arn}"  
-    port              = "${var.load_balancer_port}"  
-    protocol          = "HTTP"
-  
-    default_action {    
-        target_group_arn = "${aws_lb_target_group.load_balancer.arn}"
-        type             = "forward"  
-    }
+resource "aws_lb_listener" "api_server" {
+  load_balancer_arn = aws_lb.api_server.arn
+  port              = var.load_balancer_port
+  protocol          = "HTTP"
+
+  default_action {
+    target_group_arn = aws_lb_target_group.load_balancer.arn
+    type             = "forward"
+  }
 }
 
 resource "aws_security_group" "load_balancer" {
-    name        = "security-group-load-balancer-${var.environment}"
-    description = "Allow access from our local machine to our load balancer"
-    vpc_id      = "${var.vpc_id}"
+  name        = "security-group-load-balancer-${var.environment}"
+  description = "Allow access from our local machine to our load balancer"
+  vpc_id      = var.vpc_id
 
-    ingress {
-        from_port   = "${var.load_balancer_port}"
-        to_port     = "${var.load_balancer_port}"
-        protocol    = "tcp"
-        cidr_blocks = [
-            "0.0.0.0/0" # internet-facing load balancer should accept traffic from everywhere: https://docs.aws.amazon.com/elasticloadbalancing/latest/application/load-balancer-update-security-groups.html
-        ]
-    }
+  ingress {
+    from_port = var.load_balancer_port
+    to_port   = var.load_balancer_port
+    protocol  = "tcp"
+    cidr_blocks = [
+      "0.0.0.0/0",
+    ] # internet-facing load balancer should accept traffic from everywhere: https://docs.aws.amazon.com/elasticloadbalancing/latest/application/load-balancer-update-security-groups.html
+  }
 
-    egress {
-        # allow all traffic to private SN
-        from_port = "0"
-        to_port = "0"
-        protocol = "-1"
-        cidr_blocks = [
-            "0.0.0.0/0"
-        ]
-    }
+  egress {
+    # allow all traffic to private SN
+    from_port = "0"
+    to_port   = "0"
+    protocol  = "-1"
+    cidr_blocks = [
+      "0.0.0.0/0",
+    ]
+  }
 
-    tags { 
-        Name = "security-group-load-balancer-${var.environment}"
-    }
+  tags = {
+    Name = "security-group-load-balancer-${var.environment}"
+  }
 }
 
 # Setup bucket policy so load balancer can write to it.
 # Taken from https://docs.aws.amazon.com/elasticloadbalancing/latest/application/load-balancer-access-logs.html
 
-data "aws_caller_identity" "load_balancer" {}
+data "aws_caller_identity" "load_balancer" {
+}
 
-data "aws_elb_service_account" "main" {}
+data "aws_elb_service_account" "main" {
+}
 
 resource "aws_s3_bucket" "load_balancer_access_logs" {
-    bucket = "${var.load_balancer_access_logs_bucket}${var.bucketname_user_string}-${var.environment}"
-    acl    = "bucket-owner-full-control"
-    force_destroy = "${!var.retain_load_balancer_access_logs_after_destroy}"
-    policy = <<EOF
+  bucket        = "${var.load_balancer_access_logs_bucket}${var.bucketname_user_string}-${var.environment}"
+  acl           = "bucket-owner-full-control"
+  force_destroy = false == var.retain_load_balancer_access_logs_after_destroy
+  policy        = <<EOF
 {
   "Id": "Policy1429136655940",
   "Version": "2012-10-17",
@@ -111,36 +113,39 @@ resource "aws_s3_bucket" "load_balancer_access_logs" {
     }
   ]
 }
-    EOF
+    
+EOF
 
-    lifecycle_rule {
-        id      = "expire-logs-after-N-days"
-        enabled = true
 
-        prefix = "*"
+  lifecycle_rule {
+    id      = "expire-logs-after-N-days"
+    enabled = true
 
-        expiration {
-            days = "${var.load_balancer_days_to_keep_access_logs}"
-        }
+    prefix = "*"
+
+    expiration {
+      days = var.load_balancer_days_to_keep_access_logs
     }
+  }
 
-    server_side_encryption_configuration {
-        rule {
-            apply_server_side_encryption_by_default {
-                # It seems that the ALB isn't able to write to the bucket if we set this to "aws:kms": 
-                # we get an error saying "Failure configuring LB attributes: InvalidConfigurationRequest: Access Denied for bucket". 
-                # It also seems to be implied by the docs here that we need to use AES: https://docs.aws.amazon.com/elasticloadbalancing/latest/application/load-balancer-access-logs.html
-                sse_algorithm = "AES256" 
-            }
-        }
+  server_side_encryption_configuration {
+    rule {
+      apply_server_side_encryption_by_default {
+        # It seems that the ALB isn't able to write to the bucket if we set this to "aws:kms": 
+        # we get an error saying "Failure configuring LB attributes: InvalidConfigurationRequest: Access Denied for bucket". 
+        # It also seems to be implied by the docs here that we need to use AES: https://docs.aws.amazon.com/elasticloadbalancing/latest/application/load-balancer-access-logs.html
+        sse_algorithm = "AES256"
+      }
     }
+  }
 }
 
 resource "aws_s3_bucket_public_access_block" "load_balancer_access_logs" {
-    bucket = "${aws_s3_bucket.load_balancer_access_logs.id}"
+  bucket = aws_s3_bucket.load_balancer_access_logs.id
 
-    block_public_acls         = true
-    block_public_policy       = true
-    ignore_public_acls        = true
-    restrict_public_buckets   = true
+  block_public_acls       = true
+  block_public_policy     = true
+  ignore_public_acls      = true
+  restrict_public_buckets = true
 }
+

--- a/terraform/modules/api-server/outputs.tf
+++ b/terraform/modules/api-server/outputs.tf
@@ -1,24 +1,25 @@
 output "security_group_id" {
-    value = "${aws_security_group.api_server.id}"
-    description = "The ID of the security group we created containing the rules for talking to our API server"
+  value       = aws_security_group.api_server.id
+  description = "The ID of the security group we created containing the rules for talking to our API server"
 }
 
 output "load_balancer_port" {
-    value = "${var.load_balancer_port}"
-    description = "The port the load balancer is listening on"
+  value       = var.load_balancer_port
+  description = "The port the load balancer is listening on"
 }
 
 output "load_balancer_dns_name" {
-    value = "${aws_lb.api_server.dns_name}"
-    description = "DNS name of the load balancer we created"
+  value       = aws_lb.api_server.dns_name
+  description = "DNS name of the load balancer we created"
 }
 
 output "load_balancer_zone_id" {
-    value = "${aws_lb.api_server.zone_id}"
-    description = "Zone ID of the load balancer we created"
+  value       = aws_lb.api_server.zone_id
+  description = "Zone ID of the load balancer we created"
 }
 
 output "load_balancer_arn" {
-    value = "${aws_lb.api_server.arn}"
-    description = "ARN of the load balancer we created"
+  value       = aws_lb.api_server.arn
+  description = "ARN of the load balancer we created"
 }
+

--- a/terraform/modules/api-server/parameter-store.tf
+++ b/terraform/modules/api-server/parameter-store.tf
@@ -1,178 +1,179 @@
 resource "aws_ssm_parameter" "metrics_namespace" {
-    name        = "/${var.environment}/api-server/metrics-namespace"
-    description = "Namespace that our metrics go in"
-    type        = "String"
-    value       = "${var.metrics_namespace}"
+  name        = "/${var.environment}/api-server/metrics-namespace"
+  description = "Namespace that our metrics go in"
+  type        = "String"
+  value       = var.metrics_namespace
 }
 
 resource "aws_ssm_parameter" "parameter_memcached_location" {
-    name        = "/${var.environment}/api-server/parameter-memcached-location"
-    description = "Where to find a memcached instance to cache our parameter values"
-    type        = "String"
-    value       = "${var.parameter_memcached_location}"
+  name        = "/${var.environment}/api-server/parameter-memcached-location"
+  description = "Where to find a memcached instance to cache our parameter values"
+  type        = "String"
+  value       = var.parameter_memcached_location
 }
 
 resource "aws_ssm_parameter" "database_host" {
-    name        = "/${var.environment}/api-server/database-host"
-    description = "Host for the database from which we read our data"
-    type        = "String"
-    value       = "${var.mysql_database_host}"
+  name        = "/${var.environment}/api-server/database-host"
+  description = "Host for the database from which we read our data"
+  type        = "String"
+  value       = var.mysql_database_host
 }
 
 resource "aws_ssm_parameter" "database_port" {
-    name        = "/${var.environment}/api-server/database-port"
-    description = "Port for the database from which we read our data"
-    type        = "String"
-    value       = "${var.mysql_database_port}"
+  name        = "/${var.environment}/api-server/database-port"
+  description = "Port for the database from which we read our data"
+  type        = "String"
+  value       = var.mysql_database_port
 }
 
 resource "aws_ssm_parameter" "database_username" {
-    name        = "/${var.environment}/api-server/database-username"
-    description = "Username for the database from which we read our data"
-    type        = "String"
-    value       = "${var.mysql_database_username}"
+  name        = "/${var.environment}/api-server/database-username"
+  description = "Username for the database from which we read our data"
+  type        = "String"
+  value       = var.mysql_database_username
 }
 
 resource "aws_ssm_parameter" "database_password" {
-    name        = "/${var.environment}/api-server/database-password"
-    description = "Password for the database from which we read our data"
-    type        = "SecureString"
-    key_id      = "${var.kms_key_id}"
-    value       = "${var.mysql_database_password}"
+  name        = "/${var.environment}/api-server/database-password"
+  description = "Password for the database from which we read our data"
+  type        = "SecureString"
+  key_id      = var.kms_key_id
+  value       = var.mysql_database_password
 }
 
 resource "aws_ssm_parameter" "database_name" {
-    name        = "/${var.environment}/api-server/database-name"
-    description = "Name for the database from which we read our data"
-    type        = "String"
-    value       = "${var.mysql_database_name}"
+  name        = "/${var.environment}/api-server/database-name"
+  description = "Name for the database from which we read our data"
+  type        = "String"
+  value       = var.mysql_database_name
 }
 
 resource "aws_ssm_parameter" "database_fetch_batch_size" {
-    name        = "/${var.environment}/api-server/database-fetch-batch-size"
-    description = "Number of records to read from the database per batch"
-    type        = "String"
-    value       = "${var.mysql_database_fetch_batch_size}"
+  name        = "/${var.environment}/api-server/database-fetch-batch-size"
+  description = "Number of records to read from the database per batch"
+  type        = "String"
+  value       = var.mysql_database_fetch_batch_size
 }
 
 resource "aws_ssm_parameter" "database_connection_pool_size" {
-    name        = "/${var.environment}/api-server/database-connection-pool-size"
-    description = "Size of our pool of connections to the database"
-    type        = "String"
-    value       = "${var.mysql_database_connection_pool_size}"
+  name        = "/${var.environment}/api-server/database-connection-pool-size"
+  description = "Size of our pool of connections to the database"
+  type        = "String"
+  value       = var.mysql_database_connection_pool_size
 }
 
 resource "aws_ssm_parameter" "database_user_data_encryption_key" {
-    name        = "/${var.environment}/api-server/database-user-data-encryption-key"
-    description = "256-bit AES encryption key used to encrypt user access tokens stored in the database"
-    type        = "SecureString"
-    key_id      = "${var.kms_key_id}"
-    value       = "${var.mysql_database_user_data_encryption_key}"
+  name        = "/${var.environment}/api-server/database-user-data-encryption-key"
+  description = "256-bit AES encryption key used to encrypt user access tokens stored in the database"
+  type        = "SecureString"
+  key_id      = var.kms_key_id
+  value       = var.mysql_database_user_data_encryption_key
 }
 
 resource "aws_ssm_parameter" "api_server_host" {
-    name        = "/${var.environment}/api-server/server-host"
-    description = "Host we listen on to serve requests"
-    type        = "String"
-    value       = "0.0.0.0"
+  name        = "/${var.environment}/api-server/server-host"
+  description = "Host we listen on to serve requests"
+  type        = "String"
+  value       = "0.0.0.0"
 }
 
 resource "aws_ssm_parameter" "api_server_port" {
-    name        = "/${var.environment}/api-server/server-port"
-    description = "Port we listen on to serve requests"
-    type        = "String"
-    value       = "${var.api_server_port}"
+  name        = "/${var.environment}/api-server/server-port"
+  description = "Port we listen on to serve requests"
+  type        = "String"
+  value       = var.api_server_port
 }
 
 resource "aws_ssm_parameter" "session_encryption_key" {
-    name        = "/${var.environment}/api-server/session-encryption-key"
-    description = "Encryption key used to sign the session data we return to the user"
-    type        = "SecureString"
-    key_id      = "${var.kms_key_id}"
-    value       = "${var.session_encryption_key}"
+  name        = "/${var.environment}/api-server/session-encryption-key"
+  description = "Encryption key used to sign the session data we return to the user"
+  type        = "SecureString"
+  key_id      = var.kms_key_id
+  value       = var.session_encryption_key
 }
 
 resource "aws_ssm_parameter" "flickr_api_key" {
-    name        = "/${var.environment}/api-server/flickr-api-key"
-    description = "Flickr API key"
-    type        = "String"
-    value       = "${var.flickr_api_key}"
+  name        = "/${var.environment}/api-server/flickr-api-key"
+  description = "Flickr API key"
+  type        = "String"
+  value       = var.flickr_api_key
 }
 
 resource "aws_ssm_parameter" "flickr_secret_key" {
-    name        = "/${var.environment}/api-server/flickr-api-secret"
-    description = "Flickr API secret key"
-    type        = "SecureString"
-    key_id      = "${var.kms_key_id}"
-    value       = "${var.flickr_secret_key}"
+  name        = "/${var.environment}/api-server/flickr-api-secret"
+  description = "Flickr API secret key"
+  type        = "SecureString"
+  key_id      = var.kms_key_id
+  value       = var.flickr_secret_key
 }
 
 resource "aws_ssm_parameter" "flickr_api_retries" {
-    name        = "/${var.environment}/api-server/flickr-api-retries"
-    description = "Max number of times to retry a Flickr API call"
-    type        = "String"
-    value       = "${var.flickr_api_retries}"
+  name        = "/${var.environment}/api-server/flickr-api-retries"
+  description = "Max number of times to retry a Flickr API call"
+  type        = "String"
+  value       = var.flickr_api_retries
 }
 
 resource "aws_ssm_parameter" "flickr_api_memcached_ttl" {
-    name        = "/${var.environment}/api-server/flickr-api-memcached-ttl"
-    description = "TTL in seconds of Flickr API calls put into memcached"
-    type        = "String"
-    value       = "${var.flickr_api_memcached_ttl}"
+  name        = "/${var.environment}/api-server/flickr-api-memcached-ttl"
+  description = "TTL in seconds of Flickr API calls put into memcached"
+  type        = "String"
+  value       = var.flickr_api_memcached_ttl
 }
 
 resource "aws_ssm_parameter" "flickr_api_memcached_location" {
-    name        = "/${var.environment}/api-server/flickr-api-memcached-location"
-    description = "Endpoint of the memcached cluster that we cache Flickr API calls to"
-    type        = "String"
-    value       = "${var.flickr_api_memcached_location}"
+  name        = "/${var.environment}/api-server/flickr-api-memcached-location"
+  description = "Endpoint of the memcached cluster that we cache Flickr API calls to"
+  type        = "String"
+  value       = var.flickr_api_memcached_location
 }
 
 resource "aws_ssm_parameter" "flickr_auth_memcached_location" {
-    name        = "/${var.environment}/api-server/flickr-auth-memcached-location"
-    description = "Endpoint of the memcached cluster that we cache temporary Flickr auth request tokens in"
-    type        = "String"
-    value       = "${var.flickr_auth_memcached_location}"
+  name        = "/${var.environment}/api-server/flickr-auth-memcached-location"
+  description = "Endpoint of the memcached cluster that we cache temporary Flickr auth request tokens in"
+  type        = "String"
+  value       = var.flickr_auth_memcached_location
 }
 
 resource "aws_ssm_parameter" "flickr_auth_cache_type" {
-    name        = "/${var.environment}/api-server/flickr-auth-cache-type"
-    description = "Type of cache that we use to store temporary Flickr auth request tokens in"
-    type        = "String"
-    value       = "memcached"
+  name        = "/${var.environment}/api-server/flickr-auth-cache-type"
+  description = "Type of cache that we use to store temporary Flickr auth request tokens in"
+  type        = "String"
+  value       = "memcached"
 }
 
 resource "aws_ssm_parameter" "default_num_photo_recommendations" {
-    name        = "/${var.environment}/api-server/default-num-photo-recommendations"
-    description = "Number of photo recommendations we return if the caller doesn't specify"
-    type        = "String"
-    value       = "${var.default_num_photo_recommendations}"
+  name        = "/${var.environment}/api-server/default-num-photo-recommendations"
+  description = "Number of photo recommendations we return if the caller doesn't specify"
+  type        = "String"
+  value       = var.default_num_photo_recommendations
 }
 
 resource "aws_ssm_parameter" "default_num_user_recommendations" {
-    name        = "/${var.environment}/api-server/default-num-user-recommendations"
-    description = "Number of user recommendations we return if the caller doesn't specify"
-    type        = "String"
-    value       = "${var.default_num_user_recommendations}"
+  name        = "/${var.environment}/api-server/default-num-user-recommendations"
+  description = "Number of user recommendations we return if the caller doesn't specify"
+  type        = "String"
+  value       = var.default_num_user_recommendations
 }
 
 resource "aws_ssm_parameter" "default_num_photos_from_group" {
-    name        = "/${var.environment}/api-server/default-num-photos-from-group"
-    description = "Number of photos from a group we return if the caller doesn't specify"
-    type        = "String"
-    value       = "${var.default_num_photos_from_group}"
+  name        = "/${var.environment}/api-server/default-num-photos-from-group"
+  description = "Number of photos from a group we return if the caller doesn't specify"
+  type        = "String"
+  value       = var.default_num_photos_from_group
 }
 
 resource "aws_ssm_parameter" "puller_queue_url" {
-    name        = "/${var.environment}/api-server/puller-queue-url"
-    description = "URL of the queue to put requests for data to be pulled"
-    type        = "String"
-    value       = "${var.puller_queue_url}"
+  name        = "/${var.environment}/api-server/puller-queue-url"
+  description = "URL of the queue to put requests for data to be pulled"
+  type        = "String"
+  value       = var.puller_queue_url
 }
 
 resource "aws_ssm_parameter" "puller_queue_batch_size" {
-    name        = "/${var.environment}/api-server/puller-queue-batchsize"
-    description = "Number of items to put on the puller queue in a single batch"
-    type        = "String"
-    value       = "${var.puller_queue_batch_size}"
+  name        = "/${var.environment}/api-server/puller-queue-batchsize"
+  description = "Number of items to put on the puller queue in a single batch"
+  type        = "String"
+  value       = var.puller_queue_batch_size
 }
+

--- a/terraform/modules/api-server/security-group.tf
+++ b/terraform/modules/api-server/security-group.tf
@@ -1,27 +1,28 @@
 resource "aws_security_group" "api_server" {
-    name = "security-group-api-server-${var.environment}"
-    description = "Allow access from our local machine and VPC (i.e. the load balancer) to the port we are listening on"
-    vpc_id = "${var.vpc_id}"
+  name        = "security-group-api-server-${var.environment}"
+  description = "Allow access from our local machine and VPC (i.e. the load balancer) to the port we are listening on"
+  vpc_id      = var.vpc_id
 
-    ingress {
-        from_port = "${var.api_server_port}"
-        to_port = "${var.api_server_port}"
-        protocol = "tcp"
-        cidr_blocks = [
-            "${var.local_machine_cidr}"
-        ]
-    }
+  ingress {
+    from_port = var.api_server_port
+    to_port   = var.api_server_port
+    protocol  = "tcp"
+    cidr_blocks = [
+      var.local_machine_cidr,
+    ]
+  }
 
-    ingress {
-        from_port = "${var.api_server_port}"
-        to_port = "${var.api_server_port}"
-        protocol = "tcp"
-        cidr_blocks = [
-            "${var.vpc_cidr}"
-        ]
-    }
+  ingress {
+    from_port = var.api_server_port
+    to_port   = var.api_server_port
+    protocol  = "tcp"
+    cidr_blocks = [
+      var.vpc_cidr,
+    ]
+  }
 
-    tags { 
-        Name = "security-group-api-server-${var.environment}"
-    }
+  tags = {
+    Name = "security-group-api-server-${var.environment}"
+  }
 }
+

--- a/terraform/modules/api-server/task-definition.tf
+++ b/terraform/modules/api-server/task-definition.tf
@@ -1,25 +1,24 @@
 module "task_definition" {
-    source = "../task-definition"
+  source = "../task-definition"
 
-    name                        = "api-server-${var.environment}"
-    environment                 = "${var.environment}"
-    region                      = "${var.region}"
-    container_repository_url    = "${module.container_repository.repository_url}"
-    cluster_id                  = "${var.ecs_cluster_id}"
-    instances_memory            = "${var.ecs_instances_memory}"
-    instances_cpu               = "${var.ecs_instances_cpu}"
-    instances_log_configuration = "${var.ecs_instances_log_configuration}"
-    instances_desired_count     = "${var.ecs_instances_desired_count}"
-    instances_role_name         = "${var.ecs_instances_role_name}"
-    instances_extra_policy_arn  = "${aws_iam_policy.ecs-instance-api-server-extra-policy.arn}"
-    port_mappings               = "${data.template_file.port_mappings.rendered}"
-    has_load_balancer           = true
-    load_balancer_container_port = "${var.api_server_port}"
-    load_balancer_target_group_arn = "${aws_lb_target_group.load_balancer.arn}"
+  name                           = "api-server-${var.environment}"
+  environment                    = var.environment
+  region                         = var.region
+  container_repository_url       = module.container_repository.repository_url
+  cluster_id                     = var.ecs_cluster_id
+  instances_memory               = var.ecs_instances_memory
+  instances_cpu                  = var.ecs_instances_cpu
+  instances_log_configuration    = var.ecs_instances_log_configuration
+  instances_desired_count        = var.ecs_instances_desired_count
+  instances_role_name            = var.ecs_instances_role_name
+  instances_extra_policy_arn     = aws_iam_policy.ecs-instance-api-server-extra-policy.arn
+  port_mappings                  = data.template_file.port_mappings.rendered
+  has_load_balancer              = true
+  load_balancer_container_port   = var.api_server_port
+  load_balancer_target_group_arn = aws_lb_target_group.load_balancer.arn
 }
 
 data "aws_caller_identity" "api-server" {
-  
 }
 
 resource "aws_iam_policy" "ecs-instance-api-server-extra-policy" {
@@ -55,11 +54,12 @@ resource "aws_iam_policy" "ecs-instance-api-server-extra-policy" {
   ]
 }
 EOF
+
 }
 
 # Part of a task definition, used in the task-definition module
 data "template_file" "port_mappings" {
-    template = <<EOF
+  template = <<EOF
     "portMappings": [
       {
         "containerPort": ${var.api_server_port},
@@ -67,4 +67,6 @@ data "template_file" "port_mappings" {
       }
     ],
 EOF
+
 }
+

--- a/terraform/modules/api-server/variables.tf
+++ b/terraform/modules/api-server/variables.tf
@@ -1,52 +1,157 @@
-variable "environment" {}
-variable "region" {}
-variable "metrics_namespace" {}
-variable "parameter_memcached_location" {}
-variable "mysql_database_host" {}
-variable "mysql_database_port" {}
-variable "mysql_database_username" {}
-variable "mysql_database_password" {}
-variable "mysql_database_name" {}
-variable "mysql_database_fetch_batch_size" {}
-variable "mysql_database_connection_pool_size" {}
-variable "mysql_database_user_data_encryption_key" {}
-variable "vpc_id" {}
-variable "vpc_public_subnet_ids" { type = "list" }
-variable "vpc_cidr" {}
-variable "ecs_instances_desired_count" {}
-variable "ecs_instances_memory" {}
-variable "ecs_instances_cpu" {}
-variable "ecs_cluster_id" {}
-variable "ecs_instances_log_configuration" {}
-variable "ecs_instances_role_name" {}
-variable "ecs_days_to_keep_images" {}
-variable "local_machine_cidr" {}
-variable "api_server_port" {}
-variable "session_encryption_key" {}
-variable "load_balancer_port" {}
-variable "load_balancer_days_to_keep_access_logs" {}
-variable "load_balancer_access_logs_bucket" {}
-variable "load_balancer_access_logs_prefix" {}
-variable "bucketname_user_string" {}
-variable "retain_load_balancer_access_logs_after_destroy" {}
-variable "default_num_photo_recommendations" {}
-variable "default_num_user_recommendations" {}
-variable "default_num_photos_from_group" {}
-variable "flickr_api_key" {}
-variable "flickr_secret_key" {}
-variable "flickr_api_retries" {}
-variable "flickr_api_memcached_location" {}
-variable "flickr_api_memcached_ttl" {}
-variable "flickr_auth_memcached_location" {}
-variable "puller_queue_batch_size" {}
-variable "puller_queue_url" {}
-variable "puller_queue_arn" {}
-variable "process_name" {}
-variable "project_github_location" {}
-variable "build_logs_bucket_id" {}
-variable "buildspec_location" {}
-variable "file_path" {}
-variable "file_path_common" {}
-variable "build_service_role_arn" {}
-variable "kms_key_id" {}
-variable "kms_key_arn" {}
+variable "environment" {
+}
+
+variable "region" {
+}
+
+variable "metrics_namespace" {
+}
+
+variable "parameter_memcached_location" {
+}
+
+variable "mysql_database_host" {
+}
+
+variable "mysql_database_port" {
+}
+
+variable "mysql_database_username" {
+}
+
+variable "mysql_database_password" {
+}
+
+variable "mysql_database_name" {
+}
+
+variable "mysql_database_fetch_batch_size" {
+}
+
+variable "mysql_database_connection_pool_size" {
+}
+
+variable "mysql_database_user_data_encryption_key" {
+}
+
+variable "vpc_id" {
+}
+
+variable "vpc_public_subnet_ids" {
+  type = list(string)
+}
+
+variable "vpc_cidr" {
+}
+
+variable "ecs_instances_desired_count" {
+}
+
+variable "ecs_instances_memory" {
+}
+
+variable "ecs_instances_cpu" {
+}
+
+variable "ecs_cluster_id" {
+}
+
+variable "ecs_instances_log_configuration" {
+}
+
+variable "ecs_instances_role_name" {
+}
+
+variable "ecs_days_to_keep_images" {
+}
+
+variable "local_machine_cidr" {
+}
+
+variable "api_server_port" {
+}
+
+variable "session_encryption_key" {
+}
+
+variable "load_balancer_port" {
+}
+
+variable "load_balancer_days_to_keep_access_logs" {
+}
+
+variable "load_balancer_access_logs_bucket" {
+}
+
+variable "load_balancer_access_logs_prefix" {
+}
+
+variable "bucketname_user_string" {
+}
+
+variable "retain_load_balancer_access_logs_after_destroy" {
+}
+
+variable "default_num_photo_recommendations" {
+}
+
+variable "default_num_user_recommendations" {
+}
+
+variable "default_num_photos_from_group" {
+}
+
+variable "flickr_api_key" {
+}
+
+variable "flickr_secret_key" {
+}
+
+variable "flickr_api_retries" {
+}
+
+variable "flickr_api_memcached_location" {
+}
+
+variable "flickr_api_memcached_ttl" {
+}
+
+variable "flickr_auth_memcached_location" {
+}
+
+variable "puller_queue_batch_size" {
+}
+
+variable "puller_queue_url" {
+}
+
+variable "puller_queue_arn" {
+}
+
+variable "process_name" {
+}
+
+variable "project_github_location" {
+}
+
+variable "build_logs_bucket_id" {
+}
+
+variable "buildspec_location" {
+}
+
+variable "file_path" {
+}
+
+variable "file_path_common" {
+}
+
+variable "build_service_role_arn" {
+}
+
+variable "kms_key_id" {
+}
+
+variable "kms_key_arn" {
+}
+

--- a/terraform/modules/api-server/versions.tf
+++ b/terraform/modules/api-server/versions.tf
@@ -1,0 +1,4 @@
+
+terraform {
+  required_version = ">= 0.12"
+}

--- a/terraform/modules/build-common-infrastructure/logs-bucket.tf
+++ b/terraform/modules/build-common-infrastructure/logs-bucket.tf
@@ -24,3 +24,11 @@ resource "aws_s3_bucket" "build_logs" {
   }
 }
 
+resource "aws_s3_bucket_public_access_block" "build_logs" {
+  bucket = aws_s3_bucket.build_logs.id
+
+  block_public_acls       = true
+  block_public_policy     = true
+  ignore_public_acls      = true
+  restrict_public_buckets = true
+}

--- a/terraform/modules/build-common-infrastructure/logs-bucket.tf
+++ b/terraform/modules/build-common-infrastructure/logs-bucket.tf
@@ -1,7 +1,7 @@
 resource "aws_s3_bucket" "build_logs" {
-  bucket = "${var.build_logs_bucket}${var.bucketname_user_string}-${var.environment}"
-  acl    = "private"
-  force_destroy = "${!var.retain_build_logs_after_destroy}"
+  bucket        = "${var.build_logs_bucket}${var.bucketname_user_string}-${var.environment}"
+  acl           = "private"
+  force_destroy = false == var.retain_build_logs_after_destroy
 
   lifecycle_rule {
     id      = "expire-logs-after-N-days"
@@ -10,7 +10,7 @@ resource "aws_s3_bucket" "build_logs" {
     prefix = "*"
 
     expiration {
-      days = "${var.days_to_keep_build_logs}"
+      days = var.days_to_keep_build_logs
     }
   }
 
@@ -18,8 +18,9 @@ resource "aws_s3_bucket" "build_logs" {
     rule {
       apply_server_side_encryption_by_default {
         # Keep this as AES for consistency with the load balancer access logs (see note there)
-        sse_algorithm = "AES256" 
+        sse_algorithm = "AES256"
       }
     }
   }
 }
+

--- a/terraform/modules/build-common-infrastructure/outputs.tf
+++ b/terraform/modules/build-common-infrastructure/outputs.tf
@@ -1,9 +1,10 @@
 output "build_service_role_arn" {
-    value = "${aws_iam_role.build_common_infrastructure.arn}"
-    description = "ARN for the role which is used to run builds"
+  value       = aws_iam_role.build_common_infrastructure.arn
+  description = "ARN for the role which is used to run builds"
 }
 
 output "build_logs_bucket_id" {
-    value = "${aws_s3_bucket.build_logs.id}"
-    description = "ID of the bucket that will contain our build logs"
+  value       = aws_s3_bucket.build_logs.id
+  description = "ID of the bucket that will contain our build logs"
 }
+

--- a/terraform/modules/build-common-infrastructure/role.tf
+++ b/terraform/modules/build-common-infrastructure/role.tf
@@ -18,10 +18,11 @@ resource "aws_iam_role" "build_common_infrastructure" {
   ]
 }
 EOF
+
 }
 
 resource "aws_iam_role_policy" "build_common_infrastructure" {
-  role = "${aws_iam_role.build_common_infrastructure.name}"
+  role = aws_iam_role.build_common_infrastructure.name
 
   policy = <<POLICY
 {
@@ -90,4 +91,6 @@ resource "aws_iam_role_policy" "build_common_infrastructure" {
   ]
 }
 POLICY
+
 }
+

--- a/terraform/modules/build-common-infrastructure/variables.tf
+++ b/terraform/modules/build-common-infrastructure/variables.tf
@@ -1,9 +1,27 @@
-variable "environment" {}
-variable "environment_long_name" {}
-variable "region" {}
-variable "project_github_location" {}
-variable "build_logs_bucket" {}
-variable "bucketname_user_string" {}
-variable "retain_build_logs_after_destroy" {}
-variable "days_to_keep_build_logs" {}
-variable "s3_deployment_bucket_arn" {}
+variable "environment" {
+}
+
+variable "environment_long_name" {
+}
+
+variable "region" {
+}
+
+variable "project_github_location" {
+}
+
+variable "build_logs_bucket" {
+}
+
+variable "bucketname_user_string" {
+}
+
+variable "retain_build_logs_after_destroy" {
+}
+
+variable "days_to_keep_build_logs" {
+}
+
+variable "s3_deployment_bucket_arn" {
+}
+

--- a/terraform/modules/build-common-infrastructure/versions.tf
+++ b/terraform/modules/build-common-infrastructure/versions.tf
@@ -1,0 +1,4 @@
+
+terraform {
+  required_version = ">= 0.12"
+}

--- a/terraform/modules/build-pipeline-backend/code-build.tf
+++ b/terraform/modules/build-pipeline-backend/code-build.tf
@@ -1,14 +1,13 @@
 # Sample for building docker images: https://docs.aws.amazon.com/codebuild/latest/userguide/sample-docker.html
 
 data "aws_caller_identity" "build-pipeline-backend" {
-  
 }
 
 resource "aws_codebuild_project" "backend" {
   name          = "${var.process_name}-${var.environment}"
   description   = "Builds the ${var.environment} ${var.process_name} container"
   build_timeout = "5"
-  service_role  = "${var.build_service_role_arn}"
+  service_role  = var.build_service_role_arn
   badge_enabled = true
 
   artifacts {
@@ -26,15 +25,15 @@ resource "aws_codebuild_project" "backend" {
     type                        = "LINUX_CONTAINER"
     image_pull_credentials_type = "CODEBUILD"
     privileged_mode             = true # For building docker images
-  
+
     environment_variable {
       name  = "AWS_DEFAULT_REGION"
-      value = "${var.region}"
+      value = var.region
     }
 
     environment_variable {
       name  = "AWS_ACCOUNT_ID"
-      value = "${data.aws_caller_identity.build-pipeline-backend.account_id}"
+      value = data.aws_caller_identity.build-pipeline-backend.account_id
     }
 
     environment_variable {
@@ -44,77 +43,76 @@ resource "aws_codebuild_project" "backend" {
 
     environment_variable {
       name  = "IMAGE_REPO_NAME"
-      value = "${var.container_repository_name}"
+      value = var.container_repository_name
     }
 
     environment_variable {
       name  = "PROCESS_NAME"
-      value = "${var.process_name}"
+      value = var.process_name
     }
   }
 
   logs_config {
-    
     cloudwatch_logs {
       status = "DISABLED"
     }
 
     s3_logs {
-      status = "ENABLED"
+      status   = "ENABLED"
       location = "${var.build_logs_bucket_id}/${var.process_name}"
     }
   }
 
   source {
     type            = "GITHUB"
-    location        = "${var.project_github_location}"
-    buildspec       = "${var.buildspec_location}"
+    location        = var.project_github_location
+    buildspec       = var.buildspec_location
     git_clone_depth = 1
   }
 
   tags = {
-    Environment = "${var.environment}"
+    Environment = var.environment
   }
-
   # It would be preferable to have these builds happen in our own VPC, but the machines have to
   # be on a private subnet with access to the Internet, which requires a NAT, which incurs billing charges.
   # So just have them be in the default VPC instead
 }
 
 resource "aws_codebuild_webhook" "backend" {
-  project_name = "${aws_codebuild_project.backend.name}"
+  project_name = aws_codebuild_project.backend.name
 
   filter_group {
     filter {
-      type = "EVENT"
+      type    = "EVENT"
       pattern = "PUSH"
     }
 
     filter {
-      type = "HEAD_REF"
+      type    = "HEAD_REF"
       pattern = "master"
     }
 
     filter {
-      type = "FILE_PATH"
-      pattern = "${var.file_path}"
+      type    = "FILE_PATH"
+      pattern = var.file_path
     }
   }
 
   filter_group {
     filter {
-      type = "EVENT"
+      type    = "EVENT"
       pattern = "PUSH"
     }
 
     filter {
-      type = "HEAD_REF"
+      type    = "HEAD_REF"
       pattern = "master"
     }
 
     filter {
-      type = "FILE_PATH"
-      pattern = "${var.file_path_common}"
+      type    = "FILE_PATH"
+      pattern = var.file_path_common
     }
   }
 }
+

--- a/terraform/modules/build-pipeline-backend/variables.tf
+++ b/terraform/modules/build-pipeline-backend/variables.tf
@@ -1,10 +1,30 @@
-variable "environment" {}
-variable "region" {}
-variable "process_name" {}
-variable "project_github_location" {}
-variable "build_logs_bucket_id" {}
-variable "container_repository_name" {}
-variable "buildspec_location" {}
-variable "file_path" {}
-variable "file_path_common" {}
-variable "build_service_role_arn" {}
+variable "environment" {
+}
+
+variable "region" {
+}
+
+variable "process_name" {
+}
+
+variable "project_github_location" {
+}
+
+variable "build_logs_bucket_id" {
+}
+
+variable "container_repository_name" {
+}
+
+variable "buildspec_location" {
+}
+
+variable "file_path" {
+}
+
+variable "file_path_common" {
+}
+
+variable "build_service_role_arn" {
+}
+

--- a/terraform/modules/build-pipeline-backend/versions.tf
+++ b/terraform/modules/build-pipeline-backend/versions.tf
@@ -1,0 +1,4 @@
+
+terraform {
+  required_version = ">= 0.12"
+}

--- a/terraform/modules/build-pipeline-frontend/code-build.tf
+++ b/terraform/modules/build-pipeline-frontend/code-build.tf
@@ -2,7 +2,7 @@ resource "aws_codebuild_project" "frontend" {
   name          = "frontend-${var.environment}"
   description   = "Builds the ${var.environment} frontend"
   build_timeout = "5"
-  service_role  = "${var.build_service_role_arn}"
+  service_role  = var.build_service_role_arn
   badge_enabled = true
 
   artifacts {
@@ -19,58 +19,57 @@ resource "aws_codebuild_project" "frontend" {
     image                       = "aws/codebuild/standard:3.0"
     type                        = "LINUX_CONTAINER"
     image_pull_credentials_type = "CODEBUILD"
-  
+
     environment_variable {
       name  = "ENVIRONMENT"
-      value = "${var.environment_long_name}"
+      value = var.environment_long_name
     }
   }
 
   logs_config {
-    
     cloudwatch_logs {
       status = "DISABLED"
     }
 
     s3_logs {
-      status = "ENABLED"
+      status   = "ENABLED"
       location = "${var.build_logs_bucket_id}/frontend"
     }
   }
 
   source {
     type            = "GITHUB"
-    location        = "${var.project_github_location}"
-    buildspec       = "${var.buildspec_location}"
+    location        = var.project_github_location
+    buildspec       = var.buildspec_location
     git_clone_depth = 1
   }
 
   tags = {
-    Environment = "${var.environment}"
+    Environment = var.environment
   }
-
   # It would be preferable to have these builds happen in our own VPC, but the machines have to
   # be on a private subnet with access to the Internet, which requires a NAT, which incurs billing charges.
   # So just have them be in the default VPC instead
 }
 
 resource "aws_codebuild_webhook" "frontend" {
-  project_name = "${aws_codebuild_project.frontend.name}"
+  project_name = aws_codebuild_project.frontend.name
 
   filter_group {
     filter {
-      type = "EVENT"
+      type    = "EVENT"
       pattern = "PUSH"
     }
 
     filter {
-      type = "HEAD_REF"
+      type    = "HEAD_REF"
       pattern = "master"
     }
 
     filter {
-      type = "FILE_PATH"
-      pattern = "${var.file_path}"
+      type    = "FILE_PATH"
+      pattern = var.file_path
     }
   }
 }
+

--- a/terraform/modules/build-pipeline-frontend/variables.tf
+++ b/terraform/modules/build-pipeline-frontend/variables.tf
@@ -1,9 +1,27 @@
-variable "environment" {}
-variable "environment_long_name" {}
-variable "region" {}
-variable "project_github_location" {}
-variable "build_logs_bucket_id" {}
-variable "s3_deployment_bucket_arn" {}
-variable "buildspec_location" {}
-variable "file_path" {}
-variable "build_service_role_arn" {}
+variable "environment" {
+}
+
+variable "environment_long_name" {
+}
+
+variable "region" {
+}
+
+variable "project_github_location" {
+}
+
+variable "build_logs_bucket_id" {
+}
+
+variable "s3_deployment_bucket_arn" {
+}
+
+variable "buildspec_location" {
+}
+
+variable "file_path" {
+}
+
+variable "build_service_role_arn" {
+}
+

--- a/terraform/modules/build-pipeline-frontend/versions.tf
+++ b/terraform/modules/build-pipeline-frontend/versions.tf
@@ -1,0 +1,4 @@
+
+terraform {
+  required_version = ">= 0.12"
+}

--- a/terraform/modules/container-repository/container-repository.tf
+++ b/terraform/modules/container-repository/container-repository.tf
@@ -1,9 +1,9 @@
 resource "aws_ecr_repository" "ecr" {
-    name = "${var.name}-${var.environment}"
-} 
+  name = "${var.name}-${var.environment}"
+}
 
 resource "aws_ecr_lifecycle_policy" "lifecycle_policy" {
-  repository = "${aws_ecr_repository.ecr.name}"
+  repository = aws_ecr_repository.ecr.name
 
   policy = <<EOF
 {
@@ -24,4 +24,6 @@ resource "aws_ecr_lifecycle_policy" "lifecycle_policy" {
     ]
 }
 EOF
+
 }
+

--- a/terraform/modules/container-repository/outputs.tf
+++ b/terraform/modules/container-repository/outputs.tf
@@ -1,9 +1,10 @@
 output "repository_url" {
-    value = "${aws_ecr_repository.ecr.repository_url}"
-    description = "The URL of the respository that was created"
+  value       = aws_ecr_repository.ecr.repository_url
+  description = "The URL of the respository that was created"
 }
 
 output "repository_name" {
-    value = "${aws_ecr_repository.ecr.name}"
-    description = "The name of the repository that was created"
+  value       = aws_ecr_repository.ecr.name
+  description = "The name of the repository that was created"
 }
+

--- a/terraform/modules/container-repository/variables.tf
+++ b/terraform/modules/container-repository/variables.tf
@@ -1,3 +1,9 @@
-variable "name" {}
-variable "environment" {}
-variable "num_days_to_keep_images" {}
+variable "name" {
+}
+
+variable "environment" {
+}
+
+variable "num_days_to_keep_images" {
+}
+

--- a/terraform/modules/container-repository/versions.tf
+++ b/terraform/modules/container-repository/versions.tf
@@ -1,0 +1,4 @@
+
+terraform {
+  required_version = ">= 0.12"
+}

--- a/terraform/modules/dashboard/dashboard.tf
+++ b/terraform/modules/dashboard/dashboard.tf
@@ -111,155 +111,158 @@ resource "aws_cloudwatch_dashboard" "main" {
        }
     ]
   }
-  EOF
+  
+EOF
+
 }
 
 data "template_file" "time_to_get_all_data" {
-    vars = {
-        environment                 = "${var.environment}"
-        region                      = "${var.region}"
-    }
+  vars = {
+    environment = var.environment
+    region      = var.region
+  }
 
-    template = "${file("${path.module}/time_to_get_all_data.tpl")}"
+  template = file("${path.module}/time_to_get_all_data.tpl")
 }
 
 data "template_file" "puller_queue" {
-    vars = {
-        queue_full_name             = "${var.puller_queue_full_name}"
-        queue_base_name             = "${var.puller_queue_base_name}"
-        queue_dead_letter_full_name = "${var.puller_queue_dead_letter_full_name}"
-        region                      = "${var.region}"
-    }
+  vars = {
+    queue_full_name             = var.puller_queue_full_name
+    queue_base_name             = var.puller_queue_base_name
+    queue_dead_letter_full_name = var.puller_queue_dead_letter_full_name
+    region                      = var.region
+  }
 
-    template = "${file("${path.module}/sqs_queue.tpl")}"
+  template = file("${path.module}/sqs_queue.tpl")
 }
 
 data "template_file" "puller_response_queue" {
-    vars = {
-        queue_full_name             = "${var.puller_response_queue_full_name}"
-        queue_base_name             = "${var.puller_response_queue_base_name}"
-        queue_dead_letter_full_name = "${var.puller_response_queue_dead_letter_full_name}"
-        region                      = "${var.region}"
-    }
+  vars = {
+    queue_full_name             = var.puller_response_queue_full_name
+    queue_base_name             = var.puller_response_queue_base_name
+    queue_dead_letter_full_name = var.puller_response_queue_dead_letter_full_name
+    region                      = var.region
+  }
 
-    template = "${file("${path.module}/sqs_queue.tpl")}"
+  template = file("${path.module}/sqs_queue.tpl")
 }
 
 data "template_file" "ingester_queue" {
-    vars = {
-        queue_full_name             = "${var.ingester_queue_full_name}"
-        queue_base_name             = "${var.ingester_queue_base_name}"
-        queue_dead_letter_full_name = "${var.ingester_queue_dead_letter_full_name}"
-        region                      = "${var.region}"
-    }
+  vars = {
+    queue_full_name             = var.ingester_queue_full_name
+    queue_base_name             = var.ingester_queue_base_name
+    queue_dead_letter_full_name = var.ingester_queue_dead_letter_full_name
+    region                      = var.region
+  }
 
-    template = "${file("${path.module}/sqs_queue.tpl")}"
+  template = file("${path.module}/sqs_queue.tpl")
 }
 
 data "template_file" "ingester_response_queue" {
-    vars = {
-        queue_full_name             = "${var.ingester_response_queue_full_name}"
-        queue_base_name             = "${var.ingester_response_queue_base_name}"
-        queue_dead_letter_full_name = "${var.ingester_response_queue_dead_letter_full_name}"
-        region                      = "${var.region}"
-    }
+  vars = {
+    queue_full_name             = var.ingester_response_queue_full_name
+    queue_base_name             = var.ingester_response_queue_base_name
+    queue_dead_letter_full_name = var.ingester_response_queue_dead_letter_full_name
+    region                      = var.region
+  }
 
-    template = "${file("${path.module}/sqs_queue.tpl")}"
+  template = file("${path.module}/sqs_queue.tpl")
 }
 
 data "template_file" "ec2_network" {
-    vars = {
-        autoscaling_group_name      = "${var.ecs_autoscaling_group_name}"
-        region                      = "${var.region}"
-    }
+  vars = {
+    autoscaling_group_name = var.ecs_autoscaling_group_name
+    region                 = var.region
+  }
 
-    template = "${file("${path.module}/ec2_network.tpl")}"
+  template = file("${path.module}/ec2_network.tpl")
 }
 
 data "template_file" "ec2_cpu" {
-    vars = {
-        autoscaling_group_name      = "${var.ecs_autoscaling_group_name}"
-        region                      = "${var.region}"
-    }
+  vars = {
+    autoscaling_group_name = var.ecs_autoscaling_group_name
+    region                 = var.region
+  }
 
-    template = "${file("${path.module}/ec2_cpu.tpl")}"
+  template = file("${path.module}/ec2_cpu.tpl")
 }
 
 data "template_file" "database_io" {
-    vars = {
-        database_identifier         = "${var.database_identifier}"
-        region                      = "${var.region}"
-    }
+  vars = {
+    database_identifier = var.database_identifier
+    region              = var.region
+  }
 
-    template = "${file("${path.module}/database_io.tpl")}"
+  template = file("${path.module}/database_io.tpl")
 }
 
 data "template_file" "database_cpu" {
-    vars = {
-        database_identifier         = "${var.database_identifier}"
-        region                      = "${var.region}"
-    }
+  vars = {
+    database_identifier = var.database_identifier
+    region              = var.region
+  }
 
-    template = "${file("${path.module}/database_cpu.tpl")}"
+  template = file("${path.module}/database_cpu.tpl")
 }
 
 data "template_file" "database_disc" {
-    vars = {
-        database_identifier         = "${var.database_identifier}"
-        region                      = "${var.region}"
-    }
+  vars = {
+    database_identifier = var.database_identifier
+    region              = var.region
+  }
 
-    template = "${file("${path.module}/database_disc.tpl")}"
+  template = file("${path.module}/database_disc.tpl")
 }
 
 data "template_file" "database_memory" {
-    vars = {
-        database_identifier         = "${var.database_identifier}"
-        region                      = "${var.region}"
-    }
+  vars = {
+    database_identifier = var.database_identifier
+    region              = var.region
+  }
 
-    template = "${file("${path.module}/database_memory.tpl")}"
+  template = file("${path.module}/database_memory.tpl")
 }
 
 data "template_file" "ecs_cpu" {
-    vars = {
-        cluster_name                = "${var.ecs_cluster_name}"
-        region                      = "${var.region}"
-        environment                 = "${var.environment}"
-    }
+  vars = {
+    cluster_name = var.ecs_cluster_name
+    region       = var.region
+    environment  = var.environment
+  }
 
-    template = "${file("${path.module}/ecs_cpu.tpl")}"
+  template = file("${path.module}/ecs_cpu.tpl")
 }
 
 data "template_file" "ecs_memory" {
-    vars = {
-        cluster_name                = "${var.ecs_cluster_name}"
-        region                      = "${var.region}"
-        environment                 = "${var.environment}"
-    }
+  vars = {
+    cluster_name = var.ecs_cluster_name
+    region       = var.region
+    environment  = var.environment
+  }
 
-    template = "${file("${path.module}/ecs_memory.tpl")}"
+  template = file("${path.module}/ecs_memory.tpl")
 }
 
 data "template_file" "unhandled_exceptions" {
-    vars = {
-        title                       = "Unhandled exceptions"
-        environment                 = "${var.environment}"
-        metrics_namespace           = "${var.metrics_namespace}"
-        metric_name                 = "UnhandledException"
-        region                      = "${var.region}"
-    }
+  vars = {
+    title             = "Unhandled exceptions"
+    environment       = var.environment
+    metrics_namespace = var.metrics_namespace
+    metric_name       = "UnhandledException"
+    region            = var.region
+  }
 
-    template = "${file("${path.module}/unhandled_exceptions.tpl")}"
+  template = file("${path.module}/unhandled_exceptions.tpl")
 }
 
 data "template_file" "timing" {
-    vars = {
-        title                       = "Timing"
-        environment                 = "${var.environment}"
-        metrics_namespace           = "${var.metrics_namespace}"
-        region                      = "${var.region}"
-    }
+  vars = {
+    title             = "Timing"
+    environment       = var.environment
+    metrics_namespace = var.metrics_namespace
+    region            = var.region
+  }
 
-    template = "${file("${path.module}/timing.tpl")}"
+  template = file("${path.module}/timing.tpl")
 }
+

--- a/terraform/modules/dashboard/variables.tf
+++ b/terraform/modules/dashboard/variables.tf
@@ -1,24 +1,54 @@
-variable "environment" {}
-variable "region" {}
-variable "metrics_namespace" {}
+variable "environment" {
+}
 
-variable "puller_queue_base_name" {}
-variable "puller_queue_full_name" {}
-variable "puller_queue_dead_letter_full_name" {}
+variable "region" {
+}
 
-variable "puller_response_queue_base_name" {}
-variable "puller_response_queue_full_name" {}
-variable "puller_response_queue_dead_letter_full_name" {}
+variable "metrics_namespace" {
+}
 
-variable "ingester_queue_base_name" {}
-variable "ingester_queue_full_name" {}
-variable "ingester_queue_dead_letter_full_name" {}
+variable "puller_queue_base_name" {
+}
 
-variable "ingester_response_queue_base_name" {}
-variable "ingester_response_queue_full_name" {}
-variable "ingester_response_queue_dead_letter_full_name" {}
+variable "puller_queue_full_name" {
+}
 
-variable "database_identifier" {}
+variable "puller_queue_dead_letter_full_name" {
+}
 
-variable "ecs_autoscaling_group_name" {}
-variable "ecs_cluster_name" {}
+variable "puller_response_queue_base_name" {
+}
+
+variable "puller_response_queue_full_name" {
+}
+
+variable "puller_response_queue_dead_letter_full_name" {
+}
+
+variable "ingester_queue_base_name" {
+}
+
+variable "ingester_queue_full_name" {
+}
+
+variable "ingester_queue_dead_letter_full_name" {
+}
+
+variable "ingester_response_queue_base_name" {
+}
+
+variable "ingester_response_queue_full_name" {
+}
+
+variable "ingester_response_queue_dead_letter_full_name" {
+}
+
+variable "database_identifier" {
+}
+
+variable "ecs_autoscaling_group_name" {
+}
+
+variable "ecs_cluster_name" {
+}
+

--- a/terraform/modules/dashboard/versions.tf
+++ b/terraform/modules/dashboard/versions.tf
@@ -1,0 +1,4 @@
+
+terraform {
+  required_version = ">= 0.12"
+}

--- a/terraform/modules/database/mysql.tf
+++ b/terraform/modules/database/mysql.tf
@@ -1,20 +1,21 @@
 module "mysql" {
-    source = "../mysql"
+  source = "../mysql"
 
-    environment           = "${var.environment}"
-    vpc_id                = "${var.vpc_id}"
-    vpc_public_subnet_ids = "${var.vpc_public_subnet_ids}"
-    local_machine_cidr    = "${var.local_machine_cidr}"
-    vpc_cidr              = "${var.vpc_cidr}"
-    instance_type         = "${var.mysql_instance_type}"
-    storage_type          = "${var.mysql_storage_type}"
-    database_size_gb      = "${var.mysql_database_size_gb}"
-    storage_encrypted     = "${var.mysql_storage_encrypted}"
-    database_name         = "${var.mysql_database_name}"
-    multi_az              = "${var.mysql_multi_az}"
-    database_password     = "${var.mysql_database_password}"
-    kms_key_arn           = "${var.kms_key_arn}"
-    backup_retention_period_days = "${var.mysql_backup_retention_period_days}"
-    deletion_protection   = "${var.mysql_deletion_protection}"
-    init_script_file      = "database/photo_recommender_init.sql"
+  environment                  = var.environment
+  vpc_id                       = var.vpc_id
+  vpc_public_subnet_ids        = var.vpc_public_subnet_ids
+  local_machine_cidr           = var.local_machine_cidr
+  vpc_cidr                     = var.vpc_cidr
+  instance_type                = var.mysql_instance_type
+  storage_type                 = var.mysql_storage_type
+  database_size_gb             = var.mysql_database_size_gb
+  storage_encrypted            = var.mysql_storage_encrypted
+  database_name                = var.mysql_database_name
+  multi_az                     = var.mysql_multi_az
+  database_password            = var.mysql_database_password
+  kms_key_arn                  = var.kms_key_arn
+  backup_retention_period_days = var.mysql_backup_retention_period_days
+  deletion_protection          = var.mysql_deletion_protection
+  init_script_file             = "database/photo_recommender_init.sql"
 }
+

--- a/terraform/modules/database/outputs.tf
+++ b/terraform/modules/database/outputs.tf
@@ -1,24 +1,25 @@
 output "database_host" {
-    value = "${module.mysql.database_host}"
-    description = "Host string for the database that was created"
+  value       = module.mysql.database_host
+  description = "Host string for the database that was created"
 }
 
 output "database_port" {
-    value = "${module.mysql.database_port}"
-    description = "Port for the database that was created"
+  value       = module.mysql.database_port
+  description = "Port for the database that was created"
 }
 
 output "database_username" {
-    value = "${module.mysql.database_username}"
-    description = "Username for the database that was created"
+  value       = module.mysql.database_username
+  description = "Username for the database that was created"
 }
 
 output "database_name" {
-    value = "${module.mysql.database_name}"
-    description = "Name of the database that was created"
+  value       = module.mysql.database_name
+  description = "Name of the database that was created"
 }
 
 output "database_instance_identifier" {
-    value = "${module.mysql.database_instance_identifier}"
-    description = "The identifier of the database instance that was created"
-} 
+  value       = module.mysql.database_instance_identifier
+  description = "The identifier of the database instance that was created"
+}
+

--- a/terraform/modules/database/variables.tf
+++ b/terraform/modules/database/variables.tf
@@ -1,16 +1,49 @@
-variable "environment" {}
-variable "region" {}
-variable "mysql_database_name" {}
-variable "mysql_instance_type" {}
-variable "mysql_database_size_gb" {}
-variable "mysql_storage_type" {}
-variable "mysql_multi_az" {}
-variable "mysql_database_password" {}
-variable "mysql_backup_retention_period_days" {}
-variable "mysql_storage_encrypted" {}
-variable "mysql_deletion_protection" {}
-variable "vpc_id" {}
-variable "vpc_public_subnet_ids" { type = "list" }
-variable "local_machine_cidr" {}
-variable "vpc_cidr" {}
-variable "kms_key_arn" {}
+variable "environment" {
+}
+
+variable "region" {
+}
+
+variable "mysql_database_name" {
+}
+
+variable "mysql_instance_type" {
+}
+
+variable "mysql_database_size_gb" {
+}
+
+variable "mysql_storage_type" {
+}
+
+variable "mysql_multi_az" {
+}
+
+variable "mysql_database_password" {
+}
+
+variable "mysql_backup_retention_period_days" {
+}
+
+variable "mysql_storage_encrypted" {
+}
+
+variable "mysql_deletion_protection" {
+}
+
+variable "vpc_id" {
+}
+
+variable "vpc_public_subnet_ids" {
+  type = list(string)
+}
+
+variable "local_machine_cidr" {
+}
+
+variable "vpc_cidr" {
+}
+
+variable "kms_key_arn" {
+}
+

--- a/terraform/modules/database/versions.tf
+++ b/terraform/modules/database/versions.tf
@@ -1,0 +1,4 @@
+
+terraform {
+  required_version = ">= 0.12"
+}

--- a/terraform/modules/elastic-container-service/cluster.tf
+++ b/terraform/modules/elastic-container-service/cluster.tf
@@ -19,15 +19,7 @@ resource "aws_launch_configuration" "ecs-launch-configuration" {
     create_before_destroy = true
   }
 
-  # TF-UPGRADE-TODO: In Terraform v0.10 and earlier, it was sometimes necessary to
-  # force an interpolation expression to be interpreted as a list by wrapping it
-  # in an extra set of list brackets. That form was supported for compatibility in
-  # v0.11, but is no longer supported in Terraform v0.12.
-  #
-  # If the expression in the following list itself returns a list, remove the
-  # brackets to avoid interpretation as a list of lists. If the expression
-  # returns a single list item then leave it as-is and remove this TODO comment.
-  security_groups             = [concat(var.extra_security_groups, [aws_security_group.ecs.id])]
+  security_groups             = concat(var.extra_security_groups, [aws_security_group.ecs.id])
   associate_public_ip_address = "true"
   key_name                    = aws_key_pair.local_machine.key_name
   user_data                   = <<EOF

--- a/terraform/modules/elastic-container-service/cluster.tf
+++ b/terraform/modules/elastic-container-service/cluster.tf
@@ -1,44 +1,55 @@
 resource "aws_key_pair" "local_machine" {
-    key_name   = "local_machine_${var.environment}"
-    public_key = "${var.local_machine_public_key}"
+  key_name   = "local_machine_${var.environment}"
+  public_key = var.local_machine_public_key
 }
 
 resource "aws_launch_configuration" "ecs-launch-configuration" {
-    name_prefix                 = "ecs-launch-configuration-${var.cluster_name}-${var.environment}-" # Auto-generate the name because once it's created it can't be changed
-    image_id                    = "ami-0e5e051fd0b505db6" # ECS-optimized image for us-west-2: https://docs.aws.amazon.com/AmazonECS/latest/developerguide/launch_container_instance.html
-    instance_type               = "${var.instance_type}"
-    iam_instance_profile        = "${aws_iam_instance_profile.ecs-instance-profile.id}"
+  name_prefix          = "ecs-launch-configuration-${var.cluster_name}-${var.environment}-" # Auto-generate the name because once it's created it can't be changed
+  image_id             = "ami-0e5e051fd0b505db6"                                            # ECS-optimized image for us-west-2: https://docs.aws.amazon.com/AmazonECS/latest/developerguide/launch_container_instance.html
+  instance_type        = var.instance_type
+  iam_instance_profile = aws_iam_instance_profile.ecs-instance-profile.id
 
-    root_block_device {
-        volume_type = "standard"
-        volume_size = 30
-        delete_on_termination = true
-    }
+  root_block_device {
+    volume_type           = "standard"
+    volume_size           = 30
+    delete_on_termination = true
+  }
 
-    lifecycle {
-        create_before_destroy = true
-    }
+  lifecycle {
+    create_before_destroy = true
+  }
 
-    security_groups             = ["${concat(var.extra_security_groups, list(aws_security_group.ecs.id))}"]
-    associate_public_ip_address = "true"
-    key_name                    = "${aws_key_pair.local_machine.key_name}"
-    user_data                   = <<EOF
+  # TF-UPGRADE-TODO: In Terraform v0.10 and earlier, it was sometimes necessary to
+  # force an interpolation expression to be interpreted as a list by wrapping it
+  # in an extra set of list brackets. That form was supported for compatibility in
+  # v0.11, but is no longer supported in Terraform v0.12.
+  #
+  # If the expression in the following list itself returns a list, remove the
+  # brackets to avoid interpretation as a list of lists. If the expression
+  # returns a single list item then leave it as-is and remove this TODO comment.
+  security_groups             = [concat(var.extra_security_groups, [aws_security_group.ecs.id])]
+  associate_public_ip_address = "true"
+  key_name                    = aws_key_pair.local_machine.key_name
+  user_data                   = <<EOF
                                   #!/bin/bash
                                   echo ECS_CLUSTER=${aws_ecs_cluster.ecs-cluster.name} >> /etc/ecs/ecs.config
                                   echo ECS_ENABLE_CONTAINER_METADATA=true >> /etc/ecs/ecs.config
-                                  EOF
+                                  
+EOF
+
 }
 
 resource "aws_autoscaling_group" "ecs-autoscaling-group" {
-    name                        = "ecs-autoscaling-group-${var.cluster_name}-${var.environment}"
-    max_size                    = "${var.cluster_max_size}"
-    min_size                    = "${var.cluster_min_size}"
-    desired_capacity            = "${var.cluster_desired_size}"
-    vpc_zone_identifier         = ["${var.vpc_public_subnet_ids}"]
-    launch_configuration        = "${aws_launch_configuration.ecs-launch-configuration.name}"
-    health_check_type           = "ELB"
+  name                 = "ecs-autoscaling-group-${var.cluster_name}-${var.environment}"
+  max_size             = var.cluster_max_size
+  min_size             = var.cluster_min_size
+  desired_capacity     = var.cluster_desired_size
+  vpc_zone_identifier  = var.vpc_public_subnet_ids
+  launch_configuration = aws_launch_configuration.ecs-launch-configuration.name
+  health_check_type    = "ELB"
 }
 
 resource "aws_ecs_cluster" "ecs-cluster" {
-    name = "${var.cluster_name}-${var.environment}"
+  name = "${var.cluster_name}-${var.environment}"
 }
+

--- a/terraform/modules/elastic-container-service/instance-role.tf
+++ b/terraform/modules/elastic-container-service/instance-role.tf
@@ -1,32 +1,33 @@
 resource "aws_iam_role" "ecs-instance-role" {
-    name                = "ecs-instance-role-${var.cluster_name}-${var.environment}"
-    path                = "/"
-    assume_role_policy  = "${data.aws_iam_policy_document.ecs-instance-policy.json}"
+  name               = "ecs-instance-role-${var.cluster_name}-${var.environment}"
+  path               = "/"
+  assume_role_policy = data.aws_iam_policy_document.ecs-instance-policy.json
 }
 
 data "aws_iam_policy_document" "ecs-instance-policy" {
-    statement {
-        actions = [
-            "sts:AssumeRole"
-        ]
+  statement {
+    actions = [
+      "sts:AssumeRole",
+    ]
 
-        principals {
-            type        = "Service"
-            identifiers = ["ec2.amazonaws.com"]
-        }
+    principals {
+      type        = "Service"
+      identifiers = ["ec2.amazonaws.com"]
     }
+  }
 }
 
 resource "aws_iam_role_policy_attachment" "ecs-instance-role-attachment" {
-    role       = "${aws_iam_role.ecs-instance-role.name}"
-    policy_arn = "arn:aws:iam::aws:policy/service-role/AmazonEC2ContainerServiceforEC2Role"
+  role       = aws_iam_role.ecs-instance-role.name
+  policy_arn = "arn:aws:iam::aws:policy/service-role/AmazonEC2ContainerServiceforEC2Role"
 }
 
 resource "aws_iam_instance_profile" "ecs-instance-profile" {
-    name = "ecs-instance-profile-${var.cluster_name}-${var.environment}"
-    path = "/"
-    role = "${aws_iam_role.ecs-instance-role.id}"
-    provisioner "local-exec" {
-        command = "sleep 10"
-    }
+  name = "ecs-instance-profile-${var.cluster_name}-${var.environment}"
+  path = "/"
+  role = aws_iam_role.ecs-instance-role.id
+  provisioner "local-exec" {
+    command = "sleep 10"
+  }
 }
+

--- a/terraform/modules/elastic-container-service/logging.tf
+++ b/terraform/modules/elastic-container-service/logging.tf
@@ -1,14 +1,13 @@
 data "aws_caller_identity" "logging" {
-  
 }
 
 # NOTE: See https://docs.aws.amazon.com/AmazonCloudWatch/latest/logs/encrypt-log-data-kms.html
 resource "aws_kms_key" "logs" {
-    description             = "Used to encrypt/decrypt logs"
-    key_usage               = "ENCRYPT_DECRYPT"
-    enable_key_rotation     = true
-    deletion_window_in_days = 30
-    policy              = <<POLICY
+  description             = "Used to encrypt/decrypt logs"
+  key_usage               = "ENCRYPT_DECRYPT"
+  enable_key_rotation     = true
+  deletion_window_in_days = 30
+  policy                  = <<POLICY
 {
   "Version" : "2012-10-17",
   "Id" : "key-default-1",
@@ -35,19 +34,21 @@ resource "aws_kms_key" "logs" {
     }  
   ]
 }
-    POLICY
+    
+POLICY
+
 }
 
 resource "aws_cloudwatch_log_group" "log_group" {
-    name                = "${var.cluster_name}-${var.environment}"
-    retention_in_days   = "${var.instances_log_retention_days}"
-    kms_key_id          = "${aws_kms_key.logs.arn}"
+  name              = "${var.cluster_name}-${var.environment}"
+  retention_in_days = var.instances_log_retention_days
+  kms_key_id        = aws_kms_key.logs.arn
 }
 
 # Part of a task definition, used in task-definition.tf
 # TODO: Consider sending all logs to a single region so they can all be viewed together
 data "template_file" "log_configuration" {
-    template = <<EOF
+  template = <<EOF
     "logConfiguration": {
       "logDriver": "awslogs",
       "options": {
@@ -58,4 +59,6 @@ data "template_file" "log_configuration" {
       }
     }
 EOF
+
 }
+

--- a/terraform/modules/elastic-container-service/outputs.tf
+++ b/terraform/modules/elastic-container-service/outputs.tf
@@ -1,24 +1,25 @@
 output "cluster_id" {
-    value = "${aws_ecs_cluster.ecs-cluster.id}"
-    description = "The ID of the ECS cluster that was created"
+  value       = aws_ecs_cluster.ecs-cluster.id
+  description = "The ID of the ECS cluster that was created"
 }
 
 output "cluster_log_configuration" {
-    value = "${data.template_file.log_configuration.rendered}"
-    description = "The log configuration for all of the tasks to run on this cluster"
+  value       = data.template_file.log_configuration.rendered
+  description = "The log configuration for all of the tasks to run on this cluster"
 }
 
 output "instance_role_name" {
-    value = "${aws_iam_role.ecs-instance-role.name}"
-    description = "The name of the role assigned to each instance in the cluster. Attach extra policies needed by your task here."
+  value       = aws_iam_role.ecs-instance-role.name
+  description = "The name of the role assigned to each instance in the cluster. Attach extra policies needed by your task here."
 }
 
 output "autoscaling_group_name" {
-    value = "${aws_autoscaling_group.ecs-autoscaling-group.name}"
-    description = "The name of the autoscaling group that was created"
+  value       = aws_autoscaling_group.ecs-autoscaling-group.name
+  description = "The name of the autoscaling group that was created"
 }
 
 output "cluster_full_name" {
-    value = "${aws_ecs_cluster.ecs-cluster.name}"
-    description = "The full name of the cluster that was created"
+  value       = aws_ecs_cluster.ecs-cluster.name
+  description = "The full name of the cluster that was created"
 }
+

--- a/terraform/modules/elastic-container-service/security-group.tf
+++ b/terraform/modules/elastic-container-service/security-group.tf
@@ -1,30 +1,31 @@
 # ECS Instance Security group
 
 resource "aws_security_group" "ecs" {
-    name = "security-group-ecs-${var.cluster_name}-${var.environment}"
-    description = "Allow public access from our local network to ECS"
-    vpc_id = "${var.vpc_id}"
+  name        = "security-group-ecs-${var.cluster_name}-${var.environment}"
+  description = "Allow public access from our local network to ECS"
+  vpc_id      = var.vpc_id
 
-    ingress {
-        from_port = 22
-        to_port = 22
-        protocol = "tcp"
-        cidr_blocks = [
-            "${var.local_machine_cidr}"
-        ]
-    }
+  ingress {
+    from_port = 22
+    to_port   = 22
+    protocol  = "tcp"
+    cidr_blocks = [
+      var.local_machine_cidr,
+    ]
+  }
 
-    egress {
-        # allow all traffic to private SN
-        from_port = "0"
-        to_port = "0"
-        protocol = "-1"
-        cidr_blocks = [
-            "0.0.0.0/0"
-        ]
-    }
+  egress {
+    # allow all traffic to private SN
+    from_port = "0"
+    to_port   = "0"
+    protocol  = "-1"
+    cidr_blocks = [
+      "0.0.0.0/0",
+    ]
+  }
 
-    tags { 
-        Name = "security-group-ecs-${var.cluster_name}-${var.environment}"
-    }
+  tags = {
+    Name = "security-group-ecs-${var.cluster_name}-${var.environment}"
+  }
 }
+

--- a/terraform/modules/elastic-container-service/service-role.tf
+++ b/terraform/modules/elastic-container-service/service-role.tf
@@ -1,21 +1,22 @@
 resource "aws_iam_role" "ecs-service-role" {
-    name                = "ecs-service-role-${var.cluster_name}-${var.environment}"
-    path                = "/"
-    assume_role_policy  = "${data.aws_iam_policy_document.ecs-service-policy.json}"
+  name               = "ecs-service-role-${var.cluster_name}-${var.environment}"
+  path               = "/"
+  assume_role_policy = data.aws_iam_policy_document.ecs-service-policy.json
 }
 
 resource "aws_iam_role_policy_attachment" "ecs-service-role-attachment" {
-    role       = "${aws_iam_role.ecs-service-role.name}"
-    policy_arn = "arn:aws:iam::aws:policy/service-role/AmazonEC2ContainerServiceRole"
+  role       = aws_iam_role.ecs-service-role.name
+  policy_arn = "arn:aws:iam::aws:policy/service-role/AmazonEC2ContainerServiceRole"
 }
 
 data "aws_iam_policy_document" "ecs-service-policy" {
-    statement {
-        actions = ["sts:AssumeRole"]
+  statement {
+    actions = ["sts:AssumeRole"]
 
-        principals {
-            type        = "Service"
-            identifiers = ["ecs.amazonaws.com"]
-        }
+    principals {
+      type        = "Service"
+      identifiers = ["ecs.amazonaws.com"]
     }
+  }
 }
+

--- a/terraform/modules/elastic-container-service/variables.tf
+++ b/terraform/modules/elastic-container-service/variables.tf
@@ -1,13 +1,41 @@
-variable "cluster_name" {}
-variable "region" {}
-variable "environment" {}
-variable "local_machine_cidr" {}
-variable "instance_type" {}
-variable "cluster_desired_size" {}
-variable "cluster_min_size" {}
-variable "cluster_max_size" {}
-variable "local_machine_public_key" {}
-variable "instances_log_retention_days" {}
-variable "vpc_id" {}
-variable "vpc_public_subnet_ids" { type = "list" }
-variable "extra_security_groups" { type = "list" }
+variable "cluster_name" {
+}
+
+variable "region" {
+}
+
+variable "environment" {
+}
+
+variable "local_machine_cidr" {
+}
+
+variable "instance_type" {
+}
+
+variable "cluster_desired_size" {
+}
+
+variable "cluster_min_size" {
+}
+
+variable "cluster_max_size" {
+}
+
+variable "local_machine_public_key" {
+}
+
+variable "instances_log_retention_days" {
+}
+
+variable "vpc_id" {
+}
+
+variable "vpc_public_subnet_ids" {
+  type = list(string)
+}
+
+variable "extra_security_groups" {
+  type = list(string)
+}
+

--- a/terraform/modules/elastic-container-service/versions.tf
+++ b/terraform/modules/elastic-container-service/versions.tf
@@ -1,0 +1,4 @@
+
+terraform {
+  required_version = ">= 0.12"
+}

--- a/terraform/modules/encryption/kms.tf
+++ b/terraform/modules/encryption/kms.tf
@@ -1,8 +1,9 @@
 # Just have one KMS key that everyone references to save on billing costs
 
 resource "aws_kms_key" "parameter_secrets" {
-    description             = "Used to encrypt/decrypt secrets in the Parameter Store and elsewhere ${var.environment}"
-    key_usage               = "ENCRYPT_DECRYPT"
-    enable_key_rotation     = true
-    deletion_window_in_days = 7
+  description             = "Used to encrypt/decrypt secrets in the Parameter Store and elsewhere ${var.environment}"
+  key_usage               = "ENCRYPT_DECRYPT"
+  enable_key_rotation     = true
+  deletion_window_in_days = 7
 }
+

--- a/terraform/modules/encryption/outputs.tf
+++ b/terraform/modules/encryption/outputs.tf
@@ -1,9 +1,10 @@
 output "kms_key_id" {
-    value = "${aws_kms_key.parameter_secrets.id}"
-    description = "The ID of the key used to encrypt/decrypt secrets in the Parameter Store and elsewhere"
+  value       = aws_kms_key.parameter_secrets.id
+  description = "The ID of the key used to encrypt/decrypt secrets in the Parameter Store and elsewhere"
 }
 
 output "kms_key_arn" {
-    value = "${aws_kms_key.parameter_secrets.arn}"
-    description = "The ARN of the key used to encrypt/decrypt secrets in the Parameter Store and elsewhere"
+  value       = aws_kms_key.parameter_secrets.arn
+  description = "The ARN of the key used to encrypt/decrypt secrets in the Parameter Store and elsewhere"
 }
+

--- a/terraform/modules/encryption/variables.tf
+++ b/terraform/modules/encryption/variables.tf
@@ -1,1 +1,3 @@
-variable "environment" {}
+variable "environment" {
+}
+

--- a/terraform/modules/encryption/versions.tf
+++ b/terraform/modules/encryption/versions.tf
@@ -1,0 +1,4 @@
+
+terraform {
+  required_version = ">= 0.12"
+}

--- a/terraform/modules/frontend/build.tf
+++ b/terraform/modules/frontend/build.tf
@@ -1,13 +1,14 @@
 module "build" {
   source = "../build-pipeline-frontend"
 
-  environment               = "${var.environment}"
-  environment_long_name     = "${var.environment_long_name}"
-  region                    = "${var.region}"
-  project_github_location   = "${var.project_github_location}"
-  build_logs_bucket_id      = "${var.build_logs_bucket_id}"
-  s3_deployment_bucket_arn  = "${aws_s3_bucket.frontend.arn}"
-  buildspec_location        = "${var.buildspec_location}"
-  file_path                 = "${var.file_path}"
-  build_service_role_arn    = "${var.build_service_role_arn}"
+  environment              = var.environment
+  environment_long_name    = var.environment_long_name
+  region                   = var.region
+  project_github_location  = var.project_github_location
+  build_logs_bucket_id     = var.build_logs_bucket_id
+  s3_deployment_bucket_arn = aws_s3_bucket.frontend.arn
+  buildspec_location       = var.buildspec_location
+  file_path                = var.file_path
+  build_service_role_arn   = var.build_service_role_arn
 }
+

--- a/terraform/modules/frontend/cloudfront.tf
+++ b/terraform/modules/frontend/cloudfront.tf
@@ -1,126 +1,130 @@
-
 # This is a special user that Cloudfront assumes when reading from the bucket. We set our bucket
 # permissions such that only this user has access, rather than making it publicly readable,
 # so that people can't directly access the bucket contents.
 # https://docs.aws.amazon.com/AmazonCloudFront/latest/DeveloperGuide/private-content-restricting-access-to-s3.html
 
 resource "aws_cloudfront_origin_access_identity" "origin_access_identity" {
-    comment = "Cloudfront user allowed to read from our S3 bucket"
+  comment = "Cloudfront user allowed to read from our S3 bucket"
 }
 
 locals {
-    s3_origin_id = "static_files_origin"
-    load_balancer_origin_id = "load_balancer_origin"
-    application_domains = ["${var.application_domain}"]
+  s3_origin_id            = "static_files_origin"
+  load_balancer_origin_id = "load_balancer_origin"
+  application_domains     = [var.application_domain]
 }
 
 provider "aws" {
   # Certificates need to be in us-east-1
   # https://github.com/hashicorp/terraform/issues/10957
   region = "us-east-1"
-  alias = "use1"
+  alias  = "use1"
 }
 
 resource "aws_acm_certificate" "cert" {
-    provider            = "aws.use1"
-    count               = "${var.use_custom_domain == "true" ? 1 : 0}"
-    certificate_body    = "${var.ssl_certificate_body}"
-    private_key         = "${var.ssl_certificate_private_key}"
-    certificate_chain   = "${var.ssl_certificate_chain}"
+  provider          = aws.use1
+  count             = var.use_custom_domain == "true" ? 1 : 0
+  certificate_body  = var.ssl_certificate_body
+  private_key       = var.ssl_certificate_private_key
+  certificate_chain = var.ssl_certificate_chain
 }
 
 resource "aws_cloudfront_distribution" "application" {
-    
-    enabled = true
-    default_root_object = "index.html"
-    aliases = "${slice(local.application_domains, 0, var.use_custom_domain == "true" ? length(local.application_domains) : 0)}" # Needs to optionally be an empty list. Workaround from: https://github.com/hashicorp/terraform/issues/18259
+  enabled             = true
+  default_root_object = "index.html"
+  aliases = slice(
+    local.application_domains,
+    0,
+    var.use_custom_domain == "true" ? length(local.application_domains) : 0,
+  ) # Needs to optionally be an empty list. Workaround from: https://github.com/hashicorp/terraform/issues/18259
 
-    # Our S3 bucket
-    origin {
-        domain_name = "${aws_s3_bucket.frontend.bucket_regional_domain_name}"
-        origin_id   = "${local.s3_origin_id}"
+  # Our S3 bucket
+  origin {
+    domain_name = aws_s3_bucket.frontend.bucket_regional_domain_name
+    origin_id   = local.s3_origin_id
 
-        s3_origin_config {
-            origin_access_identity = "${aws_cloudfront_origin_access_identity.origin_access_identity.cloudfront_access_identity_path}"
-        }
+    s3_origin_config {
+      origin_access_identity = aws_cloudfront_origin_access_identity.origin_access_identity.cloudfront_access_identity_path
+    }
+  }
+
+  # Our load balancer
+  origin {
+    domain_name = var.load_balancer_dns_name
+    origin_id   = local.load_balancer_origin_id
+
+    custom_origin_config {
+      http_port                = var.load_balancer_port
+      https_port               = var.load_balancer_port
+      origin_protocol_policy   = "http-only"
+      origin_ssl_protocols     = ["SSLv3", "TLSv1", "TLSv1.1", "TLSv1.2"]
+      origin_keepalive_timeout = 30 # Max is 60
+      origin_read_timeout      = 10 # Max is 60
+    }
+  }
+
+  # Forward requests beginning with /api to our load balancer
+  ordered_cache_behavior {
+    path_pattern     = "/api/*"
+    allowed_methods  = ["DELETE", "GET", "HEAD", "OPTIONS", "PATCH", "POST", "PUT"]
+    cached_methods   = ["GET", "HEAD"]
+    target_origin_id = local.load_balancer_origin_id
+
+    forwarded_values {
+      query_string = true
+      headers      = ["*"] # This seems to be the magic that makes cloudfront not cache anything from this origin, 
+
+      # despite having set the TTLs to 0: https://aws.amazon.com/premiumsupport/knowledge-center/prevent-cloudfront-from-caching-files/
+      # This makes a special note appear in the UI saying that cacheing is disabled for this origin.
+
+      cookies {
+        forward = "all"
+      }
     }
 
-    # Our load balancer
-    origin {
-        domain_name = "${var.load_balancer_dns_name}"
-        origin_id   = "${local.load_balancer_origin_id}"
+    viewer_protocol_policy = "redirect-to-https"
+    min_ttl                = 0
+    default_ttl            = 0
+    max_ttl                = 0
+  }
 
-        custom_origin_config {
-            http_port = "${var.load_balancer_port}"
-            https_port = "${var.load_balancer_port}"
-            origin_protocol_policy = "http-only"
-            origin_ssl_protocols = ["SSLv3", "TLSv1", "TLSv1.1", "TLSv1.2"]
-            origin_keepalive_timeout = 30 # Max is 60
-            origin_read_timeout = 10 # Max is 60
-        }
+  # Forward everything else to our S3 bucket
+  default_cache_behavior {
+    allowed_methods  = ["DELETE", "GET", "HEAD", "OPTIONS", "PATCH", "POST", "PUT"]
+    cached_methods   = ["GET", "HEAD", "OPTIONS"]
+    target_origin_id = local.s3_origin_id
+
+    forwarded_values {
+      query_string = true
+
+      cookies {
+        forward = "all"
+      }
     }
 
-    # Forward requests beginning with /api to our load balancer
-    ordered_cache_behavior {
-        path_pattern     = "/api/*"
-        allowed_methods  = ["DELETE", "GET", "HEAD", "OPTIONS", "PATCH", "POST", "PUT"]
-        cached_methods   = ["GET", "HEAD"]
-        target_origin_id = "${local.load_balancer_origin_id}"
+    viewer_protocol_policy = "redirect-to-https"
+    min_ttl                = 0
+    default_ttl            = 3600
+    max_ttl                = 86400
+  }
 
-        forwarded_values {
-            query_string = true
-            headers = ["*"] # This seems to be the magic that makes cloudfront not cache anything from this origin, 
-                            # despite having set the TTLs to 0: https://aws.amazon.com/premiumsupport/knowledge-center/prevent-cloudfront-from-caching-files/
-                            # This makes a special note appear in the UI saying that cacheing is disabled for this origin.
+  logging_config {
+    include_cookies = false
+    bucket          = aws_s3_bucket.frontend_access_logs.bucket_domain_name
+    prefix          = "cloudfront/"
+  }
 
-            cookies {
-                forward = "all"
-            }
-        }
+  price_class = "PriceClass_100" # Only serve from US/Europe to keep costs down: https://aws.amazon.com/cloudfront/pricing/
 
-        viewer_protocol_policy = "redirect-to-https"
-        min_ttl                = 0
-        default_ttl            = 0
-        max_ttl                = 0
+  restrictions {
+    geo_restriction {
+      restriction_type = "none"
     }
+  }
 
-    # Forward everything else to our S3 bucket
-    default_cache_behavior {
-        allowed_methods  = ["DELETE", "GET", "HEAD", "OPTIONS", "PATCH", "POST", "PUT"]
-        cached_methods   = ["GET", "HEAD", "OPTIONS"]
-        target_origin_id = "${local.s3_origin_id}"
-
-        forwarded_values {
-            query_string = true
-
-            cookies {
-                forward = "all"
-            }
-        }
-
-        viewer_protocol_policy = "redirect-to-https"
-        min_ttl                = 0
-        default_ttl            = 3600
-        max_ttl                = 86400
-    }
-
-    logging_config {
-        include_cookies = false
-        bucket          = "${aws_s3_bucket.frontend_access_logs.bucket_domain_name}"
-        prefix          = "cloudfront/"
-    }
-
-    price_class = "PriceClass_100" # Only serve from US/Europe to keep costs down: https://aws.amazon.com/cloudfront/pricing/
-
-    restrictions {
-        geo_restriction {
-            restriction_type = "none"
-        }
-    }
-
-    viewer_certificate {
-        cloudfront_default_certificate = "${var.use_custom_domain != "true"}" # In dev, for now, we can just visit our site through cloudfront directly rather than through a domain
-        acm_certificate_arn = "${element(concat(aws_acm_certificate.cert.*.arn, list("")), 0)}" # There's either 1 or 0 certs, so the 0th element is either the cert or empty string
-        ssl_support_method = "${var.use_custom_domain == "true" ? "sni-only" : ""}" # If cloudfront_default_certificate is set then this won't be set. But terraform will try to set it everytime it runs, which takes a good 15 minutes each time
-    }
+  viewer_certificate {
+    cloudfront_default_certificate = var.use_custom_domain != "true"                          # In dev, for now, we can just visit our site through cloudfront directly rather than through a domain
+    acm_certificate_arn            = element(concat(aws_acm_certificate.cert.*.arn, [""]), 0) # There's either 1 or 0 certs, so the 0th element is either the cert or empty string
+    ssl_support_method             = var.use_custom_domain == "true" ? "sni-only" : ""        # If cloudfront_default_certificate is set then this won't be set. But terraform will try to set it everytime it runs, which takes a good 15 minutes each time
+  }
 }
+

--- a/terraform/modules/frontend/dns.tf
+++ b/terraform/modules/frontend/dns.tf
@@ -1,17 +1,17 @@
-
 resource "aws_route53_zone" "primary" {
-    name = "${var.application_domain}"
-    force_destroy = true
+  name          = var.application_domain
+  force_destroy = true
 }
 
 resource "aws_route53_record" "cloudfront" {
-    zone_id = "${aws_route53_zone.primary.zone_id}"
-    name    = "${var.application_domain}"
-    type    = "A"
+  zone_id = aws_route53_zone.primary.zone_id
+  name    = var.application_domain
+  type    = "A"
 
-    alias {
-        name                   = "${aws_cloudfront_distribution.application.domain_name}"
-        zone_id                = "${aws_cloudfront_distribution.application.hosted_zone_id}"
-        evaluate_target_health = true
-    }
+  alias {
+    name                   = aws_cloudfront_distribution.application.domain_name
+    zone_id                = aws_cloudfront_distribution.application.hosted_zone_id
+    evaluate_target_health = true
+  }
 }
+

--- a/terraform/modules/frontend/outputs.tf
+++ b/terraform/modules/frontend/outputs.tf
@@ -1,4 +1,5 @@
 output "s3_deployment_bucket_arn" {
-    value = "${aws_s3_bucket.frontend.arn}"
-    description = "The ARN of the bucket that hosts our deployment"
+  value       = aws_s3_bucket.frontend.arn
+  description = "The ARN of the bucket that hosts our deployment"
 }
+

--- a/terraform/modules/frontend/s3.tf
+++ b/terraform/modules/frontend/s3.tf
@@ -1,41 +1,42 @@
 resource "aws_s3_bucket" "frontend" {
-    bucket = "${var.application_name}${var.bucketname_user_string}-${var.environment}"
-    acl    = "bucket-owner-full-control"
-    force_destroy = true
+  bucket        = "${var.application_name}${var.bucketname_user_string}-${var.environment}"
+  acl           = "bucket-owner-full-control"
+  force_destroy = true
 
-    website {
-        index_document = "index.html"
-        error_document = "index.html"
+  website {
+    index_document = "index.html"
+    error_document = "index.html"
+  }
+
+  logging {
+    target_bucket = aws_s3_bucket.frontend_access_logs.id
+    target_prefix = "access-log/"
+  }
+
+  lifecycle_rule {
+    id      = "expire-old-versions-after-N-days"
+    enabled = true
+
+    prefix = "*"
+
+    noncurrent_version_expiration {
+      days = var.days_to_keep_old_versions
     }
-
-    logging {
-        target_bucket = "${aws_s3_bucket.frontend_access_logs.id}"
-        target_prefix = "access-log/"
-    }
-
-    lifecycle_rule {
-        id      = "expire-old-versions-after-N-days"
-        enabled = true
-
-        prefix = "*"
-
-        noncurrent_version_expiration {
-            days = "${var.days_to_keep_old_versions}"
-        }
-    }
+  }
 }
 
 resource "aws_s3_bucket_public_access_block" "frontend" {
-    bucket = "${aws_s3_bucket.frontend.id}"
+  bucket = aws_s3_bucket.frontend.id
 
-    block_public_acls         = false   # Needed to allow deployment into this bucket. I don't understand why. 
-                                        # Giving explicit permission to the IAM user doing the deployment doesn't help. 
-                                        # The console still says "bucket and objects not public" (as desired), 
-                                        # and trying to go to the website link for this bucket gives a 403 forbidden (as desired)
-                                        # I wrote up an issue here: https://github.com/multiplegeorges/vue-cli-plugin-s3-deploy/issues/79
-    block_public_policy       = true
-    ignore_public_acls        = true
-    restrict_public_buckets   = true
+  block_public_acls = false # Needed to allow deployment into this bucket. I don't understand why. 
+
+  # Giving explicit permission to the IAM user doing the deployment doesn't help. 
+  # The console still says "bucket and objects not public" (as desired), 
+  # and trying to go to the website link for this bucket gives a 403 forbidden (as desired)
+  # I wrote up an issue here: https://github.com/multiplegeorges/vue-cli-plugin-s3-deploy/issues/79
+  block_public_policy     = true
+  ignore_public_acls      = true
+  restrict_public_buckets = true
 }
 
 # We need to give the cloudfront user the ability to read from this bucket, and our current
@@ -45,66 +46,68 @@ resource "aws_s3_bucket_public_access_block" "frontend" {
 # to the IAM user who created the bucket. That's the same IAM user who will be deploying files
 # into this bucket, so it needs an individual permission
 
-data "aws_caller_identity" "current" {}
+data "aws_caller_identity" "current" {
+}
 
 data "aws_iam_policy_document" "allow_cloudfront_and_current_user" {
-    statement {
-        actions   = ["s3:GetObject"]
-        resources = ["${aws_s3_bucket.frontend.arn}/*"]
+  statement {
+    actions   = ["s3:GetObject"]
+    resources = ["${aws_s3_bucket.frontend.arn}/*"]
 
-        principals {
-            type        = "AWS"
-            identifiers = ["${aws_cloudfront_origin_access_identity.origin_access_identity.iam_arn}"]
-        }
+    principals {
+      type        = "AWS"
+      identifiers = [aws_cloudfront_origin_access_identity.origin_access_identity.iam_arn]
     }
+  }
 
-    statement {
-        actions   = ["s3:ListBucket"]
-        resources = ["${aws_s3_bucket.frontend.arn}"]
+  statement {
+    actions   = ["s3:ListBucket"]
+    resources = [aws_s3_bucket.frontend.arn]
 
-        principals {
-            type        = "AWS"
-            identifiers = ["${aws_cloudfront_origin_access_identity.origin_access_identity.iam_arn}"]
-        }
+    principals {
+      type        = "AWS"
+      identifiers = [aws_cloudfront_origin_access_identity.origin_access_identity.iam_arn]
     }
+  }
 }
 
 resource "aws_s3_bucket_policy" "frontend_cloudfront_current_user" {
-    bucket = "${aws_s3_bucket.frontend.id}"
-    policy = "${data.aws_iam_policy_document.allow_cloudfront_and_current_user.json}"
+  bucket = aws_s3_bucket.frontend.id
+  policy = data.aws_iam_policy_document.allow_cloudfront_and_current_user.json
 }
 
 resource "aws_s3_bucket" "frontend_access_logs" {
-    bucket = "${var.frontend_access_logs_bucket}${var.bucketname_user_string}-${var.environment}"
-    acl    = "log-delivery-write"
-    force_destroy = "${!var.retain_frontend_access_logs_after_destroy}"
+  bucket        = "${var.frontend_access_logs_bucket}${var.bucketname_user_string}-${var.environment}"
+  acl           = "log-delivery-write"
+  force_destroy = false == var.retain_frontend_access_logs_after_destroy
 
-    lifecycle_rule {
-        id      = "expire-logs-after-N-days"
-        enabled = true
+  lifecycle_rule {
+    id      = "expire-logs-after-N-days"
+    enabled = true
 
-        prefix = "*"
+    prefix = "*"
 
-        expiration {
-            days = "${var.days_to_keep_frontend_access_logs}"
-        }
+    expiration {
+      days = var.days_to_keep_frontend_access_logs
     }
+  }
 
-    server_side_encryption_configuration {
-        rule {
-            apply_server_side_encryption_by_default {
-                # Keep this as AES for consistency with the load balancer access logs (see note there)
-                sse_algorithm = "AES256" 
-            }
-        }
+  server_side_encryption_configuration {
+    rule {
+      apply_server_side_encryption_by_default {
+        # Keep this as AES for consistency with the load balancer access logs (see note there)
+        sse_algorithm = "AES256"
+      }
     }
+  }
 }
 
 resource "aws_s3_bucket_public_access_block" "frontend_access_logs" {
-    bucket = "${aws_s3_bucket.frontend_access_logs.id}"
+  bucket = aws_s3_bucket.frontend_access_logs.id
 
-    block_public_acls         = true
-    block_public_policy       = true
-    ignore_public_acls        = true
-    restrict_public_buckets   = true
+  block_public_acls       = true
+  block_public_policy     = true
+  ignore_public_acls      = true
+  restrict_public_buckets = true
 }
+

--- a/terraform/modules/frontend/variables.tf
+++ b/terraform/modules/frontend/variables.tf
@@ -1,23 +1,69 @@
-variable "environment" {}
-variable "environment_long_name" {}
-variable "region" {}
-variable "days_to_keep_old_versions" {}
-variable "load_balancer_dns_name" {}
-variable "load_balancer_port" {}
-variable "load_balancer_zone_id" {}
-variable "load_balancer_arn" {}
-variable "application_name" {}
-variable "application_domain" {}
-variable "frontend_access_logs_bucket" {}
-variable "retain_frontend_access_logs_after_destroy" {}
-variable "days_to_keep_frontend_access_logs" {}
-variable "bucketname_user_string" {}
-variable "use_custom_domain" {}
-variable "ssl_certificate_body" {}
-variable "ssl_certificate_private_key" {}
-variable "ssl_certificate_chain" {}
-variable "project_github_location" {}
-variable "build_logs_bucket_id" {}
-variable "buildspec_location" {}
-variable "file_path" {}
-variable "build_service_role_arn" {}
+variable "environment" {
+}
+
+variable "environment_long_name" {
+}
+
+variable "region" {
+}
+
+variable "days_to_keep_old_versions" {
+}
+
+variable "load_balancer_dns_name" {
+}
+
+variable "load_balancer_port" {
+}
+
+variable "load_balancer_zone_id" {
+}
+
+variable "load_balancer_arn" {
+}
+
+variable "application_name" {
+}
+
+variable "application_domain" {
+}
+
+variable "frontend_access_logs_bucket" {
+}
+
+variable "retain_frontend_access_logs_after_destroy" {
+}
+
+variable "days_to_keep_frontend_access_logs" {
+}
+
+variable "bucketname_user_string" {
+}
+
+variable "use_custom_domain" {
+}
+
+variable "ssl_certificate_body" {
+}
+
+variable "ssl_certificate_private_key" {
+}
+
+variable "ssl_certificate_chain" {
+}
+
+variable "project_github_location" {
+}
+
+variable "build_logs_bucket_id" {
+}
+
+variable "buildspec_location" {
+}
+
+variable "file_path" {
+}
+
+variable "build_service_role_arn" {
+}
+

--- a/terraform/modules/frontend/versions.tf
+++ b/terraform/modules/frontend/versions.tf
@@ -1,0 +1,4 @@
+
+terraform {
+  required_version = ">= 0.12"
+}

--- a/terraform/modules/ingester-database/build.tf
+++ b/terraform/modules/ingester-database/build.tf
@@ -1,14 +1,15 @@
 module "build" {
   source = "../build-pipeline-backend"
 
-  environment               = "${var.environment}"
-  region                    = "${var.region}"
-  process_name              = "${var.process_name}"
-  project_github_location   = "${var.project_github_location}"
-  build_logs_bucket_id      = "${var.build_logs_bucket_id}"
-  buildspec_location        = "${var.buildspec_location}"
-  file_path                 = "${var.file_path}"
-  file_path_common          = "${var.file_path_common}"
-  build_service_role_arn    = "${var.build_service_role_arn}"
-  container_repository_name = "${module.container_repository.repository_name}"
+  environment               = var.environment
+  region                    = var.region
+  process_name              = var.process_name
+  project_github_location   = var.project_github_location
+  build_logs_bucket_id      = var.build_logs_bucket_id
+  buildspec_location        = var.buildspec_location
+  file_path                 = var.file_path
+  file_path_common          = var.file_path_common
+  build_service_role_arn    = var.build_service_role_arn
+  container_repository_name = module.container_repository.repository_name
 }
+

--- a/terraform/modules/ingester-database/container-repository.tf
+++ b/terraform/modules/ingester-database/container-repository.tf
@@ -1,7 +1,8 @@
 module "container_repository" {
-    source = "../container-repository"
+  source = "../container-repository"
 
-    name = "ingester-database"
-    environment = "${var.environment}"
-    num_days_to_keep_images = "${var.ecs_days_to_keep_images}"
+  name                    = "ingester-database"
+  environment             = var.environment
+  num_days_to_keep_images = var.ecs_days_to_keep_images
 }
+

--- a/terraform/modules/ingester-database/input-sqs-queue.tf
+++ b/terraform/modules/ingester-database/input-sqs-queue.tf
@@ -1,10 +1,11 @@
 module "input_sqs_queue" {
-    source = "../sqs-queue"
+  source = "../sqs-queue"
 
-    queue_name                  = "ingester-queue"
-    environment                 = "${var.environment}"
-    max_redrives                = 4
-    visibility_timeout_seconds  = 30
-    message_retention_seconds   = 1209600 # 14 days
-    long_polling_seconds        = "${var.input_queue_long_polling_seconds}"
+  queue_name                 = "ingester-queue"
+  environment                = var.environment
+  max_redrives               = 4
+  visibility_timeout_seconds = 30
+  message_retention_seconds  = 1209600 # 14 days
+  long_polling_seconds       = var.input_queue_long_polling_seconds
 }
+

--- a/terraform/modules/ingester-database/output-sqs-queue.tf
+++ b/terraform/modules/ingester-database/output-sqs-queue.tf
@@ -1,10 +1,11 @@
 module "output_sqs_queue" {
-    source = "../sqs-queue"
+  source = "../sqs-queue"
 
-    queue_name                  = "ingester-response-queue"
-    environment                 = "${var.environment}"
-    max_redrives                = 4
-    visibility_timeout_seconds  = 30
-    message_retention_seconds   = 1209600 # 14 days
-    long_polling_seconds        = "${var.output_queue_long_polling_seconds}"
+  queue_name                 = "ingester-response-queue"
+  environment                = var.environment
+  max_redrives               = 4
+  visibility_timeout_seconds = 30
+  message_retention_seconds  = 1209600 # 14 days
+  long_polling_seconds       = var.output_queue_long_polling_seconds
 }
+

--- a/terraform/modules/ingester-database/outputs.tf
+++ b/terraform/modules/ingester-database/outputs.tf
@@ -1,49 +1,50 @@
 output "ingester_queue_url" {
-    value = "${module.input_sqs_queue.queue_url}"
-    description = "The URL of the ingester queue"
+  value       = module.input_sqs_queue.queue_url
+  description = "The URL of the ingester queue"
 }
 
 output "ingester_queue_arn" {
-    value = "${module.input_sqs_queue.queue_arn}"
-    description = "The ARN of the ingester queue"
+  value       = module.input_sqs_queue.queue_arn
+  description = "The ARN of the ingester queue"
 }
 
 output "ingester_queue_base_name" {
-    value = "${module.input_sqs_queue.queue_base_name}"
-    description = "The base name of the ingester queue"
+  value       = module.input_sqs_queue.queue_base_name
+  description = "The base name of the ingester queue"
 }
 
 output "ingester_queue_full_name" {
-    value = "${module.input_sqs_queue.queue_full_name}"
-    description = "The full name of the ingester queue"
+  value       = module.input_sqs_queue.queue_full_name
+  description = "The full name of the ingester queue"
 }
 
 output "ingester_queue_dead_letter_full_name" {
-    value = "${module.input_sqs_queue.queue_dead_letter_full_name}"
-    description = "The full name of the ingester dead letter queue"
+  value       = module.input_sqs_queue.queue_dead_letter_full_name
+  description = "The full name of the ingester dead letter queue"
 }
 
 output "ingester_response_queue_url" {
-    value = "${module.output_sqs_queue.queue_url}"
-    description = "The URL of the ingester response queue"
+  value       = module.output_sqs_queue.queue_url
+  description = "The URL of the ingester response queue"
 }
 
 output "ingester_response_queue_arn" {
-    value = "${module.output_sqs_queue.queue_arn}"
-    description = "The ARN of the ingester response queue"
+  value       = module.output_sqs_queue.queue_arn
+  description = "The ARN of the ingester response queue"
 }
 
 output "ingester_response_queue_base_name" {
-    value = "${module.output_sqs_queue.queue_base_name}"
-    description = "The base name of the ingester response queue"
+  value       = module.output_sqs_queue.queue_base_name
+  description = "The base name of the ingester response queue"
 }
 
 output "ingester_response_queue_full_name" {
-    value = "${module.output_sqs_queue.queue_full_name}"
-    description = "The full name of the ingester response queue"
+  value       = module.output_sqs_queue.queue_full_name
+  description = "The full name of the ingester response queue"
 }
 
 output "ingester_response_queue_dead_letter_full_name" {
-    value = "${module.output_sqs_queue.queue_dead_letter_full_name}"
-    description = "The full name of the ingester response dead letter queue"
+  value       = module.output_sqs_queue.queue_dead_letter_full_name
+  description = "The full name of the ingester response dead letter queue"
 }
+

--- a/terraform/modules/ingester-database/parameter-store.tf
+++ b/terraform/modules/ingester-database/parameter-store.tf
@@ -1,98 +1,99 @@
 resource "aws_ssm_parameter" "metrics_namespace" {
-    name        = "/${var.environment}/ingester-database/metrics-namespace"
-    description = "Namespace that our metrics go in"
-    type        = "String"
-    value       = "${var.metrics_namespace}"
+  name        = "/${var.environment}/ingester-database/metrics-namespace"
+  description = "Namespace that our metrics go in"
+  type        = "String"
+  value       = var.metrics_namespace
 }
 
 resource "aws_ssm_parameter" "parameter_memcached_location" {
-    name        = "/${var.environment}/ingester-database/parameter-memcached-location"
-    description = "Where to find a memcached instance to cache our parameter values"
-    type        = "String"
-    value       = "${var.parameter_memcached_location}"
+  name        = "/${var.environment}/ingester-database/parameter-memcached-location"
+  description = "Where to find a memcached instance to cache our parameter values"
+  type        = "String"
+  value       = var.parameter_memcached_location
 }
 
 resource "aws_ssm_parameter" "output_database_host" {
-    name        = "/${var.environment}/ingester-database/output-database-host"
-    description = "Host for the database into which we ingest data from the queue"
-    type        = "String"
-    value       = "${var.mysql_database_host}"
+  name        = "/${var.environment}/ingester-database/output-database-host"
+  description = "Host for the database into which we ingest data from the queue"
+  type        = "String"
+  value       = var.mysql_database_host
 }
 
 resource "aws_ssm_parameter" "output_database_port" {
-    name        = "/${var.environment}/ingester-database/output-database-port"
-    description = "Port for the database into which we ingest data from the queue"
-    type        = "String"
-    value       = "${var.mysql_database_port}"
+  name        = "/${var.environment}/ingester-database/output-database-port"
+  description = "Port for the database into which we ingest data from the queue"
+  type        = "String"
+  value       = var.mysql_database_port
 }
 
 resource "aws_ssm_parameter" "output_database_username" {
-    name        = "/${var.environment}/ingester-database/output-database-username"
-    description = "Username for the database into which we ingest data from the queue"
-    type        = "String"
-    value       = "${var.mysql_database_username}"
+  name        = "/${var.environment}/ingester-database/output-database-username"
+  description = "Username for the database into which we ingest data from the queue"
+  type        = "String"
+  value       = var.mysql_database_username
 }
 
 resource "aws_ssm_parameter" "output_database_password" {
-    name        = "/${var.environment}/ingester-database/output-database-password"
-    description = "Password for the database into which we ingest data from the queue"
-    type        = "SecureString"
-    key_id      = "${var.kms_key_id}"
-    value       = "${var.mysql_database_password}"
+  name        = "/${var.environment}/ingester-database/output-database-password"
+  description = "Password for the database into which we ingest data from the queue"
+  type        = "SecureString"
+  key_id      = var.kms_key_id
+  value       = var.mysql_database_password
 }
 
 resource "aws_ssm_parameter" "output_database_name" {
-    name        = "/${var.environment}/ingester-database/output-database-name"
-    description = "Name for the database into which we ingest data from the queue"
-    type        = "String"
-    value       = "${var.mysql_database_name}"
+  name        = "/${var.environment}/ingester-database/output-database-name"
+  description = "Name for the database into which we ingest data from the queue"
+  type        = "String"
+  value       = var.mysql_database_name
 }
 
 resource "aws_ssm_parameter" "output_database_min_batch_size" {
-    name        = "/${var.environment}/ingester-database/output-database-min-batchsize"
-    description = "Minimum number of items to put into the database in a single batch"
-    type        = "String"
-    value       = "${var.mysql_database_min_batch_size}"
+  name        = "/${var.environment}/ingester-database/output-database-min-batchsize"
+  description = "Minimum number of items to put into the database in a single batch"
+  type        = "String"
+  value       = var.mysql_database_min_batch_size
 }
 
 resource "aws_ssm_parameter" "output_database_maxretries" {
-    name        = "/${var.environment}/ingester-database/output-database-maxretries"
-    description = "Number of items to retry a put operation to the database"
-    type        = "String"
-    value       = "${var.mysql_database_maxretries}"
+  name        = "/${var.environment}/ingester-database/output-database-maxretries"
+  description = "Number of items to retry a put operation to the database"
+  type        = "String"
+  value       = var.mysql_database_maxretries
 }
 
 resource "aws_ssm_parameter" "input_queue_url" {
-    name        = "/${var.environment}/ingester-database/input-queue-url"
-    description = "Endpoint of queue we use to ingest favorites data intended for the database"
-    type        = "String"
-    value       = "${module.input_sqs_queue.queue_url}"
+  name        = "/${var.environment}/ingester-database/input-queue-url"
+  description = "Endpoint of queue we use to ingest favorites data intended for the database"
+  type        = "String"
+  value       = module.input_sqs_queue.queue_url
 }
 
 resource "aws_ssm_parameter" "input_queue_batch_size" {
-    name        = "/${var.environment}/ingester-database/input-queue-batchsize"
-    description = "Number of items to take off of the input queue in a single batch"
-    type        = "String"
-    value       = "${var.input_queue_batch_size}"
+  name        = "/${var.environment}/ingester-database/input-queue-batchsize"
+  description = "Number of items to take off of the input queue in a single batch"
+  type        = "String"
+  value       = var.input_queue_batch_size
 }
 
 resource "aws_ssm_parameter" "input_queue_max_items_to_process" {
-    name        = "/${var.environment}/ingester-database/input-queue-maxitemstoprocess"
-    description = "Maximum number of items to take off the input queue before exiting"
-    type        = "String"
-    value       = "${var.input_queue_max_items_to_process}"
+  name        = "/${var.environment}/ingester-database/input-queue-maxitemstoprocess"
+  description = "Maximum number of items to take off the input queue before exiting"
+  type        = "String"
+  value       = var.input_queue_max_items_to_process
 }
 
 resource "aws_ssm_parameter" "output_queue_url" {
-    name        = "/${var.environment}/ingester-database/output-queue-url"
-    description = "URL of the queue to put ingester response messages on"
-    type        = "String"
-    value       = "${module.output_sqs_queue.queue_url}"
+  name        = "/${var.environment}/ingester-database/output-queue-url"
+  description = "URL of the queue to put ingester response messages on"
+  type        = "String"
+  value       = module.output_sqs_queue.queue_url
 }
 
 resource "aws_ssm_parameter" "output_queue_batch_size" {
-    name        = "/${var.environment}/ingester-database/output-queue-batchsize"
-    description = "Number of items to put on the output queue in a single batch"
-    type        = "String"
-    value       = "${var.output_queue_batch_size}"
+  name        = "/${var.environment}/ingester-database/output-queue-batchsize"
+  description = "Number of items to put on the output queue in a single batch"
+  type        = "String"
+  value       = var.output_queue_batch_size
 }
+

--- a/terraform/modules/ingester-database/task-definition.tf
+++ b/terraform/modules/ingester-database/task-definition.tf
@@ -1,25 +1,24 @@
 module "task_definition" {
-    source = "../task-definition"
+  source = "../task-definition"
 
-    name                        = "ingester-database-${var.environment}"
-    environment                 = "${var.environment}"
-    region                      = "${var.region}"
-    container_repository_url    = "${module.container_repository.repository_url}"
-    cluster_id                  = "${var.ecs_cluster_id}"
-    instances_memory            = "${var.ecs_instances_memory}"
-    instances_cpu               = "${var.ecs_instances_cpu}"
-    instances_log_configuration = "${var.ecs_instances_log_configuration}"
-    instances_desired_count     = "${var.ecs_instances_desired_count}"
-    instances_role_name         = "${var.ecs_instances_role_name}"
-    instances_extra_policy_arn  = "${aws_iam_policy.ecs-instance-ingester-database-extra-policy.arn}"
-    port_mappings               = ""
-    has_load_balancer           = false
-    load_balancer_container_port = -1
-    load_balancer_target_group_arn = ""
+  name                           = "ingester-database-${var.environment}"
+  environment                    = var.environment
+  region                         = var.region
+  container_repository_url       = module.container_repository.repository_url
+  cluster_id                     = var.ecs_cluster_id
+  instances_memory               = var.ecs_instances_memory
+  instances_cpu                  = var.ecs_instances_cpu
+  instances_log_configuration    = var.ecs_instances_log_configuration
+  instances_desired_count        = var.ecs_instances_desired_count
+  instances_role_name            = var.ecs_instances_role_name
+  instances_extra_policy_arn     = aws_iam_policy.ecs-instance-ingester-database-extra-policy.arn
+  port_mappings                  = ""
+  has_load_balancer              = false
+  load_balancer_container_port   = -1
+  load_balancer_target_group_arn = ""
 }
 
 data "aws_caller_identity" "ingester_database" {
-  
 }
 
 resource "aws_iam_policy" "ecs-instance-ingester-database-extra-policy" {
@@ -64,4 +63,6 @@ resource "aws_iam_policy" "ecs-instance-ingester-database-extra-policy" {
   ]
 }
 EOF
+
 }
+

--- a/terraform/modules/ingester-database/variables.tf
+++ b/terraform/modules/ingester-database/variables.tf
@@ -1,32 +1,96 @@
-variable "environment" {}
-variable "region" {}
-variable "metrics_namespace" {}
-variable "parameter_memcached_location" {}
-variable "mysql_database_host" {}
-variable "mysql_database_port" {}
-variable "mysql_database_username" {}
-variable "mysql_database_password" {}
-variable "mysql_database_name" {}
-variable "mysql_database_min_batch_size" {}
-variable "mysql_database_maxretries" {}
-variable "ecs_instances_desired_count" {}
-variable "ecs_instances_memory" {}
-variable "ecs_instances_cpu" {}
-variable "ecs_cluster_id" {}
-variable "ecs_instances_log_configuration" {}
-variable "ecs_instances_role_name" {}
-variable "ecs_days_to_keep_images" {}
-variable "input_queue_batch_size" {}
-variable "input_queue_max_items_to_process" {}
-variable "input_queue_long_polling_seconds" {}
-variable "output_queue_long_polling_seconds" {}
-variable "output_queue_batch_size" {}
-variable "process_name" {}
-variable "project_github_location" {}
-variable "build_logs_bucket_id" {}
-variable "buildspec_location" {}
-variable "file_path" {}
-variable "file_path_common" {}
-variable "build_service_role_arn" {}
-variable "kms_key_id" {}
-variable "kms_key_arn" {}
+variable "environment" {
+}
+
+variable "region" {
+}
+
+variable "metrics_namespace" {
+}
+
+variable "parameter_memcached_location" {
+}
+
+variable "mysql_database_host" {
+}
+
+variable "mysql_database_port" {
+}
+
+variable "mysql_database_username" {
+}
+
+variable "mysql_database_password" {
+}
+
+variable "mysql_database_name" {
+}
+
+variable "mysql_database_min_batch_size" {
+}
+
+variable "mysql_database_maxretries" {
+}
+
+variable "ecs_instances_desired_count" {
+}
+
+variable "ecs_instances_memory" {
+}
+
+variable "ecs_instances_cpu" {
+}
+
+variable "ecs_cluster_id" {
+}
+
+variable "ecs_instances_log_configuration" {
+}
+
+variable "ecs_instances_role_name" {
+}
+
+variable "ecs_days_to_keep_images" {
+}
+
+variable "input_queue_batch_size" {
+}
+
+variable "input_queue_max_items_to_process" {
+}
+
+variable "input_queue_long_polling_seconds" {
+}
+
+variable "output_queue_long_polling_seconds" {
+}
+
+variable "output_queue_batch_size" {
+}
+
+variable "process_name" {
+}
+
+variable "project_github_location" {
+}
+
+variable "build_logs_bucket_id" {
+}
+
+variable "buildspec_location" {
+}
+
+variable "file_path" {
+}
+
+variable "file_path_common" {
+}
+
+variable "build_service_role_arn" {
+}
+
+variable "kms_key_id" {
+}
+
+variable "kms_key_arn" {
+}
+

--- a/terraform/modules/ingester-database/versions.tf
+++ b/terraform/modules/ingester-database/versions.tf
@@ -1,0 +1,4 @@
+
+terraform {
+  required_version = ">= 0.12"
+}

--- a/terraform/modules/ingester-response-reader/build.tf
+++ b/terraform/modules/ingester-response-reader/build.tf
@@ -1,14 +1,15 @@
 module "build" {
   source = "../build-pipeline-backend"
 
-  environment               = "${var.environment}"
-  region                    = "${var.region}"
-  process_name              = "${var.process_name}"
-  project_github_location   = "${var.project_github_location}"
-  build_logs_bucket_id      = "${var.build_logs_bucket_id}"
-  buildspec_location        = "${var.buildspec_location}"
-  file_path                 = "${var.file_path}"
-  file_path_common          = "${var.file_path_common}"
-  build_service_role_arn    = "${var.build_service_role_arn}"
-  container_repository_name = "${module.container_repository.repository_name}"
+  environment               = var.environment
+  region                    = var.region
+  process_name              = var.process_name
+  project_github_location   = var.project_github_location
+  build_logs_bucket_id      = var.build_logs_bucket_id
+  buildspec_location        = var.buildspec_location
+  file_path                 = var.file_path
+  file_path_common          = var.file_path_common
+  build_service_role_arn    = var.build_service_role_arn
+  container_repository_name = module.container_repository.repository_name
 }
+

--- a/terraform/modules/ingester-response-reader/container-repository.tf
+++ b/terraform/modules/ingester-response-reader/container-repository.tf
@@ -1,7 +1,8 @@
 module "container_repository" {
-    source = "../container-repository"
+  source = "../container-repository"
 
-    name = "ingester-response-reader"
-    environment = "${var.environment}"
-    num_days_to_keep_images = "${var.ecs_days_to_keep_images}"
+  name                    = "ingester-response-reader"
+  environment             = var.environment
+  num_days_to_keep_images = var.ecs_days_to_keep_images
 }
+

--- a/terraform/modules/ingester-response-reader/parameter-store.tf
+++ b/terraform/modules/ingester-response-reader/parameter-store.tf
@@ -1,48 +1,49 @@
 resource "aws_ssm_parameter" "metrics_namespace" {
-    name        = "/${var.environment}/ingester-response-reader/metrics-namespace"
-    description = "Namespace that our metrics go in"
-    type        = "String"
-    value       = "${var.metrics_namespace}"
+  name        = "/${var.environment}/ingester-response-reader/metrics-namespace"
+  description = "Namespace that our metrics go in"
+  type        = "String"
+  value       = var.metrics_namespace
 }
 
 resource "aws_ssm_parameter" "parameter_memcached_location" {
-    name        = "/${var.environment}/ingester-response-reader/parameter-memcached-location"
-    description = "Where to find a memcached instance to cache our parameter values"
-    type        = "String"
-    value       = "${var.parameter_memcached_location}"
+  name        = "/${var.environment}/ingester-response-reader/parameter-memcached-location"
+  description = "Where to find a memcached instance to cache our parameter values"
+  type        = "String"
+  value       = var.parameter_memcached_location
 }
 
 resource "aws_ssm_parameter" "api_server_host" {
-    name        = "/${var.environment}/ingester-response-reader/api-server-host"
-    description = "Host for API server"
-    type        = "String"
-    value       = "${var.api_server_host}"
+  name        = "/${var.environment}/ingester-response-reader/api-server-host"
+  description = "Host for API server"
+  type        = "String"
+  value       = var.api_server_host
 }
 
 resource "aws_ssm_parameter" "api_server_port" {
-    name        = "/${var.environment}/ingester-response-reader/api-server-port"
-    description = "Port for the API server"
-    type        = "String"
-    value       = "${var.api_server_port}"
+  name        = "/${var.environment}/ingester-response-reader/api-server-port"
+  description = "Port for the API server"
+  type        = "String"
+  value       = var.api_server_port
 }
 
 resource "aws_ssm_parameter" "ingester_response_queue_url" {
-    name        = "/${var.environment}/ingester-response-reader/ingester-response-queue-url"
-    description = "Endpoint of queue we use to ingest responses about successful data ingestion"
-    type        = "String"
-    value       = "${var.ingester_response_queue_url}"
+  name        = "/${var.environment}/ingester-response-reader/ingester-response-queue-url"
+  description = "Endpoint of queue we use to ingest responses about successful data ingestion"
+  type        = "String"
+  value       = var.ingester_response_queue_url
 }
 
 resource "aws_ssm_parameter" "ingester_response_queue_batch_size" {
-    name        = "/${var.environment}/ingester-response-reader/ingester-response-queue-batchsize"
-    description = "Number of items to take off of the ingester response queue in a single batch"
-    type        = "String"
-    value       = "${var.ingester_response_queue_batch_size}"
+  name        = "/${var.environment}/ingester-response-reader/ingester-response-queue-batchsize"
+  description = "Number of items to take off of the ingester response queue in a single batch"
+  type        = "String"
+  value       = var.ingester_response_queue_batch_size
 }
 
 resource "aws_ssm_parameter" "ingester_response_queue_max_items_to_process" {
-    name        = "/${var.environment}/ingester-response-reader/ingester-response-queue-maxitemstoprocess"
-    description = "Maximum number of items to take off the ingester response queue before exiting"
-    type        = "String"
-    value       = "${var.ingester_response_queue_max_items_to_process}"
+  name        = "/${var.environment}/ingester-response-reader/ingester-response-queue-maxitemstoprocess"
+  description = "Maximum number of items to take off the ingester response queue before exiting"
+  type        = "String"
+  value       = var.ingester_response_queue_max_items_to_process
 }
+

--- a/terraform/modules/ingester-response-reader/task-definition.tf
+++ b/terraform/modules/ingester-response-reader/task-definition.tf
@@ -1,25 +1,24 @@
 module "task_definition" {
-    source = "../task-definition"
+  source = "../task-definition"
 
-    name                        = "ingester-response-reader-${var.environment}"
-    environment                 = "${var.environment}"
-    region                      = "${var.region}"
-    container_repository_url    = "${module.container_repository.repository_url}"
-    cluster_id                  = "${var.ecs_cluster_id}"
-    instances_memory            = "${var.ecs_instances_memory}"
-    instances_cpu               = "${var.ecs_instances_cpu}"
-    instances_log_configuration = "${var.ecs_instances_log_configuration}"
-    instances_desired_count     = "${var.ecs_instances_desired_count}"
-    instances_role_name         = "${var.ecs_instances_role_name}"
-    instances_extra_policy_arn  = "${aws_iam_policy.ecs-instance-ingester-response-reader-extra-policy.arn}"
-    port_mappings               = ""
-    has_load_balancer           = false
-    load_balancer_container_port = -1
-    load_balancer_target_group_arn = ""
+  name                           = "ingester-response-reader-${var.environment}"
+  environment                    = var.environment
+  region                         = var.region
+  container_repository_url       = module.container_repository.repository_url
+  cluster_id                     = var.ecs_cluster_id
+  instances_memory               = var.ecs_instances_memory
+  instances_cpu                  = var.ecs_instances_cpu
+  instances_log_configuration    = var.ecs_instances_log_configuration
+  instances_desired_count        = var.ecs_instances_desired_count
+  instances_role_name            = var.ecs_instances_role_name
+  instances_extra_policy_arn     = aws_iam_policy.ecs-instance-ingester-response-reader-extra-policy.arn
+  port_mappings                  = ""
+  has_load_balancer              = false
+  load_balancer_container_port   = -1
+  load_balancer_target_group_arn = ""
 }
 
 data "aws_caller_identity" "ingester-response-reader" {
-  
 }
 
 resource "aws_iam_policy" "ecs-instance-ingester-response-reader-extra-policy" {
@@ -56,4 +55,6 @@ resource "aws_iam_policy" "ecs-instance-ingester-response-reader-extra-policy" {
   ]
 }
 EOF
+
 }
+

--- a/terraform/modules/ingester-response-reader/variables.tf
+++ b/terraform/modules/ingester-response-reader/variables.tf
@@ -1,24 +1,72 @@
-variable "environment" {}
-variable "region" {}
-variable "metrics_namespace" {}
-variable "parameter_memcached_location" {}
-variable "api_server_host" {}
-variable "api_server_port" {}
-variable "ecs_instances_desired_count" {}
-variable "ecs_instances_memory" {}
-variable "ecs_instances_cpu" {}
-variable "ecs_cluster_id" {}
-variable "ecs_instances_log_configuration" {}
-variable "ecs_instances_role_name" {}
-variable "ecs_days_to_keep_images" {}
-variable "ingester_response_queue_batch_size" {}
-variable "ingester_response_queue_max_items_to_process" {}
-variable "ingester_response_queue_url" {}
-variable "ingester_response_queue_arn" {}
-variable "process_name" {}
-variable "project_github_location" {}
-variable "build_logs_bucket_id" {}
-variable "buildspec_location" {}
-variable "file_path" {}
-variable "file_path_common" {}
-variable "build_service_role_arn" {}
+variable "environment" {
+}
+
+variable "region" {
+}
+
+variable "metrics_namespace" {
+}
+
+variable "parameter_memcached_location" {
+}
+
+variable "api_server_host" {
+}
+
+variable "api_server_port" {
+}
+
+variable "ecs_instances_desired_count" {
+}
+
+variable "ecs_instances_memory" {
+}
+
+variable "ecs_instances_cpu" {
+}
+
+variable "ecs_cluster_id" {
+}
+
+variable "ecs_instances_log_configuration" {
+}
+
+variable "ecs_instances_role_name" {
+}
+
+variable "ecs_days_to_keep_images" {
+}
+
+variable "ingester_response_queue_batch_size" {
+}
+
+variable "ingester_response_queue_max_items_to_process" {
+}
+
+variable "ingester_response_queue_url" {
+}
+
+variable "ingester_response_queue_arn" {
+}
+
+variable "process_name" {
+}
+
+variable "project_github_location" {
+}
+
+variable "build_logs_bucket_id" {
+}
+
+variable "buildspec_location" {
+}
+
+variable "file_path" {
+}
+
+variable "file_path_common" {
+}
+
+variable "build_service_role_arn" {
+}
+

--- a/terraform/modules/ingester-response-reader/versions.tf
+++ b/terraform/modules/ingester-response-reader/versions.tf
@@ -1,0 +1,4 @@
+
+terraform {
+  required_version = ">= 0.12"
+}

--- a/terraform/modules/memcached/memcached.tf
+++ b/terraform/modules/memcached/memcached.tf
@@ -1,38 +1,39 @@
 resource "aws_security_group" "elasticache" {
-    name        = "memcached-${var.environment}"
-    description = "Allow communication with the memcached instance"
-    vpc_id      = "${var.vpc_id}"
+  name        = "memcached-${var.environment}"
+  description = "Allow communication with the memcached instance"
+  vpc_id      = var.vpc_id
 
-    tags = {
-        Name = "terraform-elasticache-${var.environment}"
-    }
+  tags = {
+    Name = "terraform-elasticache-${var.environment}"
+  }
 }
 
 resource "aws_security_group_rule" "elasticache" {
-    cidr_blocks       = ["${var.vpc_cidr}"]
-    description       = "Allow EC2 instances to communicate with the memcached instance"
-    from_port         = 11211
-    protocol          = "tcp"
-    security_group_id = "${aws_security_group.elasticache.id}"
-    to_port           = 11211
-    type              = "ingress"
+  cidr_blocks       = [var.vpc_cidr]
+  description       = "Allow EC2 instances to communicate with the memcached instance"
+  from_port         = 11211
+  protocol          = "tcp"
+  security_group_id = aws_security_group.elasticache.id
+  to_port           = 11211
+  type              = "ingress"
 }
 
 resource "aws_elasticache_subnet_group" "subnet_group" {
-    name       = "elasticache-subnet-group-memcached-${var.environment}"
-    subnet_ids = ["${var.vpc_public_subnet_ids}"]
+  name       = "elasticache-subnet-group-memcached-${var.environment}"
+  subnet_ids = var.vpc_public_subnet_ids
 }
 
 resource "aws_elasticache_cluster" "memcached" {
-    count                = "${var.memcached_num_cache_nodes != 0 ? 1 : 0}" # Don't create the resource at all if we specify 0 nodes. See https://itnext.io/things-i-wish-i-knew-about-terraform-before-jumping-into-it-43ee92a9dd65
+  count = var.memcached_num_cache_nodes != 0 ? 1 : 0 # Don't create the resource at all if we specify 0 nodes. See https://itnext.io/things-i-wish-i-knew-about-terraform-before-jumping-into-it-43ee92a9dd65
 
-    cluster_id           = "memcached-${var.environment}"
-    engine               = "memcached"
-    node_type            = "${var.memcached_node_type}"
-    num_cache_nodes      = "${var.memcached_num_cache_nodes}"
-    az_mode              = "${var.memcached_az_mode}"
-    parameter_group_name = "default.memcached1.5"
-    port                 = 11211
-    security_group_ids   = ["${aws_security_group.elasticache.id}"]
-    subnet_group_name    = "${aws_elasticache_subnet_group.subnet_group.name}"
+  cluster_id           = "memcached-${var.environment}"
+  engine               = "memcached"
+  node_type            = var.memcached_node_type
+  num_cache_nodes      = var.memcached_num_cache_nodes
+  az_mode              = var.memcached_az_mode
+  parameter_group_name = "default.memcached1.5"
+  port                 = 11211
+  security_group_ids   = [aws_security_group.elasticache.id]
+  subnet_group_name    = aws_elasticache_subnet_group.subnet_group.name
 }
+

--- a/terraform/modules/memcached/outputs.tf
+++ b/terraform/modules/memcached/outputs.tf
@@ -1,8 +1,22 @@
 output "location" {
-    # Ugly syntax here for referencing a resource that may not exist. See https://github.com/hashicorp/terraform/issues/16726
-    # Puts "localhost:11211" in this attribute if the memcached cluster wasn't created. The script will attempt to connect to there, fail, and continue in that case
-    # Also note that all variables are internally stored as strings, so having the port as an int results in a strange error message: https://github.com/hashicorp/terraform/issues/17033
-    value       = "${format("%s:%s", element(concat(aws_elasticache_cluster.memcached.*.cluster_address, list("localhost")), 0), element(concat(aws_elasticache_cluster.memcached.*.port, list("11211")), 0))}"
+  # Ugly syntax here for referencing a resource that may not exist. See https://github.com/hashicorp/terraform/issues/16726
+  # Puts "localhost:11211" in this attribute if the memcached cluster wasn't created. The script will attempt to connect to there, fail, and continue in that case
+  # Also note that all variables are internally stored as strings, so having the port as an int results in a strange error message: https://github.com/hashicorp/terraform/issues/17033
+  value = format(
+    "%s:%s",
+    element(
+      concat(
+        aws_elasticache_cluster.memcached.*.cluster_address,
+        ["localhost"],
+      ),
+      0,
+    ),
+    element(
+      concat(aws_elasticache_cluster.memcached.*.port, ["11211"]),
+      0,
+    ),
+  )
 
-    description = "Connection string for the memcached cluster created (or 'localhost:11211' if it was not created)"
+  description = "Connection string for the memcached cluster created (or 'localhost:11211' if it was not created)"
 }
+

--- a/terraform/modules/memcached/variables.tf
+++ b/terraform/modules/memcached/variables.tf
@@ -1,10 +1,25 @@
-variable "environment" {}
-variable "region" {}
+variable "environment" {
+}
 
-variable "vpc_id" {}
-variable "vpc_public_subnet_ids" { type = "list" }
-variable "vpc_cidr" {}
+variable "region" {
+}
 
-variable "memcached_node_type" {}
-variable "memcached_num_cache_nodes" {}
-variable "memcached_az_mode" {}
+variable "vpc_id" {
+}
+
+variable "vpc_public_subnet_ids" {
+  type = list(string)
+}
+
+variable "vpc_cidr" {
+}
+
+variable "memcached_node_type" {
+}
+
+variable "memcached_num_cache_nodes" {
+}
+
+variable "memcached_az_mode" {
+}
+

--- a/terraform/modules/memcached/versions.tf
+++ b/terraform/modules/memcached/versions.tf
@@ -1,0 +1,4 @@
+
+terraform {
+  required_version = ">= 0.12"
+}

--- a/terraform/modules/mysql/mysql.tf
+++ b/terraform/modules/mysql/mysql.tf
@@ -1,64 +1,63 @@
 resource "aws_db_subnet_group" "public_subnet_group" {
-    name       = "db-subnet-group-${var.database_name}-${var.environment}"
-    subnet_ids = ["${var.vpc_public_subnet_ids}"]
+  name       = "db-subnet-group-${var.database_name}-${var.environment}"
+  subnet_ids = var.vpc_public_subnet_ids
 
-    tags = {
-        Name = "db-subnet-group-${var.database_name}-${var.environment}"
-    }
+  tags = {
+    Name = "db-subnet-group-${var.database_name}-${var.environment}"
+  }
 }
 
 resource "aws_db_instance" "mysql_database" {
+  instance_class = var.instance_type
+  identifier     = "${var.database_name}-${var.environment}"
+  name           = var.database_name
+  multi_az       = var.multi_az
 
-    instance_class                  = "${var.instance_type}"
-    identifier                      = "${var.database_name}-${var.environment}"
-    name                            = "${var.database_name}"
-    multi_az                        = "${var.multi_az}"
+  allocated_storage = var.database_size_gb
+  storage_type      = var.storage_type
 
-    allocated_storage               = "${var.database_size_gb}"
-    storage_type                    = "${var.storage_type}"
+  storage_encrypted = var.storage_encrypted
+  kms_key_id        = var.storage_encrypted ? var.kms_key_arn : "" # Luckily we're able to use "" here to denote an empty field. Support for a null value is coming in terraform 0.12: https://github.com/hashicorp/terraform/issues/14037
 
-    storage_encrypted               = "${var.storage_encrypted}"
-    kms_key_id                      = "${var.storage_encrypted ? "${var.kms_key_arn}" : ""}" # Luckily we're able to use "" here to denote an empty field. Support for a null value is coming in terraform 0.12: https://github.com/hashicorp/terraform/issues/14037
+  engine               = "mysql"
+  engine_version       = "8.0"
+  parameter_group_name = "default.mysql8.0"
 
-    engine                          = "mysql"
-    engine_version                  = "8.0"
-    parameter_group_name            = "default.mysql8.0"
+  allow_major_version_upgrade = false
+  apply_immediately           = true
+  auto_minor_version_upgrade  = true
+  backup_retention_period     = var.backup_retention_period_days
+  copy_tags_to_snapshot       = true
 
-    allow_major_version_upgrade     = false
-    apply_immediately               = true
-    auto_minor_version_upgrade      = true
-    backup_retention_period         = "${var.backup_retention_period_days}"
-    copy_tags_to_snapshot           = true
+  deletion_protection       = var.deletion_protection
+  skip_final_snapshot       = false == var.deletion_protection
+  final_snapshot_identifier = "${var.database_name}-${var.environment}-final-snapshot"
 
-    deletion_protection             = "${var.deletion_protection}"
-    skip_final_snapshot             = "${!var.deletion_protection}"
-    final_snapshot_identifier       = "${var.database_name}-${var.environment}-final-snapshot"
+  enabled_cloudwatch_logs_exports = ["error", "general", "slowquery"]
+  monitoring_interval             = 0
 
-    enabled_cloudwatch_logs_exports = [ "error", "general", "slowquery" ]
-    monitoring_interval             = 0
+  iam_database_authentication_enabled = false
+  username                            = "${var.database_name}_${var.environment}"
+  password                            = var.database_password
 
-    iam_database_authentication_enabled = false
-    username                        = "${var.database_name}_${var.environment}"
-    password                        = "${var.database_password}"
+  publicly_accessible    = true
+  db_subnet_group_name   = aws_db_subnet_group.public_subnet_group.name
+  vpc_security_group_ids = [aws_security_group.rds.id]
 
-    publicly_accessible             = true
-    db_subnet_group_name            = "${aws_db_subnet_group.public_subnet_group.name}"
-    vpc_security_group_ids          = [ "${aws_security_group.rds.id}" ]
-
-    tags = {
-        Environment = "${var.environment}"
-    }
-}           
+  tags = {
+    Environment = var.environment
+  }
+}
 
 # Init the database with a script to create tables/indexes/etc
 
 resource "null_resource" "init-database" {
-    
-    triggers {
-        database_id = "${aws_db_instance.mysql_database.id}" # Run this every time the database is changed
-    }
+  triggers = {
+    database_id = aws_db_instance.mysql_database.id # Run this every time the database is changed
+  }
 
-    provisioner "local-exec" {
-        command = "mysql --host=${aws_db_instance.mysql_database.address} --port=${aws_db_instance.mysql_database.port} --user=${aws_db_instance.mysql_database.username} --password=${var.database_password} --database=${aws_db_instance.mysql_database.name} < ../modules/${var.init_script_file}"
-    }
+  provisioner "local-exec" {
+    command = "mysql --host=${aws_db_instance.mysql_database.address} --port=${aws_db_instance.mysql_database.port} --user=${aws_db_instance.mysql_database.username} --password=${var.database_password} --database=${aws_db_instance.mysql_database.name} < ../modules/${var.init_script_file}"
+  }
 }
+

--- a/terraform/modules/mysql/outputs.tf
+++ b/terraform/modules/mysql/outputs.tf
@@ -1,24 +1,25 @@
 output "database_host" {
-    value = "${element(split(":", aws_db_instance.mysql_database.endpoint), 0)}"
-    description = "The host of the database that was created"
+  value       = element(split(":", aws_db_instance.mysql_database.endpoint), 0)
+  description = "The host of the database that was created"
 }
 
 output "database_port" {
-    value = "${aws_db_instance.mysql_database.port}"
-    description = "The port of the database that was created"
+  value       = aws_db_instance.mysql_database.port
+  description = "The port of the database that was created"
 }
 
 output "database_username" {
-    value = "${aws_db_instance.mysql_database.username}"
-    description = "The username for the database that was created"
+  value       = aws_db_instance.mysql_database.username
+  description = "The username for the database that was created"
 }
 
 output "database_name" {
-    value = "${aws_db_instance.mysql_database.name}"
-    description = "The name of the database that was created within the instance"
+  value       = aws_db_instance.mysql_database.name
+  description = "The name of the database that was created within the instance"
 }
 
 output "database_instance_identifier" {
-    value = "${aws_db_instance.mysql_database.identifier}"
-    description = "The identifier of the database instance that was created"
-} 
+  value       = aws_db_instance.mysql_database.identifier
+  description = "The identifier of the database instance that was created"
+}
+

--- a/terraform/modules/mysql/security-group.tf
+++ b/terraform/modules/mysql/security-group.tf
@@ -1,29 +1,30 @@
 resource "aws_security_group" "rds" {
-    name = "security-group-rds-${var.database_name}-${var.environment}"
-    description = "Allow access from our local machine and VPC to RDS"
-    vpc_id = "${var.vpc_id}"
+  name        = "security-group-rds-${var.database_name}-${var.environment}"
+  description = "Allow access from our local machine and VPC to RDS"
+  vpc_id      = var.vpc_id
 
-    ingress {
-        from_port = 3306
-        to_port = 3306
-        protocol = "tcp"
-        cidr_blocks = [
-            "${var.local_machine_cidr}",
-            "${var.vpc_cidr}"
-        ]
-    }
+  ingress {
+    from_port = 3306
+    to_port   = 3306
+    protocol  = "tcp"
+    cidr_blocks = [
+      var.local_machine_cidr,
+      var.vpc_cidr,
+    ]
+  }
 
-    egress {
-        # allow all traffic to private SN
-        from_port = "0"
-        to_port = "0"
-        protocol = "-1"
-        cidr_blocks = [
-            "0.0.0.0/0"
-        ]
-    }
+  egress {
+    # allow all traffic to private SN
+    from_port = "0"
+    to_port   = "0"
+    protocol  = "-1"
+    cidr_blocks = [
+      "0.0.0.0/0",
+    ]
+  }
 
-    tags { 
-        Name = "security-group-rds-${var.database_name}-${var.environment}"
-    }
+  tags = {
+    Name = "security-group-rds-${var.database_name}-${var.environment}"
+  }
 }
+

--- a/terraform/modules/mysql/variables.tf
+++ b/terraform/modules/mysql/variables.tf
@@ -1,16 +1,49 @@
-variable "environment" {}
-variable "instance_type" {}
-variable "database_size_gb" {}
-variable "database_name" {}
-variable "multi_az" {}
-variable "storage_type" {}
-variable "database_password" {}
-variable "vpc_id" {}
-variable "vpc_public_subnet_ids" { type = "list" }
-variable "local_machine_cidr" {}
-variable "vpc_cidr" {}
-variable "backup_retention_period_days" {}
-variable "init_script_file" {}
-variable "storage_encrypted" {}
-variable "deletion_protection" {}
-variable "kms_key_arn" {}
+variable "environment" {
+}
+
+variable "instance_type" {
+}
+
+variable "database_size_gb" {
+}
+
+variable "database_name" {
+}
+
+variable "multi_az" {
+}
+
+variable "storage_type" {
+}
+
+variable "database_password" {
+}
+
+variable "vpc_id" {
+}
+
+variable "vpc_public_subnet_ids" {
+  type = list(string)
+}
+
+variable "local_machine_cidr" {
+}
+
+variable "vpc_cidr" {
+}
+
+variable "backup_retention_period_days" {
+}
+
+variable "init_script_file" {
+}
+
+variable "storage_encrypted" {
+}
+
+variable "deletion_protection" {
+}
+
+variable "kms_key_arn" {
+}
+

--- a/terraform/modules/mysql/versions.tf
+++ b/terraform/modules/mysql/versions.tf
@@ -1,0 +1,4 @@
+
+terraform {
+  required_version = ">= 0.12"
+}

--- a/terraform/modules/puller-flickr/build.tf
+++ b/terraform/modules/puller-flickr/build.tf
@@ -1,14 +1,15 @@
 module "build" {
   source = "../build-pipeline-backend"
 
-  environment               = "${var.environment}"
-  region                    = "${var.region}"
-  process_name              = "${var.process_name}"
-  project_github_location   = "${var.project_github_location}"
-  build_logs_bucket_id      = "${var.build_logs_bucket_id}"
-  buildspec_location        = "${var.buildspec_location}"
-  file_path                 = "${var.file_path}"
-  file_path_common          = "${var.file_path_common}"
-  build_service_role_arn    = "${var.build_service_role_arn}"
-  container_repository_name = "${module.container_repository.repository_name}"
+  environment               = var.environment
+  region                    = var.region
+  process_name              = var.process_name
+  project_github_location   = var.project_github_location
+  build_logs_bucket_id      = var.build_logs_bucket_id
+  buildspec_location        = var.buildspec_location
+  file_path                 = var.file_path
+  file_path_common          = var.file_path_common
+  build_service_role_arn    = var.build_service_role_arn
+  container_repository_name = module.container_repository.repository_name
 }
+

--- a/terraform/modules/puller-flickr/container-repository.tf
+++ b/terraform/modules/puller-flickr/container-repository.tf
@@ -1,7 +1,8 @@
 module "container_repository" {
-    source = "../container-repository"
+  source = "../container-repository"
 
-    name = "puller-flickr"
-    environment = "${var.environment}"
-    num_days_to_keep_images = "${var.ecs_days_to_keep_images}"
+  name                    = "puller-flickr"
+  environment             = var.environment
+  num_days_to_keep_images = var.ecs_days_to_keep_images
 }
+

--- a/terraform/modules/puller-flickr/parameter-store.tf
+++ b/terraform/modules/puller-flickr/parameter-store.tf
@@ -1,119 +1,120 @@
 resource "aws_ssm_parameter" "metrics_namespace" {
-    name        = "/${var.environment}/puller-flickr/metrics-namespace"
-    description = "Namespace that our metrics go in"
-    type        = "String"
-    value       = "${var.metrics_namespace}"
+  name        = "/${var.environment}/puller-flickr/metrics-namespace"
+  description = "Namespace that our metrics go in"
+  type        = "String"
+  value       = var.metrics_namespace
 }
 
 resource "aws_ssm_parameter" "parameter_memcached_location" {
-    name        = "/${var.environment}/puller-flickr/parameter-memcached-location"
-    description = "Where to find a memcached instance to cache our parameter values"
-    type        = "String"
-    value       = "${var.parameter_memcached_location}"
+  name        = "/${var.environment}/puller-flickr/parameter-memcached-location"
+  description = "Where to find a memcached instance to cache our parameter values"
+  type        = "String"
+  value       = var.parameter_memcached_location
 }
 
 resource "aws_ssm_parameter" "flickr_api_key" {
-    name        = "/${var.environment}/puller-flickr/flickr-api-key"
-    description = "Flickr API key"
-    type        = "String"
-    value       = "${var.flickr_api_key}"
+  name        = "/${var.environment}/puller-flickr/flickr-api-key"
+  description = "Flickr API key"
+  type        = "String"
+  value       = var.flickr_api_key
 }
 
 resource "aws_ssm_parameter" "flickr_secret_key" {
-    name        = "/${var.environment}/puller-flickr/flickr-api-secret"
-    description = "Flickr API secret key"
-    type        = "SecureString"
-    key_id      = "${var.kms_key_id}"
-    value       = "${var.flickr_secret_key}"
+  name        = "/${var.environment}/puller-flickr/flickr-api-secret"
+  description = "Flickr API secret key"
+  type        = "SecureString"
+  key_id      = var.kms_key_id
+  value       = var.flickr_secret_key
 }
 
 resource "aws_ssm_parameter" "flickr_api_retries" {
-    name        = "/${var.environment}/puller-flickr/flickr-api-retries"
-    description = "Max number of times to retry a Flickr API call"
-    type        = "String"
-    value       = "${var.flickr_api_retries}"
+  name        = "/${var.environment}/puller-flickr/flickr-api-retries"
+  description = "Max number of times to retry a Flickr API call"
+  type        = "String"
+  value       = var.flickr_api_retries
 }
 
 resource "aws_ssm_parameter" "flickr_api_contacts_max_per_call" {
-    name        = "/${var.environment}/puller-flickr/flickr-api-contacts-maxpercall"
-    description = "Max number of contacts to get per API call"
-    type        = "String"
-    value       = "${var.flickr_api_contacts_max_per_call}"
+  name        = "/${var.environment}/puller-flickr/flickr-api-contacts-maxpercall"
+  description = "Max number of contacts to get per API call"
+  type        = "String"
+  value       = var.flickr_api_contacts_max_per_call
 }
 
 resource "aws_ssm_parameter" "flickr_api_favorites_max_per_call" {
-    name        = "/${var.environment}/puller-flickr/flickr-api-favorites-maxpercall"
-    description = "Max number of favorites to get per API call"
-    type        = "String"
-    value       = "${var.flickr_api_favorites_max_per_call}"
+  name        = "/${var.environment}/puller-flickr/flickr-api-favorites-maxpercall"
+  description = "Max number of favorites to get per API call"
+  type        = "String"
+  value       = var.flickr_api_favorites_max_per_call
 }
 
 resource "aws_ssm_parameter" "flickr_api_favorites_max_to_get" {
-    name        = "/${var.environment}/puller-flickr/flickr-api-favorites-maxtoget"
-    description = "Max number of favorites to get in total"
-    type        = "String"
-    value       = "${var.flickr_api_favorites_max_to_get}"
+  name        = "/${var.environment}/puller-flickr/flickr-api-favorites-maxtoget"
+  description = "Max number of favorites to get in total"
+  type        = "String"
+  value       = var.flickr_api_favorites_max_to_get
 }
 
 resource "aws_ssm_parameter" "flickr_api_favorites_max_calls_to_make" {
-    name        = "/${var.environment}/puller-flickr/flickr-api-favorites-maxcallstomake"
-    description = "Max number of calls to favorites endpoint to make per user."
-    type        = "String"
-    value       = "${var.flickr_api_favorites_max_calls_to_make}"
+  name        = "/${var.environment}/puller-flickr/flickr-api-favorites-maxcallstomake"
+  description = "Max number of calls to favorites endpoint to make per user."
+  type        = "String"
+  value       = var.flickr_api_favorites_max_calls_to_make
 }
 
 resource "aws_ssm_parameter" "memcached_ttl" {
-    name        = "/${var.environment}/puller-flickr/memcached-ttl"
-    description = "TTL in seconds of Flickr API calls put into memcached"
-    type        = "String"
-    value       = "${var.memcached_ttl}"
+  name        = "/${var.environment}/puller-flickr/memcached-ttl"
+  description = "TTL in seconds of Flickr API calls put into memcached"
+  type        = "String"
+  value       = var.memcached_ttl
 }
 
 resource "aws_ssm_parameter" "memcached_location" {
-    name        = "/${var.environment}/puller-flickr/memcached-location"
-    description = "Endpoint of the memcached cluster that we cache Flickr API calls to"
-    type        = "String"
-    value       = "${var.memcached_location}"
+  name        = "/${var.environment}/puller-flickr/memcached-location"
+  description = "Endpoint of the memcached cluster that we cache Flickr API calls to"
+  type        = "String"
+  value       = var.memcached_location
 }
 
 resource "aws_ssm_parameter" "output_queue_url" {
-    name        = "/${var.environment}/puller-flickr/output-queue-url"
-    description = "URL of the queue to put favorites data into for later ingestion into the database"
-    type        = "String"
-    value       = "${var.output_queue_url}"
+  name        = "/${var.environment}/puller-flickr/output-queue-url"
+  description = "URL of the queue to put favorites data into for later ingestion into the database"
+  type        = "String"
+  value       = var.output_queue_url
 }
 
 resource "aws_ssm_parameter" "output_queue_batch_size" {
-    name        = "/${var.environment}/puller-flickr/output-queue-batchsize"
-    description = "Number of items to put on the output queue in a single batch"
-    type        = "String"
-    value       = "${var.output_queue_batch_size}"
+  name        = "/${var.environment}/puller-flickr/output-queue-batchsize"
+  description = "Number of items to put on the output queue in a single batch"
+  type        = "String"
+  value       = var.output_queue_batch_size
 }
 
 resource "aws_ssm_parameter" "puller_queue_url" {
-    name        = "/${var.environment}/puller-flickr/puller-queue-url"
-    description = "URL of the queue to get requests for data to be pulled"
-    type        = "String"
-    value       = "${var.puller_queue_url}"
+  name        = "/${var.environment}/puller-flickr/puller-queue-url"
+  description = "URL of the queue to get requests for data to be pulled"
+  type        = "String"
+  value       = var.puller_queue_url
 }
 
 resource "aws_ssm_parameter" "puller_queue_batch_size" {
-    name        = "/${var.environment}/puller-flickr/puller-queue-batchsize"
-    description = "Number of items to get from the puller queue in a single batch"
-    type        = "String"
-    value       = "${var.puller_queue_batch_size}"
+  name        = "/${var.environment}/puller-flickr/puller-queue-batchsize"
+  description = "Number of items to get from the puller queue in a single batch"
+  type        = "String"
+  value       = var.puller_queue_batch_size
 }
 
 resource "aws_ssm_parameter" "puller_queue_max_items_to_process" {
-    name        = "/${var.environment}/puller-flickr/puller-queue-maxitemstoprocess"
-    description = "Maximum number of items to get from the puller queue before exiting"
-    type        = "String"
-    value       = "${var.puller_queue_max_items_to_process}"
+  name        = "/${var.environment}/puller-flickr/puller-queue-maxitemstoprocess"
+  description = "Maximum number of items to get from the puller queue before exiting"
+  type        = "String"
+  value       = var.puller_queue_max_items_to_process
 }
 
 resource "aws_ssm_parameter" "puller_response_queue_url" {
-    name        = "/${var.environment}/puller-flickr/puller-response-queue-url"
-    description = "URL where we put messages saying we've successfully pulled data"
-    type        = "String"
-    value       = "${var.puller_response_queue_url}"
+  name        = "/${var.environment}/puller-flickr/puller-response-queue-url"
+  description = "URL where we put messages saying we've successfully pulled data"
+  type        = "String"
+  value       = var.puller_response_queue_url
 }
+

--- a/terraform/modules/puller-flickr/task-definition.tf
+++ b/terraform/modules/puller-flickr/task-definition.tf
@@ -1,25 +1,24 @@
 module "task_definition" {
-    source = "../task-definition"
+  source = "../task-definition"
 
-    name                        = "puller-flickr-${var.environment}"
-    environment                 = "${var.environment}"
-    region                      = "${var.region}"
-    container_repository_url    = "${module.container_repository.repository_url}"
-    cluster_id                  = "${var.ecs_cluster_id}"
-    instances_memory            = "${var.ecs_instances_memory}"
-    instances_cpu               = "${var.ecs_instances_cpu}"
-    instances_log_configuration = "${var.ecs_instances_log_configuration}"
-    instances_desired_count     = "${var.ecs_instances_desired_count}"
-    instances_role_name         = "${var.ecs_instances_role_name}"
-    instances_extra_policy_arn  = "${aws_iam_policy.ecs-instance-puller-flickr-extra-policy.arn}"
-    port_mappings               = ""
-    has_load_balancer           = false
-    load_balancer_container_port = -1
-    load_balancer_target_group_arn = ""
+  name                           = "puller-flickr-${var.environment}"
+  environment                    = var.environment
+  region                         = var.region
+  container_repository_url       = module.container_repository.repository_url
+  cluster_id                     = var.ecs_cluster_id
+  instances_memory               = var.ecs_instances_memory
+  instances_cpu                  = var.ecs_instances_cpu
+  instances_log_configuration    = var.ecs_instances_log_configuration
+  instances_desired_count        = var.ecs_instances_desired_count
+  instances_role_name            = var.ecs_instances_role_name
+  instances_extra_policy_arn     = aws_iam_policy.ecs-instance-puller-flickr-extra-policy.arn
+  port_mappings                  = ""
+  has_load_balancer              = false
+  load_balancer_container_port   = -1
+  load_balancer_target_group_arn = ""
 }
 
 data "aws_caller_identity" "puller_flickr" {
-  
 }
 
 resource "aws_iam_policy" "ecs-instance-puller-flickr-extra-policy" {
@@ -72,4 +71,6 @@ resource "aws_iam_policy" "ecs-instance-puller-flickr-extra-policy" {
   ]
 }
 EOF
+
 }
+

--- a/terraform/modules/puller-flickr/variables.tf
+++ b/terraform/modules/puller-flickr/variables.tf
@@ -1,39 +1,117 @@
-variable "environment" {}
-variable "region" {}
-variable "metrics_namespace" {}
-variable "parameter_memcached_location" {}
-variable "memcached_location" {}
-variable "memcached_ttl" {}
-variable "ecs_instances_desired_count" {}
-variable "ecs_instances_memory" {}
-variable "ecs_instances_cpu" {}
-variable "ecs_cluster_id" {}
-variable "ecs_instances_log_configuration" {}
-variable "ecs_instances_role_name" {}
-variable "ecs_days_to_keep_images" {}
-variable "flickr_api_key" {}
-variable "flickr_secret_key" {}
-variable "flickr_api_retries" {}
-variable "flickr_api_favorites_max_per_call" {}
-variable "flickr_api_favorites_max_to_get" {}
-variable "flickr_api_favorites_max_calls_to_make" {}
-variable "flickr_api_contacts_max_per_call" {}
-variable "output_queue_url" {}
-variable "output_queue_arn" {}
-variable "output_queue_batch_size" {}
-variable "puller_queue_url" {}
-variable "puller_queue_arn" {}
-variable "puller_queue_batch_size" {}
-variable "puller_queue_max_items_to_process" {}
-variable "puller_response_queue_url" {}
-variable "puller_response_queue_arn" {}
-variable "puller_response_queue_batch_size" {}
-variable "process_name" {}
-variable "project_github_location" {}
-variable "build_logs_bucket_id" {}
-variable "buildspec_location" {}
-variable "file_path" {}
-variable "file_path_common" {}
-variable "build_service_role_arn" {}
-variable "kms_key_id" {}
-variable "kms_key_arn" {}
+variable "environment" {
+}
+
+variable "region" {
+}
+
+variable "metrics_namespace" {
+}
+
+variable "parameter_memcached_location" {
+}
+
+variable "memcached_location" {
+}
+
+variable "memcached_ttl" {
+}
+
+variable "ecs_instances_desired_count" {
+}
+
+variable "ecs_instances_memory" {
+}
+
+variable "ecs_instances_cpu" {
+}
+
+variable "ecs_cluster_id" {
+}
+
+variable "ecs_instances_log_configuration" {
+}
+
+variable "ecs_instances_role_name" {
+}
+
+variable "ecs_days_to_keep_images" {
+}
+
+variable "flickr_api_key" {
+}
+
+variable "flickr_secret_key" {
+}
+
+variable "flickr_api_retries" {
+}
+
+variable "flickr_api_favorites_max_per_call" {
+}
+
+variable "flickr_api_favorites_max_to_get" {
+}
+
+variable "flickr_api_favorites_max_calls_to_make" {
+}
+
+variable "flickr_api_contacts_max_per_call" {
+}
+
+variable "output_queue_url" {
+}
+
+variable "output_queue_arn" {
+}
+
+variable "output_queue_batch_size" {
+}
+
+variable "puller_queue_url" {
+}
+
+variable "puller_queue_arn" {
+}
+
+variable "puller_queue_batch_size" {
+}
+
+variable "puller_queue_max_items_to_process" {
+}
+
+variable "puller_response_queue_url" {
+}
+
+variable "puller_response_queue_arn" {
+}
+
+variable "puller_response_queue_batch_size" {
+}
+
+variable "process_name" {
+}
+
+variable "project_github_location" {
+}
+
+variable "build_logs_bucket_id" {
+}
+
+variable "buildspec_location" {
+}
+
+variable "file_path" {
+}
+
+variable "file_path_common" {
+}
+
+variable "build_service_role_arn" {
+}
+
+variable "kms_key_id" {
+}
+
+variable "kms_key_arn" {
+}
+

--- a/terraform/modules/puller-flickr/versions.tf
+++ b/terraform/modules/puller-flickr/versions.tf
@@ -1,0 +1,4 @@
+
+terraform {
+  required_version = ">= 0.12"
+}

--- a/terraform/modules/puller-response-reader/build.tf
+++ b/terraform/modules/puller-response-reader/build.tf
@@ -1,14 +1,15 @@
 module "build" {
   source = "../build-pipeline-backend"
 
-  environment               = "${var.environment}"
-  region                    = "${var.region}"
-  process_name              = "${var.process_name}"
-  project_github_location   = "${var.project_github_location}"
-  build_logs_bucket_id      = "${var.build_logs_bucket_id}"
-  buildspec_location        = "${var.buildspec_location}"
-  file_path                 = "${var.file_path}"
-  file_path_common          = "${var.file_path_common}"
-  build_service_role_arn    = "${var.build_service_role_arn}"
-  container_repository_name = "${module.container_repository.repository_name}"
+  environment               = var.environment
+  region                    = var.region
+  process_name              = var.process_name
+  project_github_location   = var.project_github_location
+  build_logs_bucket_id      = var.build_logs_bucket_id
+  buildspec_location        = var.buildspec_location
+  file_path                 = var.file_path
+  file_path_common          = var.file_path_common
+  build_service_role_arn    = var.build_service_role_arn
+  container_repository_name = module.container_repository.repository_name
 }
+

--- a/terraform/modules/puller-response-reader/container-repository.tf
+++ b/terraform/modules/puller-response-reader/container-repository.tf
@@ -1,7 +1,8 @@
 module "container_repository" {
-    source = "../container-repository"
+  source = "../container-repository"
 
-    name = "puller-response-reader"
-    environment = "${var.environment}"
-    num_days_to_keep_images = "${var.ecs_days_to_keep_images}"
+  name                    = "puller-response-reader"
+  environment             = var.environment
+  num_days_to_keep_images = var.ecs_days_to_keep_images
 }
+

--- a/terraform/modules/puller-response-reader/parameter-store.tf
+++ b/terraform/modules/puller-response-reader/parameter-store.tf
@@ -1,62 +1,63 @@
 resource "aws_ssm_parameter" "metrics_namespace" {
-    name        = "/${var.environment}/puller-response-reader/metrics-namespace"
-    description = "Namespace that our metrics go in"
-    type        = "String"
-    value       = "${var.metrics_namespace}"
+  name        = "/${var.environment}/puller-response-reader/metrics-namespace"
+  description = "Namespace that our metrics go in"
+  type        = "String"
+  value       = var.metrics_namespace
 }
 
 resource "aws_ssm_parameter" "parameter_memcached_location" {
-    name        = "/${var.environment}/puller-response-reader/parameter-memcached-location"
-    description = "Where to find a memcached instance to cache our parameter values"
-    type        = "String"
-    value       = "${var.parameter_memcached_location}"
+  name        = "/${var.environment}/puller-response-reader/parameter-memcached-location"
+  description = "Where to find a memcached instance to cache our parameter values"
+  type        = "String"
+  value       = var.parameter_memcached_location
 }
 
 resource "aws_ssm_parameter" "api_server_host" {
-    name        = "/${var.environment}/puller-response-reader/api-server-host"
-    description = "Host for API server"
-    type        = "String"
-    value       = "${var.api_server_host}"
+  name        = "/${var.environment}/puller-response-reader/api-server-host"
+  description = "Host for API server"
+  type        = "String"
+  value       = var.api_server_host
 }
 
 resource "aws_ssm_parameter" "api_server_port" {
-    name        = "/${var.environment}/puller-response-reader/api-server-port"
-    description = "Port for the API server"
-    type        = "String"
-    value       = "${var.api_server_port}"
+  name        = "/${var.environment}/puller-response-reader/api-server-port"
+  description = "Port for the API server"
+  type        = "String"
+  value       = var.api_server_port
 }
 
 resource "aws_ssm_parameter" "puller_queue_url" {
-    name        = "/${var.environment}/puller-response-reader/puller-queue-url"
-    description = "URL of the queue to put requests for data to be pulled"
-    type        = "String"
-    value       = "${var.puller_queue_url}"
+  name        = "/${var.environment}/puller-response-reader/puller-queue-url"
+  description = "URL of the queue to put requests for data to be pulled"
+  type        = "String"
+  value       = var.puller_queue_url
 }
 
 resource "aws_ssm_parameter" "puller_queue_batch_size" {
-    name        = "/${var.environment}/puller-response-reader/puller-queue-batchsize"
-    description = "Number of items to put on the puller queue in a single batch"
-    type        = "String"
-    value       = "${var.puller_queue_batch_size}"
+  name        = "/${var.environment}/puller-response-reader/puller-queue-batchsize"
+  description = "Number of items to put on the puller queue in a single batch"
+  type        = "String"
+  value       = var.puller_queue_batch_size
 }
 
 resource "aws_ssm_parameter" "puller_response_queue_url" {
-    name        = "/${var.environment}/puller-response-reader/puller-response-queue-url"
-    description = "Endpoint of queue we use to ingest responses about successful data pulling"
-    type        = "String"
-    value       = "${var.puller_response_queue_url}"
+  name        = "/${var.environment}/puller-response-reader/puller-response-queue-url"
+  description = "Endpoint of queue we use to ingest responses about successful data pulling"
+  type        = "String"
+  value       = var.puller_response_queue_url
 }
 
 resource "aws_ssm_parameter" "puller_response_queue_batch_size" {
-    name        = "/${var.environment}/puller-response-reader/puller-response-queue-batchsize"
-    description = "Number of items to take off of the puller response queue in a single batch"
-    type        = "String"
-    value       = "${var.puller_response_queue_batch_size}"
+  name        = "/${var.environment}/puller-response-reader/puller-response-queue-batchsize"
+  description = "Number of items to take off of the puller response queue in a single batch"
+  type        = "String"
+  value       = var.puller_response_queue_batch_size
 }
 
 resource "aws_ssm_parameter" "puller_response_queue_max_items_to_process" {
-    name        = "/${var.environment}/puller-response-reader/puller-response-queue-maxitemstoprocess"
-    description = "Maximum number of items to take off the puller response queue before exiting"
-    type        = "String"
-    value       = "${var.puller_response_queue_max_items_to_process}"
+  name        = "/${var.environment}/puller-response-reader/puller-response-queue-maxitemstoprocess"
+  description = "Maximum number of items to take off the puller response queue before exiting"
+  type        = "String"
+  value       = var.puller_response_queue_max_items_to_process
 }
+

--- a/terraform/modules/puller-response-reader/task-definition.tf
+++ b/terraform/modules/puller-response-reader/task-definition.tf
@@ -1,25 +1,24 @@
 module "task_definition" {
-    source = "../task-definition"
+  source = "../task-definition"
 
-    name                        = "puller-response-reader-${var.environment}"
-    environment                 = "${var.environment}"
-    region                      = "${var.region}"
-    container_repository_url    = "${module.container_repository.repository_url}"
-    cluster_id                  = "${var.ecs_cluster_id}"
-    instances_memory            = "${var.ecs_instances_memory}"
-    instances_cpu               = "${var.ecs_instances_cpu}"
-    instances_log_configuration = "${var.ecs_instances_log_configuration}"
-    instances_desired_count     = "${var.ecs_instances_desired_count}"
-    instances_role_name         = "${var.ecs_instances_role_name}"
-    instances_extra_policy_arn  = "${aws_iam_policy.ecs-instance-puller-response-reader-extra-policy.arn}"
-    port_mappings               = ""
-    has_load_balancer           = false
-    load_balancer_container_port = -1
-    load_balancer_target_group_arn = ""
+  name                           = "puller-response-reader-${var.environment}"
+  environment                    = var.environment
+  region                         = var.region
+  container_repository_url       = module.container_repository.repository_url
+  cluster_id                     = var.ecs_cluster_id
+  instances_memory               = var.ecs_instances_memory
+  instances_cpu                  = var.ecs_instances_cpu
+  instances_log_configuration    = var.ecs_instances_log_configuration
+  instances_desired_count        = var.ecs_instances_desired_count
+  instances_role_name            = var.ecs_instances_role_name
+  instances_extra_policy_arn     = aws_iam_policy.ecs-instance-puller-response-reader-extra-policy.arn
+  port_mappings                  = ""
+  has_load_balancer              = false
+  load_balancer_container_port   = -1
+  load_balancer_target_group_arn = ""
 }
 
 data "aws_caller_identity" "puller-response-reader" {
-  
 }
 
 resource "aws_iam_policy" "ecs-instance-puller-response-reader-extra-policy" {
@@ -64,4 +63,6 @@ resource "aws_iam_policy" "ecs-instance-puller-response-reader-extra-policy" {
   ]
 }
 EOF
+
 }
+

--- a/terraform/modules/puller-response-reader/variables.tf
+++ b/terraform/modules/puller-response-reader/variables.tf
@@ -1,27 +1,81 @@
-variable "environment" {}
-variable "region" {}
-variable "metrics_namespace" {}
-variable "parameter_memcached_location" {}
-variable "api_server_host" {}
-variable "api_server_port" {}
-variable "ecs_instances_desired_count" {}
-variable "ecs_instances_memory" {}
-variable "ecs_instances_cpu" {}
-variable "ecs_cluster_id" {}
-variable "ecs_instances_log_configuration" {}
-variable "ecs_instances_role_name" {}
-variable "ecs_days_to_keep_images" {}
-variable "puller_queue_batch_size" {}
-variable "puller_response_queue_batch_size" {}
-variable "puller_response_queue_max_items_to_process" {}
-variable "puller_queue_url" {}
-variable "puller_queue_arn" {}
-variable "puller_response_queue_url" {}
-variable "puller_response_queue_arn" {}
-variable "process_name" {}
-variable "project_github_location" {}
-variable "build_logs_bucket_id" {}
-variable "buildspec_location" {}
-variable "file_path" {}
-variable "file_path_common" {}
-variable "build_service_role_arn" {}
+variable "environment" {
+}
+
+variable "region" {
+}
+
+variable "metrics_namespace" {
+}
+
+variable "parameter_memcached_location" {
+}
+
+variable "api_server_host" {
+}
+
+variable "api_server_port" {
+}
+
+variable "ecs_instances_desired_count" {
+}
+
+variable "ecs_instances_memory" {
+}
+
+variable "ecs_instances_cpu" {
+}
+
+variable "ecs_cluster_id" {
+}
+
+variable "ecs_instances_log_configuration" {
+}
+
+variable "ecs_instances_role_name" {
+}
+
+variable "ecs_days_to_keep_images" {
+}
+
+variable "puller_queue_batch_size" {
+}
+
+variable "puller_response_queue_batch_size" {
+}
+
+variable "puller_response_queue_max_items_to_process" {
+}
+
+variable "puller_queue_url" {
+}
+
+variable "puller_queue_arn" {
+}
+
+variable "puller_response_queue_url" {
+}
+
+variable "puller_response_queue_arn" {
+}
+
+variable "process_name" {
+}
+
+variable "project_github_location" {
+}
+
+variable "build_logs_bucket_id" {
+}
+
+variable "buildspec_location" {
+}
+
+variable "file_path" {
+}
+
+variable "file_path_common" {
+}
+
+variable "build_service_role_arn" {
+}
+

--- a/terraform/modules/puller-response-reader/versions.tf
+++ b/terraform/modules/puller-response-reader/versions.tf
@@ -1,0 +1,4 @@
+
+terraform {
+  required_version = ">= 0.12"
+}

--- a/terraform/modules/scheduler/build.tf
+++ b/terraform/modules/scheduler/build.tf
@@ -1,14 +1,15 @@
 module "build" {
   source = "../build-pipeline-backend"
 
-  environment               = "${var.environment}"
-  region                    = "${var.region}"
-  process_name              = "${var.process_name}"
-  project_github_location   = "${var.project_github_location}"
-  build_logs_bucket_id      = "${var.build_logs_bucket_id}"
-  buildspec_location        = "${var.buildspec_location}"
-  file_path                 = "${var.file_path}"
-  file_path_common          = "${var.file_path_common}"
-  build_service_role_arn    = "${var.build_service_role_arn}"
-  container_repository_name = "${module.container_repository.repository_name}"
+  environment               = var.environment
+  region                    = var.region
+  process_name              = var.process_name
+  project_github_location   = var.project_github_location
+  build_logs_bucket_id      = var.build_logs_bucket_id
+  buildspec_location        = var.buildspec_location
+  file_path                 = var.file_path
+  file_path_common          = var.file_path_common
+  build_service_role_arn    = var.build_service_role_arn
+  container_repository_name = module.container_repository.repository_name
 }
+

--- a/terraform/modules/scheduler/container-repository.tf
+++ b/terraform/modules/scheduler/container-repository.tf
@@ -1,7 +1,8 @@
 module "container_repository" {
-    source = "../container-repository"
+  source = "../container-repository"
 
-    name = "scheduler"
-    environment = "${var.environment}"
-    num_days_to_keep_images = "${var.ecs_days_to_keep_images}"
+  name                    = "scheduler"
+  environment             = var.environment
+  num_days_to_keep_images = var.ecs_days_to_keep_images
 }
+

--- a/terraform/modules/scheduler/outputs.tf
+++ b/terraform/modules/scheduler/outputs.tf
@@ -1,49 +1,50 @@
 output "puller_queue_url" {
-    value = "${module.puller_queue.queue_url}"
-    description = "The URL of the puller queue"
+  value       = module.puller_queue.queue_url
+  description = "The URL of the puller queue"
 }
 
 output "puller_queue_arn" {
-    value = "${module.puller_queue.queue_arn}"
-    description = "The ARN of the puller queue"
+  value       = module.puller_queue.queue_arn
+  description = "The ARN of the puller queue"
 }
 
 output "puller_queue_base_name" {
-    value = "${module.puller_queue.queue_base_name}"
-    description = "The base name of the puller queue"
+  value       = module.puller_queue.queue_base_name
+  description = "The base name of the puller queue"
 }
 
 output "puller_queue_full_name" {
-    value = "${module.puller_queue.queue_full_name}"
-    description = "The full name of the puller queue"
+  value       = module.puller_queue.queue_full_name
+  description = "The full name of the puller queue"
 }
 
 output "puller_queue_dead_letter_full_name" {
-    value = "${module.puller_queue.queue_dead_letter_full_name}"
-    description = "The full name of the puller dead letter queue"
+  value       = module.puller_queue.queue_dead_letter_full_name
+  description = "The full name of the puller dead letter queue"
 }
 
 output "puller_response_queue_url" {
-    value = "${module.puller_response_queue.queue_url}"
-    description = "The URL of the puller response queue"
+  value       = module.puller_response_queue.queue_url
+  description = "The URL of the puller response queue"
 }
 
 output "puller_response_queue_arn" {
-    value = "${module.puller_response_queue.queue_arn}"
-    description = "The ARN of the puller response queue"
+  value       = module.puller_response_queue.queue_arn
+  description = "The ARN of the puller response queue"
 }
 
 output "puller_response_queue_base_name" {
-    value = "${module.puller_response_queue.queue_base_name}"
-    description = "The base name of the puller response queue"
+  value       = module.puller_response_queue.queue_base_name
+  description = "The base name of the puller response queue"
 }
 
 output "puller_response_queue_full_name" {
-    value = "${module.puller_response_queue.queue_full_name}"
-    description = "The full name of the puller response queue"
+  value       = module.puller_response_queue.queue_full_name
+  description = "The full name of the puller response queue"
 }
 
 output "puller_response_queue_dead_letter_full_name" {
-    value = "${module.puller_response_queue.queue_dead_letter_full_name}"
-    description = "The full name of the puller response dead letter queue"
+  value       = module.puller_response_queue.queue_dead_letter_full_name
+  description = "The full name of the puller response dead letter queue"
 }
+

--- a/terraform/modules/scheduler/parameter-store.tf
+++ b/terraform/modules/scheduler/parameter-store.tf
@@ -1,69 +1,70 @@
 resource "aws_ssm_parameter" "metrics_namespace" {
-    name        = "/${var.environment}/scheduler/metrics-namespace"
-    description = "Namespace that our metrics go in"
-    type        = "String"
-    value       = "${var.metrics_namespace}"
+  name        = "/${var.environment}/scheduler/metrics-namespace"
+  description = "Namespace that our metrics go in"
+  type        = "String"
+  value       = var.metrics_namespace
 }
 
 resource "aws_ssm_parameter" "parameter_memcached_location" {
-    name        = "/${var.environment}/scheduler/parameter-memcached-location"
-    description = "Where to find a memcached instance to cache our parameter values"
-    type        = "String"
-    value       = "${var.parameter_memcached_location}"
+  name        = "/${var.environment}/scheduler/parameter-memcached-location"
+  description = "Where to find a memcached instance to cache our parameter values"
+  type        = "String"
+  value       = var.parameter_memcached_location
 }
 
 resource "aws_ssm_parameter" "api_server_host" {
-    name        = "/${var.environment}/scheduler/api-server-host"
-    description = "Host for API server from which we get scheduling information"
-    type        = "String"
-    value       = "${var.api_server_host}"
+  name        = "/${var.environment}/scheduler/api-server-host"
+  description = "Host for API server from which we get scheduling information"
+  type        = "String"
+  value       = var.api_server_host
 }
 
 resource "aws_ssm_parameter" "api_server_port" {
-    name        = "/${var.environment}/scheduler/api-server-port"
-    description = "Port for the API server from which we get scheduling information"
-    type        = "String"
-    value       = "${var.api_server_port}"
+  name        = "/${var.environment}/scheduler/api-server-port"
+  description = "Port for the API server from which we get scheduling information"
+  type        = "String"
+  value       = var.api_server_port
 }
 
 resource "aws_ssm_parameter" "puller_queue_url" {
-    name        = "/${var.environment}/scheduler/puller-queue-url"
-    description = "URL of the queue to put requests for data to be pulled"
-    type        = "String"
-    value       = "${module.puller_queue.queue_url}"
+  name        = "/${var.environment}/scheduler/puller-queue-url"
+  description = "URL of the queue to put requests for data to be pulled"
+  type        = "String"
+  value       = module.puller_queue.queue_url
 }
 
 resource "aws_ssm_parameter" "puller_queue_batch_size" {
-    name        = "/${var.environment}/scheduler/puller-queue-batchsize"
-    description = "Number of items to put on the puller queue in a single batch"
-    type        = "String"
-    value       = "${var.puller_queue_batch_size}"
+  name        = "/${var.environment}/scheduler/puller-queue-batchsize"
+  description = "Number of items to put on the puller queue in a single batch"
+  type        = "String"
+  value       = var.puller_queue_batch_size
 }
 
 resource "aws_ssm_parameter" "scheduler_seconds_between_user_data_updates" {
-    name        = "/${var.environment}/scheduler/seconds-between-user-data-updates"
-    description = "Number of seconds between requests from the scheduler to update user data from each provider"
-    type        = "String"
-    value       = "${var.scheduler_seconds_between_user_data_updates}"
+  name        = "/${var.environment}/scheduler/seconds-between-user-data-updates"
+  description = "Number of seconds between requests from the scheduler to update user data from each provider"
+  type        = "String"
+  value       = var.scheduler_seconds_between_user_data_updates
 }
 
 resource "aws_ssm_parameter" "max_iterations_before_exit" {
-    name        = "/${var.environment}/scheduler/max-iterations-before-exit"
-    description = "Number of times we iterate over our tasks before exiting and being restarted"
-    type        = "String"
-    value       = "${var.max_iterations_before_exit}"
+  name        = "/${var.environment}/scheduler/max-iterations-before-exit"
+  description = "Number of times we iterate over our tasks before exiting and being restarted"
+  type        = "String"
+  value       = var.max_iterations_before_exit
 }
 
 resource "aws_ssm_parameter" "min_sleep_ms_between_iterations" {
-    name        = "/${var.environment}/scheduler/min-sleep-ms-between-iterations"
-    description = "Minimum number of milliseconds we sleep between iterations"
-    type        = "String"
-    value       = "${var.min_sleep_ms_between_iterations}"
+  name        = "/${var.environment}/scheduler/min-sleep-ms-between-iterations"
+  description = "Minimum number of milliseconds we sleep between iterations"
+  type        = "String"
+  value       = var.min_sleep_ms_between_iterations
 }
 
 resource "aws_ssm_parameter" "duration_to_request_lock_seconds" {
-    name        = "/${var.environment}/scheduler/duration-to-request-lock-seconds"
-    description = "Number of seconds for which to request a lock on other scheduler instances beginning processing"
-    type        = "String"
-    value       = "${var.duration_to_request_lock_seconds}"
+  name        = "/${var.environment}/scheduler/duration-to-request-lock-seconds"
+  description = "Number of seconds for which to request a lock on other scheduler instances beginning processing"
+  type        = "String"
+  value       = var.duration_to_request_lock_seconds
 }
+

--- a/terraform/modules/scheduler/puller-queue.tf
+++ b/terraform/modules/scheduler/puller-queue.tf
@@ -1,10 +1,11 @@
 module "puller_queue" {
-    source = "../sqs-queue"
+  source = "../sqs-queue"
 
-    queue_name                  = "puller-queue"
-    environment                 = "${var.environment}"
-    max_redrives                = 4
-    visibility_timeout_seconds  = 45 # It can take quite a while to pull all of the favorites for a user if they have a lot 
-    message_retention_seconds   = 1209600 # 14 days
-    long_polling_seconds        = "${var.puller_queue_long_polling_seconds}"
+  queue_name                 = "puller-queue"
+  environment                = var.environment
+  max_redrives               = 4
+  visibility_timeout_seconds = 45      # It can take quite a while to pull all of the favorites for a user if they have a lot 
+  message_retention_seconds  = 1209600 # 14 days
+  long_polling_seconds       = var.puller_queue_long_polling_seconds
 }
+

--- a/terraform/modules/scheduler/puller-response-queue.tf
+++ b/terraform/modules/scheduler/puller-response-queue.tf
@@ -1,10 +1,11 @@
 module "puller_response_queue" {
-    source = "../sqs-queue"
+  source = "../sqs-queue"
 
-    queue_name                  = "puller-response-queue"
-    environment                 = "${var.environment}"
-    max_redrives                = 4
-    visibility_timeout_seconds  = 30
-    message_retention_seconds   = 1209600 # 14 days
-    long_polling_seconds        = "${var.puller_response_queue_long_polling_seconds}"
+  queue_name                 = "puller-response-queue"
+  environment                = var.environment
+  max_redrives               = 4
+  visibility_timeout_seconds = 30
+  message_retention_seconds  = 1209600 # 14 days
+  long_polling_seconds       = var.puller_response_queue_long_polling_seconds
 }
+

--- a/terraform/modules/scheduler/task-definition.tf
+++ b/terraform/modules/scheduler/task-definition.tf
@@ -1,25 +1,24 @@
 module "task_definition" {
-    source = "../task-definition"
+  source = "../task-definition"
 
-    name                        = "scheduler-${var.environment}"
-    environment                 = "${var.environment}"
-    region                      = "${var.region}"
-    container_repository_url    = "${module.container_repository.repository_url}"
-    cluster_id                  = "${var.ecs_cluster_id}"
-    instances_memory            = "${var.ecs_instances_memory}"
-    instances_cpu               = "${var.ecs_instances_cpu}"
-    instances_log_configuration = "${var.ecs_instances_log_configuration}"
-    instances_desired_count     = "${var.ecs_instances_desired_count}"
-    instances_role_name         = "${var.ecs_instances_role_name}"
-    instances_extra_policy_arn  = "${aws_iam_policy.ecs-instance-scheduler-extra-policy.arn}"
-    port_mappings               = ""
-    has_load_balancer           = false
-    load_balancer_container_port = -1
-    load_balancer_target_group_arn = ""
+  name                           = "scheduler-${var.environment}"
+  environment                    = var.environment
+  region                         = var.region
+  container_repository_url       = module.container_repository.repository_url
+  cluster_id                     = var.ecs_cluster_id
+  instances_memory               = var.ecs_instances_memory
+  instances_cpu                  = var.ecs_instances_cpu
+  instances_log_configuration    = var.ecs_instances_log_configuration
+  instances_desired_count        = var.ecs_instances_desired_count
+  instances_role_name            = var.ecs_instances_role_name
+  instances_extra_policy_arn     = aws_iam_policy.ecs-instance-scheduler-extra-policy.arn
+  port_mappings                  = ""
+  has_load_balancer              = false
+  load_balancer_container_port   = -1
+  load_balancer_target_group_arn = ""
 }
 
 data "aws_caller_identity" "scheduler" {
-  
 }
 
 resource "aws_iam_policy" "ecs-instance-scheduler-extra-policy" {
@@ -55,4 +54,6 @@ resource "aws_iam_policy" "ecs-instance-scheduler-extra-policy" {
   ]
 }
 EOF
+
 }
+

--- a/terraform/modules/scheduler/variables.tf
+++ b/terraform/modules/scheduler/variables.tf
@@ -1,29 +1,87 @@
-variable "environment" {}
-variable "region" {}
-variable "metrics_namespace" {}
-variable "parameter_memcached_location" {}
-variable "api_server_host" {}
-variable "api_server_port" {}
-variable "ecs_instances_desired_count" {}
-variable "ecs_instances_memory" {}
-variable "ecs_instances_cpu" {}
-variable "ecs_cluster_id" {}
-variable "ecs_instances_log_configuration" {}
-variable "ecs_instances_role_name" {}
-variable "ecs_days_to_keep_images" {}
-variable "puller_queue_batch_size" {}
-variable "scheduler_seconds_between_user_data_updates" {}
-variable "ingester_database_queue_url" {}
-variable "ingester_database_queue_arn" {}
-variable "max_iterations_before_exit" {}
-variable "min_sleep_ms_between_iterations" {}
-variable "duration_to_request_lock_seconds" {}
-variable "puller_queue_long_polling_seconds" {}
-variable "puller_response_queue_long_polling_seconds" {}
-variable "process_name" {}
-variable "project_github_location" {}
-variable "build_logs_bucket_id" {}
-variable "buildspec_location" {}
-variable "file_path" {}
-variable "file_path_common" {}
-variable "build_service_role_arn" {}
+variable "environment" {
+}
+
+variable "region" {
+}
+
+variable "metrics_namespace" {
+}
+
+variable "parameter_memcached_location" {
+}
+
+variable "api_server_host" {
+}
+
+variable "api_server_port" {
+}
+
+variable "ecs_instances_desired_count" {
+}
+
+variable "ecs_instances_memory" {
+}
+
+variable "ecs_instances_cpu" {
+}
+
+variable "ecs_cluster_id" {
+}
+
+variable "ecs_instances_log_configuration" {
+}
+
+variable "ecs_instances_role_name" {
+}
+
+variable "ecs_days_to_keep_images" {
+}
+
+variable "puller_queue_batch_size" {
+}
+
+variable "scheduler_seconds_between_user_data_updates" {
+}
+
+variable "ingester_database_queue_url" {
+}
+
+variable "ingester_database_queue_arn" {
+}
+
+variable "max_iterations_before_exit" {
+}
+
+variable "min_sleep_ms_between_iterations" {
+}
+
+variable "duration_to_request_lock_seconds" {
+}
+
+variable "puller_queue_long_polling_seconds" {
+}
+
+variable "puller_response_queue_long_polling_seconds" {
+}
+
+variable "process_name" {
+}
+
+variable "project_github_location" {
+}
+
+variable "build_logs_bucket_id" {
+}
+
+variable "buildspec_location" {
+}
+
+variable "file_path" {
+}
+
+variable "file_path_common" {
+}
+
+variable "build_service_role_arn" {
+}
+

--- a/terraform/modules/scheduler/versions.tf
+++ b/terraform/modules/scheduler/versions.tf
@@ -1,0 +1,4 @@
+
+terraform {
+  required_version = ">= 0.12"
+}

--- a/terraform/modules/sqs-queue/outputs.tf
+++ b/terraform/modules/sqs-queue/outputs.tf
@@ -1,24 +1,25 @@
 output "queue_url" {
-    value = "${aws_sqs_queue.queue.id}"
-    description = "The URL of the main queue created"
+  value       = aws_sqs_queue.queue.id
+  description = "The URL of the main queue created"
 }
 
 output "queue_arn" {
-    value = "${aws_sqs_queue.queue.arn}"
-    description = "The ARN of the main queue created"
+  value       = aws_sqs_queue.queue.arn
+  description = "The ARN of the main queue created"
 }
 
 output "queue_base_name" {
-    value = "${var.queue_name}"
-    description = "The base name of the queue (without environment)"
+  value       = var.queue_name
+  description = "The base name of the queue (without environment)"
 }
 
 output "queue_full_name" {
-    value = "${var.queue_name}-${var.environment}"
-    description = "The full name of the queue (with environment)"
+  value       = "${var.queue_name}-${var.environment}"
+  description = "The full name of the queue (with environment)"
 }
 
 output "queue_dead_letter_full_name" {
-    value = "${var.queue_name}-dead-letter-${var.environment}"
-    description = "The full name of the queue's dead letter queue (with environment)"
+  value       = "${var.queue_name}-dead-letter-${var.environment}"
+  description = "The full name of the queue's dead letter queue (with environment)"
 }
+

--- a/terraform/modules/sqs-queue/sqs-queue.tf
+++ b/terraform/modules/sqs-queue/sqs-queue.tf
@@ -1,31 +1,30 @@
 resource "aws_sqs_queue" "queue" {
-    name                        = "${var.queue_name}-${var.environment}"
-    visibility_timeout_seconds  = "${var.visibility_timeout_seconds}"
-    delay_seconds               = 0
-    max_message_size            = 262144 # 256kB
-    message_retention_seconds   = "${var.message_retention_seconds}"
-    receive_wait_time_seconds   = "${var.long_polling_seconds}" # Enable long polling: https://docs.aws.amazon.com/AWSSimpleQueueService/latest/SQSDeveloperGuide/sqs-short-and-long-polling.html#sqs-long-polling
-    redrive_policy              = "{\"deadLetterTargetArn\":\"${aws_sqs_queue.dead_letter_queue.arn}\",\"maxReceiveCount\":${var.max_redrives}}"
+  name                       = "${var.queue_name}-${var.environment}"
+  visibility_timeout_seconds = var.visibility_timeout_seconds
+  delay_seconds              = 0
+  max_message_size           = 262144 # 256kB
+  message_retention_seconds  = var.message_retention_seconds
+  receive_wait_time_seconds  = var.long_polling_seconds # Enable long polling: https://docs.aws.amazon.com/AWSSimpleQueueService/latest/SQSDeveloperGuide/sqs-short-and-long-polling.html#sqs-long-polling
+  redrive_policy             = "{\"deadLetterTargetArn\":\"${aws_sqs_queue.dead_letter_queue.arn}\",\"maxReceiveCount\":${var.max_redrives}}"
 
-    tags = {
-        Environment = "${var.environment}"
-    }
+  tags = {
+    Environment = var.environment
+  }
 
-    # Not sure why we need an explicit dependency here, but otherwise we get an error saying that the queue referenced
-    # in the redrive policy doesn't exist yet.
-    depends_on = [
-        "aws_sqs_queue.dead_letter_queue"
-    ]
+  # Not sure why we need an explicit dependency here, but otherwise we get an error saying that the queue referenced
+  # in the redrive policy doesn't exist yet.
+  depends_on = [aws_sqs_queue.dead_letter_queue]
 }
 
 resource "aws_sqs_queue" "dead_letter_queue" {
-    name                      = "${var.queue_name}-dead-letter-${var.environment}"
-    delay_seconds             = 0
-    max_message_size          = 262144 # 256kB
-    message_retention_seconds = 1209600 # 14 days
-    receive_wait_time_seconds = 0
+  name                      = "${var.queue_name}-dead-letter-${var.environment}"
+  delay_seconds             = 0
+  max_message_size          = 262144  # 256kB
+  message_retention_seconds = 1209600 # 14 days
+  receive_wait_time_seconds = 0
 
-    tags = {
-        Environment = "${var.environment}"
-    }
+  tags = {
+    Environment = var.environment
+  }
 }
+

--- a/terraform/modules/sqs-queue/variables.tf
+++ b/terraform/modules/sqs-queue/variables.tf
@@ -1,6 +1,18 @@
-variable "environment" {}
-variable "queue_name" {}
-variable "max_redrives" {}
-variable "visibility_timeout_seconds" {}
-variable "message_retention_seconds" {}
-variable "long_polling_seconds" {}
+variable "environment" {
+}
+
+variable "queue_name" {
+}
+
+variable "max_redrives" {
+}
+
+variable "visibility_timeout_seconds" {
+}
+
+variable "message_retention_seconds" {
+}
+
+variable "long_polling_seconds" {
+}
+

--- a/terraform/modules/sqs-queue/versions.tf
+++ b/terraform/modules/sqs-queue/versions.tf
@@ -1,0 +1,4 @@
+
+terraform {
+  required_version = ">= 0.12"
+}

--- a/terraform/modules/task-definition/task-definition.tf
+++ b/terraform/modules/task-definition/task-definition.tf
@@ -1,6 +1,6 @@
 data "aws_ecs_task_definition" "task_definition" {
-    depends_on = [ "aws_ecs_task_definition.task_definition" ] # https://github.com/terraform-providers/terraform-provider-aws/issues/1274
-    task_definition = "${aws_ecs_task_definition.task_definition.family}"
+  depends_on      = [aws_ecs_task_definition.task_definition] # https://github.com/terraform-providers/terraform-provider-aws/issues/1274
+  task_definition = aws_ecs_task_definition.task_definition.family
 }
 
 # NOTE: to debug issues with this JSON, try targetting this specific resource when running terraform. 
@@ -10,8 +10,8 @@ data "aws_ecs_task_definition" "task_definition" {
 # See https://github.com/terraform-providers/terraform-provider-aws/issues/3281
 
 resource "aws_ecs_task_definition" "task_definition" {
-    family                = "${var.name}"
-    container_definitions = <<DEFINITION
+  family                = var.name
+  container_definitions = <<DEFINITION
 [
   {
     "name": "${var.name}",
@@ -29,19 +29,19 @@ resource "aws_ecs_task_definition" "task_definition" {
 ]
 DEFINITION
 
-    # Consider putting this in if we see this stuff getting rebuilt every run when we don't want to. 
-    # Note then that there will be an extra step when we change the task definition: https://github.com/terraform-providers/terraform-provider-aws/issues/1274
-    #lifecycle {
-    #    ignore_changes = [
-    #      "container_definitions" # if template file changed, do nothing, believe that human's changes are source of truth
-    #    ]
-    #}
+  # Consider putting this in if we see this stuff getting rebuilt every run when we don't want to. 
+  # Note then that there will be an extra step when we change the task definition: https://github.com/terraform-providers/terraform-provider-aws/issues/1274
+  #lifecycle {
+  #    ignore_changes = [
+  #      "container_definitions" # if template file changed, do nothing, believe that human's changes are source of truth
+  #    ]
+  #}
 }
 
 # Add extra permissions to the instances in the cluster to support the actions puller-flickr needs to take
 resource "aws_iam_role_policy_attachment" "attach-extra-policy" {
-    role       = "${var.instances_role_name}"
-    policy_arn = "${var.instances_extra_policy_arn}"
+  role       = var.instances_role_name
+  policy_arn = var.instances_extra_policy_arn
 }
 
 # terraform 0.11 doesn't have support for dynamic blocks yet, and we need to use a block to describe our optional load balancer.
@@ -49,40 +49,42 @@ resource "aws_iam_role_policy_attachment" "attach-extra-policy" {
 # Dynamic blocks are coming in terraform 0.12: https://github.com/hashicorp/terraform/issues/7034
 
 resource "aws_ecs_service" "ecs_service_no_load_balancer" {
-    count           = "${var.has_load_balancer ? 0 : 1}"
+  count = var.has_load_balancer ? 0 : 1
 
-    name            = "${var.name}"
-    cluster         = "${var.cluster_id}"
-    task_definition = "${aws_ecs_task_definition.task_definition.family}:${max("${aws_ecs_task_definition.task_definition.revision}", "${data.aws_ecs_task_definition.task_definition.revision}")}"
-    desired_count   = "${var.instances_desired_count}"
-
-    # Consider putting this in if we see this stuff getting rebuilt every run when we don't want to. 
-    # Note then that there will be an extra step when we change the task definition: https://github.com/terraform-providers/terraform-provider-aws/issues/1274
-    #lifecycle {
-    #    ignore_changes = ["task_definition"] # the same here, do nothing if it was already installed
-    #}
+  name    = var.name
+  cluster = var.cluster_id
+  task_definition = "${aws_ecs_task_definition.task_definition.family}:${max(
+    aws_ecs_task_definition.task_definition.revision,
+    data.aws_ecs_task_definition.task_definition.revision,
+  )}"
+  desired_count = var.instances_desired_count
+  # Consider putting this in if we see this stuff getting rebuilt every run when we don't want to. 
+  # Note then that there will be an extra step when we change the task definition: https://github.com/terraform-providers/terraform-provider-aws/issues/1274
+  #lifecycle {
+  #    ignore_changes = ["task_definition"] # the same here, do nothing if it was already installed
+  #}
 }
 
 resource "aws_ecs_service" "ecs_service_with_load_balancer" {
-    count           = "${var.has_load_balancer ? 1 : 0}"
+  count = var.has_load_balancer ? 1 : 0
 
-    name            = "${var.name}"
-    cluster         = "${var.cluster_id}"
-    task_definition = "${aws_ecs_task_definition.task_definition.family}:${max("${aws_ecs_task_definition.task_definition.revision}", "${data.aws_ecs_task_definition.task_definition.revision}")}"
-    desired_count   = "${var.instances_desired_count}"
+  name    = var.name
+  cluster = var.cluster_id
+  task_definition = "${aws_ecs_task_definition.task_definition.family}:${max(
+    aws_ecs_task_definition.task_definition.revision,
+    data.aws_ecs_task_definition.task_definition.revision,
+  )}"
+  desired_count = var.instances_desired_count
 
-    load_balancer {
-        target_group_arn = "${var.load_balancer_target_group_arn}"
-        container_name   = "${var.name}"
-        container_port   = "${var.load_balancer_container_port}"
-    }
-
-    # Consider putting this in if we see this stuff getting rebuilt every run when we don't want to. 
-    # Note then that there will be an extra step when we change the task definition: https://github.com/terraform-providers/terraform-provider-aws/issues/1274
-    #lifecycle {
-    #    ignore_changes = ["task_definition"] # the same here, do nothing if it was already installed
-    #}
+  load_balancer {
+    target_group_arn = var.load_balancer_target_group_arn
+    container_name   = var.name
+    container_port   = var.load_balancer_container_port
+  }
+  # Consider putting this in if we see this stuff getting rebuilt every run when we don't want to. 
+  # Note then that there will be an extra step when we change the task definition: https://github.com/terraform-providers/terraform-provider-aws/issues/1274
+  #lifecycle {
+  #    ignore_changes = ["task_definition"] # the same here, do nothing if it was already installed
+  #}
 }
-
-
 

--- a/terraform/modules/task-definition/variables.tf
+++ b/terraform/modules/task-definition/variables.tf
@@ -1,15 +1,45 @@
-variable "name" {}
-variable "environment" {}
-variable "region" {}
-variable "instances_desired_count" {}
-variable "instances_memory" {}
-variable "instances_cpu" {}
-variable "cluster_id" {}
-variable "instances_log_configuration" {}
-variable "instances_role_name" {}
-variable "instances_extra_policy_arn" {}
-variable "container_repository_url" {}
-variable "port_mappings" {}
-variable "has_load_balancer" {}
-variable "load_balancer_container_port" {}
-variable "load_balancer_target_group_arn" {}
+variable "name" {
+}
+
+variable "environment" {
+}
+
+variable "region" {
+}
+
+variable "instances_desired_count" {
+}
+
+variable "instances_memory" {
+}
+
+variable "instances_cpu" {
+}
+
+variable "cluster_id" {
+}
+
+variable "instances_log_configuration" {
+}
+
+variable "instances_role_name" {
+}
+
+variable "instances_extra_policy_arn" {
+}
+
+variable "container_repository_url" {
+}
+
+variable "port_mappings" {
+}
+
+variable "has_load_balancer" {
+}
+
+variable "load_balancer_container_port" {
+}
+
+variable "load_balancer_target_group_arn" {
+}
+

--- a/terraform/modules/task-definition/versions.tf
+++ b/terraform/modules/task-definition/versions.tf
@@ -1,0 +1,4 @@
+
+terraform {
+  required_version = ">= 0.12"
+}

--- a/terraform/modules/vpc/outputs.tf
+++ b/terraform/modules/vpc/outputs.tf
@@ -1,29 +1,30 @@
 output "vpc_id" {
-    value = "${aws_vpc.vpc.id}"
-    description = "The ID of the VPC created"
+  value       = aws_vpc.vpc.id
+  description = "The ID of the VPC created"
 }
 
 output "vpc_public_subnet_ids" {
-    value = [ "${aws_subnet.public-subnet.*.id}" ]
-    description = "The IDs of the public subnets created"
+  value       = [aws_subnet.public-subnet.*.id]
+  description = "The IDs of the public subnets created"
 }
 
 output "vpc_public_subnet_arns" {
-    value = [ "${aws_subnet.public-subnet.*.arn}" ]
-    description = "The ARNs of the public subnets created"
+  value       = [aws_subnet.public-subnet.*.arn]
+  description = "The ARNs of the public subnets created"
 }
 
 output "vpc_private_subnet_ids" {
-    value = [ "${aws_subnet.private-subnet.*.id}" ]
-    description = "The IDs of the private subnets created"
+  value       = [aws_subnet.private-subnet.*.id]
+  description = "The IDs of the private subnets created"
 }
 
 output "vpc_private_subnet_arns" {
-    value = [ "${aws_subnet.private-subnet.*.arn}" ]
-    description = "The ARNs of the private subnets created"
+  value       = [aws_subnet.private-subnet.*.arn]
+  description = "The ARNs of the private subnets created"
 }
 
 output "vpc_cidr_block" {
-    value = "${var.cidr_block}"
-    description = "The CIDR block covered by the VPC created"
+  value       = var.cidr_block
+  description = "The CIDR block covered by the VPC created"
 }
+

--- a/terraform/modules/vpc/outputs.tf
+++ b/terraform/modules/vpc/outputs.tf
@@ -4,22 +4,22 @@ output "vpc_id" {
 }
 
 output "vpc_public_subnet_ids" {
-  value       = [aws_subnet.public-subnet.*.id]
+  value       = aws_subnet.public-subnet[*].id
   description = "The IDs of the public subnets created"
 }
 
 output "vpc_public_subnet_arns" {
-  value       = [aws_subnet.public-subnet.*.arn]
+  value       = aws_subnet.public-subnet[*].arn
   description = "The ARNs of the public subnets created"
 }
 
 output "vpc_private_subnet_ids" {
-  value       = [aws_subnet.private-subnet.*.id]
+  value       = aws_subnet.private-subnet[*].id
   description = "The IDs of the private subnets created"
 }
 
 output "vpc_private_subnet_arns" {
-  value       = [aws_subnet.private-subnet.*.arn]
+  value       = aws_subnet.private-subnet[*].arn
   description = "The ARNs of the private subnets created"
 }
 

--- a/terraform/modules/vpc/private-subnet.tf
+++ b/terraform/modules/vpc/private-subnet.tf
@@ -1,11 +1,12 @@
 # Private subnet - 1 per subnet listed in our variables
 resource "aws_subnet" "private-subnet" {
-    count = "${length(var.private_subnets)}"
+  count = length(var.private_subnets)
 
-    vpc_id = "${aws_vpc.vpc.id}"
-    cidr_block = "${element(values(var.private_subnets), count.index)}"
-    availability_zone = "${element(keys(var.private_subnets), count.index)}"
-    tags {
-        Name = "private-subnet-${var.vpc_name}-${element(keys(var.private_subnets), count.index)}-${var.environment}"
-    }
+  vpc_id            = aws_vpc.vpc.id
+  cidr_block        = element(values(var.private_subnets), count.index)
+  availability_zone = element(keys(var.private_subnets), count.index)
+  tags = {
+    Name = "private-subnet-${var.vpc_name}-${element(keys(var.private_subnets), count.index)}-${var.environment}"
+  }
 }
+

--- a/terraform/modules/vpc/public-subnet.tf
+++ b/terraform/modules/vpc/public-subnet.tf
@@ -1,31 +1,32 @@
 # Public subnet - 1 per subnet listed in our variables
 resource "aws_subnet" "public-subnet" {
-    count = "${length(var.public_subnets)}"
+  count = length(var.public_subnets)
 
-    vpc_id = "${aws_vpc.vpc.id}"
-    cidr_block = "${element(values(var.public_subnets), count.index)}"
-    availability_zone = "${element(keys(var.public_subnets), count.index)}"
-    tags {
-        Name = "public-subnet-${var.vpc_name}-${element(keys(var.public_subnets), count.index)}-${var.environment}"
-    }
+  vpc_id            = aws_vpc.vpc.id
+  cidr_block        = element(values(var.public_subnets), count.index)
+  availability_zone = element(keys(var.public_subnets), count.index)
+  tags = {
+    Name = "public-subnet-${var.vpc_name}-${element(keys(var.public_subnets), count.index)}-${var.environment}"
+  }
 }
 
 # Routing table for our public subnets
 resource "aws_route_table" "public-subnet-routing-table" {
-    vpc_id = "${aws_vpc.vpc.id}"
-    route {
-        cidr_block = "0.0.0.0/0"
-        gateway_id = "${aws_internet_gateway.internet-gateway.id}"
-    }
-    tags {
-        Name = "public-subnet-routing-table-${var.vpc_name}-${var.environment}"
-    }
+  vpc_id = aws_vpc.vpc.id
+  route {
+    cidr_block = "0.0.0.0/0"
+    gateway_id = aws_internet_gateway.internet-gateway.id
+  }
+  tags = {
+    Name = "public-subnet-routing-table-${var.vpc_name}-${var.environment}"
+  }
 }
 
 # Associate the routing table to each public subnet
 resource "aws_route_table_association" "public-subnet-routing-table-association" {
-    count           = "${length(var.public_subnets)}"
+  count = length(var.public_subnets)
 
-    subnet_id       = "${element(aws_subnet.public-subnet.*.id, count.index)}"
-    route_table_id  = "${aws_route_table.public-subnet-routing-table.id}"
+  subnet_id      = element(aws_subnet.public-subnet.*.id, count.index)
+  route_table_id = aws_route_table.public-subnet-routing-table.id
 }
+

--- a/terraform/modules/vpc/variables.tf
+++ b/terraform/modules/vpc/variables.tf
@@ -1,5 +1,17 @@
-variable "vpc_name" {}
-variable "environment" {}
-variable "cidr_block" {}
-variable "public_subnets" { type = "map" }
-variable "private_subnets" { type = "map" }
+variable "vpc_name" {
+}
+
+variable "environment" {
+}
+
+variable "cidr_block" {
+}
+
+variable "public_subnets" {
+  type = map(string)
+}
+
+variable "private_subnets" {
+  type = map(string)
+}
+

--- a/terraform/modules/vpc/versions.tf
+++ b/terraform/modules/vpc/versions.tf
@@ -1,0 +1,4 @@
+
+terraform {
+  required_version = ">= 0.12"
+}

--- a/terraform/modules/vpc/vpc.tf
+++ b/terraform/modules/vpc/vpc.tf
@@ -1,18 +1,19 @@
 # Based off of https://dwmkerr.com/dynamic-and-configurable-availability-zones-in-terraform/
 
 resource "aws_vpc" "vpc" {
-    cidr_block = "${var.cidr_block}"
-    enable_dns_support = true
-    enable_dns_hostnames = true
-    tags {
-        Name = "${var.vpc_name}-${var.environment}"
-    }
+  cidr_block           = var.cidr_block
+  enable_dns_support   = true
+  enable_dns_hostnames = true
+  tags = {
+    Name = "${var.vpc_name}-${var.environment}"
+  }
 }
 
 # Internet gateway for the public subnet
 resource "aws_internet_gateway" "internet-gateway" {
-    vpc_id = "${aws_vpc.vpc.id}"
-    tags {
-        Name = "internet-gateway-${var.vpc_name}-${var.environment}"
-    }
+  vpc_id = aws_vpc.vpc.id
+  tags = {
+    Name = "internet-gateway-${var.vpc_name}-${var.environment}"
+  }
 }
+

--- a/terraform/prod/main.tf
+++ b/terraform/prod/main.tf
@@ -33,7 +33,7 @@ module "build-common-infrastructure" {
   project_github_location  = var.project_github_location
   s3_deployment_bucket_arn = module.frontend.s3_deployment_bucket_arn
 
-  build_logs_bucket               = "build-logs"
+  build_logs_bucket               = "photo-recommender-build-logs"
   bucketname_user_string          = var.bucketname_user_string
   retain_build_logs_after_destroy = "false" # For dev, we don't care about retaining these logs after doing a terraform destroy
   days_to_keep_build_logs         = 90
@@ -345,7 +345,7 @@ module "api_server" {
 
   retain_load_balancer_access_logs_after_destroy = "false" # For dev, we don't care about retaining these logs after doing a terraform destroy
   load_balancer_days_to_keep_access_logs         = 30
-  load_balancer_access_logs_bucket               = "load-balancer-access-logs"
+  load_balancer_access_logs_bucket               = "photo-recommender-load-balancer-access-logs"
   load_balancer_access_logs_prefix               = "api-server-lb"
   bucketname_user_string                         = var.bucketname_user_string
 
@@ -404,7 +404,7 @@ module "frontend" {
   load_balancer_port     = module.api_server.load_balancer_port
   load_balancer_zone_id  = module.api_server.load_balancer_zone_id
 
-  frontend_access_logs_bucket               = "frontend-access-logs"
+  frontend_access_logs_bucket               = "photo-recommender-frontend-access-logs"
   retain_frontend_access_logs_after_destroy = "false" # For dev, we don't care about retaining these logs after doing a terraform destroy
   days_to_keep_frontend_access_logs         = 30
 

--- a/terraform/prod/main.tf
+++ b/terraform/prod/main.tf
@@ -1,485 +1,486 @@
 module "vpc" {
-    source = "../modules/vpc"
+  source = "../modules/vpc"
 
-    vpc_name = "photo-recommender"
-    environment = "${var.environment}"
+  vpc_name    = "photo-recommender"
+  environment = var.environment
 
-    cidr_block = "10.10.0.0/16"
+  cidr_block = "10.10.0.0/16"
 
-    public_subnets = {
-        us-west-2a = "10.10.1.0/24"
-        us-west-2b = "10.10.2.0/24"
-    }
+  public_subnets = {
+    us-west-2a = "10.10.1.0/24"
+    us-west-2b = "10.10.2.0/24"
+  }
 
-    private_subnets = {
-        us-west-2a = "10.10.3.0/24"
-        us-west-2b = "10.10.4.0/24"
-    }
+  private_subnets = {
+    us-west-2a = "10.10.3.0/24"
+    us-west-2b = "10.10.4.0/24"
+  }
 }
 
 module "encryption" {
-    source = "../modules/encryption"
+  source = "../modules/encryption"
 
-    environment = "${var.environment}"
+  environment = var.environment
 }
 
 module "build-common-infrastructure" {
-    source = "../modules/build-common-infrastructure"
+  source = "../modules/build-common-infrastructure"
 
-    environment = "${var.environment}"
-    environment_long_name = "${var.environment_long_name}"
-    region = "${var.region}"
+  environment           = var.environment
+  environment_long_name = var.environment_long_name
+  region                = var.region
 
-    project_github_location = "${var.project_github_location}"
-    s3_deployment_bucket_arn = "${module.frontend.s3_deployment_bucket_arn}"
+  project_github_location  = var.project_github_location
+  s3_deployment_bucket_arn = module.frontend.s3_deployment_bucket_arn
 
-    build_logs_bucket = "build-logs"
-    bucketname_user_string  = "${var.bucketname_user_string}"
-    retain_build_logs_after_destroy = "false" # For dev, we don't care about retaining these logs after doing a terraform destroy
-    days_to_keep_build_logs = 90
+  build_logs_bucket               = "build-logs"
+  bucketname_user_string          = var.bucketname_user_string
+  retain_build_logs_after_destroy = "false" # For dev, we don't care about retaining these logs after doing a terraform destroy
+  days_to_keep_build_logs         = 90
 }
 
 module "elastic_container_service" {
-    source = "../modules/elastic-container-service"
+  source = "../modules/elastic-container-service"
 
-    environment = "${var.environment}"
-    region = "${var.region}"
-    cluster_name = "photo-recommender"
+  environment  = var.environment
+  region       = var.region
+  cluster_name = "photo-recommender"
 
-    vpc_id = "${module.vpc.vpc_id}"
-    vpc_public_subnet_ids = "${module.vpc.vpc_public_subnet_ids}"
+  vpc_id                = module.vpc.vpc_id
+  vpc_public_subnet_ids = module.vpc.vpc_public_subnet_ids
 
-    local_machine_cidr = "${var.local_machine_cidr}"
-    local_machine_public_key = "${var.local_machine_public_key}"
+  local_machine_cidr       = var.local_machine_cidr
+  local_machine_public_key = var.local_machine_public_key
 
-    extra_security_groups = ["${module.api_server.security_group_id}"]
+  extra_security_groups = [module.api_server.security_group_id]
 
-    instance_type = "c5.large"#"t2.micro"
-    cluster_desired_size = 20#0#2#20
-    cluster_min_size = 0
-    cluster_max_size = 20#0#2#20
-    instances_log_retention_days = 1
+  instance_type                = "c5.large" #"t2.micro"
+  cluster_desired_size         = 20         #0#2#20
+  cluster_min_size             = 0
+  cluster_max_size             = 20 #0#2#20
+  instances_log_retention_days = 1
 }
 
 module "database" {
-    source = "../modules/database"
+  source = "../modules/database"
 
-    environment = "${var.environment}"
-    region = "${var.region}"
+  environment = var.environment
+  region      = var.region
 
-    vpc_id                  = "${module.vpc.vpc_id}"
-    vpc_public_subnet_ids   = "${module.vpc.vpc_public_subnet_ids}"
-    vpc_cidr                = "${module.vpc.vpc_cidr_block}"
-    local_machine_cidr      = "${var.local_machine_cidr}"
+  vpc_id                = module.vpc.vpc_id
+  vpc_public_subnet_ids = module.vpc.vpc_public_subnet_ids
+  vpc_cidr              = module.vpc.vpc_cidr_block
+  local_machine_cidr    = var.local_machine_cidr
 
-    mysql_database_name     = "photorecommender"
-    mysql_instance_type     = "db.m5.large"#"db.t2.micro" 
-    mysql_storage_encrypted = false # db.t2.micro doesn't support encryption at rest -- needs to be at least db.t2.small
-    mysql_storage_type      = "gp2" # General purpose SSD
-    mysql_database_size_gb  = 5
-    mysql_multi_az          = false # Disable database multi-AZ in dev to save billing charges
-    mysql_backup_retention_period_days = 3
-    mysql_deletion_protection = true
+  mysql_database_name                = "photorecommender"
+  mysql_instance_type                = "db.m5.large" #"db.t2.micro" 
+  mysql_storage_encrypted            = false         # db.t2.micro doesn't support encryption at rest -- needs to be at least db.t2.small
+  mysql_storage_type                 = "gp2"         # General purpose SSD
+  mysql_database_size_gb             = 5
+  mysql_multi_az                     = false # Disable database multi-AZ in dev to save billing charges
+  mysql_backup_retention_period_days = 3
+  mysql_deletion_protection          = true
 
-    mysql_database_password = "${var.database_password_prod}"
-    kms_key_arn             = "${module.encryption.kms_key_arn}"
+  mysql_database_password = var.database_password_prod
+  kms_key_arn             = module.encryption.kms_key_arn
 }
 
 module "memcached" {
-    source = "../modules/memcached"
+  source = "../modules/memcached"
 
-    # Note that some sensitive info can get stored here, such as temporary tokens during the flickr auth process.
-    # Thus, this instance isn't accessible publicly.
+  # Note that some sensitive info can get stored here, such as temporary tokens during the flickr auth process.
+  # Thus, this instance isn't accessible publicly.
 
-    environment = "${var.environment}"
-    region = "${var.region}"
+  environment = var.environment
+  region      = var.region
 
-    vpc_id                  = "${module.vpc.vpc_id}"
-    vpc_public_subnet_ids   = "${module.vpc.vpc_private_subnet_ids}"
-    vpc_cidr                = "${module.vpc.vpc_cidr_block}"
+  vpc_id                = module.vpc.vpc_id
+  vpc_public_subnet_ids = module.vpc.vpc_private_subnet_ids
+  vpc_cidr              = module.vpc.vpc_cidr_block
 
-    memcached_node_type = "cache.t2.micro"
-    memcached_num_cache_nodes = 1 # Set to 0 to disable memcached in dev to save billing charges
-    memcached_az_mode = "single-az" # Single az in dev to save billing charges
+  memcached_node_type       = "cache.t2.micro"
+  memcached_num_cache_nodes = 1           # Set to 0 to disable memcached in dev to save billing charges
+  memcached_az_mode         = "single-az" # Single az in dev to save billing charges
 }
 
 module "scheduler" {
-    source = "../modules/scheduler"
+  source = "../modules/scheduler"
 
-    environment = "${var.environment}"
-    region = "${var.region}"
-    metrics_namespace = "${var.metrics_namespace}"
+  environment       = var.environment
+  region            = var.region
+  metrics_namespace = var.metrics_namespace
 
-    parameter_memcached_location = "${module.memcached.location}"
+  parameter_memcached_location = module.memcached.location
 
-    ecs_cluster_id = "${module.elastic_container_service.cluster_id}"
-    ecs_instances_role_name = "${module.elastic_container_service.instance_role_name}"
-    ecs_instances_desired_count = 4
-    ecs_instances_memory = 64
-    ecs_instances_cpu = 200
-    ecs_instances_log_configuration = "${module.elastic_container_service.cluster_log_configuration}"
-    ecs_days_to_keep_images = 1#0
+  ecs_cluster_id                  = module.elastic_container_service.cluster_id
+  ecs_instances_role_name         = module.elastic_container_service.instance_role_name
+  ecs_instances_desired_count     = 4
+  ecs_instances_memory            = 64
+  ecs_instances_cpu               = 200
+  ecs_instances_log_configuration = module.elastic_container_service.cluster_log_configuration
+  ecs_days_to_keep_images         = 1 #0
 
-    api_server_host = "${module.api_server.load_balancer_dns_name}"
-    api_server_port = "${module.api_server.load_balancer_port}"
+  api_server_host = module.api_server.load_balancer_dns_name
+  api_server_port = module.api_server.load_balancer_port
 
-    scheduler_seconds_between_user_data_updates = 7200
+  scheduler_seconds_between_user_data_updates = 7200
 
-    puller_queue_batch_size = 10
+  puller_queue_batch_size = 10
 
-    ingester_database_queue_url = "${module.ingester_database.ingester_queue_url}"
-    ingester_database_queue_arn = "${module.ingester_database.ingester_queue_arn}"
+  ingester_database_queue_url = module.ingester_database.ingester_queue_url
+  ingester_database_queue_arn = module.ingester_database.ingester_queue_arn
 
-    puller_queue_long_polling_seconds = 10 # We can poll as long as we want, because nothing happens when we find no more new messages other than we restart
-    puller_response_queue_long_polling_seconds = 1 # Don't do long polling for too long: we can only write out our batches to the API server after we find no more new messages
+  puller_queue_long_polling_seconds          = 10 # We can poll as long as we want, because nothing happens when we find no more new messages other than we restart
+  puller_response_queue_long_polling_seconds = 1  # Don't do long polling for too long: we can only write out our batches to the API server after we find no more new messages
 
-    max_iterations_before_exit = 1000
-    sleep_ms_between_iterations = 500
+  max_iterations_before_exit  = 1000
+  sleep_ms_between_iterations = 500
 
-    duration_to_request_lock_seconds = 10
+  duration_to_request_lock_seconds = 10
 
-    process_name                = "scheduler"
-    project_github_location     = "${var.project_github_location}"
-    build_logs_bucket_id        = "${module.build-common-infrastructure.build_logs_bucket_id}"
-    buildspec_location          = "backend/buildspec.yml"
-    file_path                   = "backend/scheduler/*"
-    file_path_common            = "backend/common/*"
-    build_service_role_arn      = "${module.build-common-infrastructure.build_service_role_arn}"
+  process_name            = "scheduler"
+  project_github_location = var.project_github_location
+  build_logs_bucket_id    = module.build-common-infrastructure.build_logs_bucket_id
+  buildspec_location      = "backend/buildspec.yml"
+  file_path               = "backend/scheduler/*"
+  file_path_common        = "backend/common/*"
+  build_service_role_arn  = module.build-common-infrastructure.build_service_role_arn
 }
 
 module "puller-response-reader" {
-    source = "../modules/puller-response-reader"
+  source = "../modules/puller-response-reader"
 
-    environment = "${var.environment}"
-    region = "${var.region}"
-    metrics_namespace = "${var.metrics_namespace}"
+  environment       = var.environment
+  region            = var.region
+  metrics_namespace = var.metrics_namespace
 
-    parameter_memcached_location = "${module.memcached.location}"
+  parameter_memcached_location = module.memcached.location
 
-    ecs_cluster_id = "${module.elastic_container_service.cluster_id}"
-    ecs_instances_role_name = "${module.elastic_container_service.instance_role_name}"
-    ecs_instances_desired_count = 20
-    ecs_instances_memory = 64
-    ecs_instances_cpu = 200
-    ecs_instances_log_configuration = "${module.elastic_container_service.cluster_log_configuration}"
-    ecs_days_to_keep_images = 1
+  ecs_cluster_id                  = module.elastic_container_service.cluster_id
+  ecs_instances_role_name         = module.elastic_container_service.instance_role_name
+  ecs_instances_desired_count     = 20
+  ecs_instances_memory            = 64
+  ecs_instances_cpu               = 200
+  ecs_instances_log_configuration = module.elastic_container_service.cluster_log_configuration
+  ecs_days_to_keep_images         = 1
 
-    api_server_host = "${module.api_server.load_balancer_dns_name}"
-    api_server_port = "${module.api_server.load_balancer_port}"
+  api_server_host = module.api_server.load_balancer_dns_name
+  api_server_port = module.api_server.load_balancer_port
 
-    puller_queue_url = "${module.scheduler.puller_queue_url}"
-    puller_queue_arn = "${module.scheduler.puller_queue_arn}"
-    puller_response_queue_url = "${module.scheduler.puller_response_queue_url}"
-    puller_response_queue_arn = "${module.scheduler.puller_response_queue_arn}"
+  puller_queue_url          = module.scheduler.puller_queue_url
+  puller_queue_arn          = module.scheduler.puller_queue_arn
+  puller_response_queue_url = module.scheduler.puller_response_queue_url
+  puller_response_queue_arn = module.scheduler.puller_response_queue_arn
 
-    puller_queue_batch_size = 10
+  puller_queue_batch_size = 10
 
-    puller_response_queue_batch_size = 1 # Each message takes a while to process, so hoarding a bunch of messages in an individual instance means that other instances may be underutilized
-    puller_response_queue_max_items_to_process = 10000
+  puller_response_queue_batch_size           = 1 # Each message takes a while to process, so hoarding a bunch of messages in an individual instance means that other instances may be underutilized
+  puller_response_queue_max_items_to_process = 10000
 
-    process_name                = "puller-response-reader"
-    project_github_location     = "${var.project_github_location}"
-    build_logs_bucket_id        = "${module.build-common-infrastructure.build_logs_bucket_id}"
-    buildspec_location          = "backend/buildspec.yml"
-    file_path                   = "backend/puller-response-reader/*"
-    file_path_common            = "backend/common/*"
-    build_service_role_arn      = "${module.build-common-infrastructure.build_service_role_arn}"
+  process_name            = "puller-response-reader"
+  project_github_location = var.project_github_location
+  build_logs_bucket_id    = module.build-common-infrastructure.build_logs_bucket_id
+  buildspec_location      = "backend/buildspec.yml"
+  file_path               = "backend/puller-response-reader/*"
+  file_path_common        = "backend/common/*"
+  build_service_role_arn  = module.build-common-infrastructure.build_service_role_arn
 }
 
 module "ingester_response_reader" {
-    source = "../modules/ingester-response-reader"
+  source = "../modules/ingester-response-reader"
 
-    environment = "${var.environment}"
-    region = "${var.region}"
-    metrics_namespace = "${var.metrics_namespace}"
+  environment       = var.environment
+  region            = var.region
+  metrics_namespace = var.metrics_namespace
 
-    parameter_memcached_location = "${module.memcached.location}"
+  parameter_memcached_location = module.memcached.location
 
-    ecs_cluster_id = "${module.elastic_container_service.cluster_id}"
-    ecs_instances_role_name = "${module.elastic_container_service.instance_role_name}"
-    ecs_instances_desired_count = 20
-    ecs_instances_memory = 64
-    ecs_instances_cpu = 200
-    ecs_instances_log_configuration = "${module.elastic_container_service.cluster_log_configuration}"
-    ecs_days_to_keep_images = 1
+  ecs_cluster_id                  = module.elastic_container_service.cluster_id
+  ecs_instances_role_name         = module.elastic_container_service.instance_role_name
+  ecs_instances_desired_count     = 20
+  ecs_instances_memory            = 64
+  ecs_instances_cpu               = 200
+  ecs_instances_log_configuration = module.elastic_container_service.cluster_log_configuration
+  ecs_days_to_keep_images         = 1
 
-    api_server_host = "${module.api_server.load_balancer_dns_name}"
-    api_server_port = "${module.api_server.load_balancer_port}"
+  api_server_host = module.api_server.load_balancer_dns_name
+  api_server_port = module.api_server.load_balancer_port
 
-    ingester_response_queue_url = "${module.ingester_database.ingester_response_queue_url}"
-    ingester_response_queue_arn = "${module.ingester_database.ingester_response_queue_arn}"
+  ingester_response_queue_url = module.ingester_database.ingester_response_queue_url
+  ingester_response_queue_arn = module.ingester_database.ingester_response_queue_arn
 
-    ingester_response_queue_batch_size = 1 # Each message takes a while to process, so hoarding a bunch of messages in an individual instance means that other instances may be underutilized
-    ingester_response_queue_max_items_to_process = 10000
+  ingester_response_queue_batch_size           = 1 # Each message takes a while to process, so hoarding a bunch of messages in an individual instance means that other instances may be underutilized
+  ingester_response_queue_max_items_to_process = 10000
 
-    process_name                = "ingester-response-reader"
-    project_github_location     = "${var.project_github_location}"
-    build_logs_bucket_id        = "${module.build-common-infrastructure.build_logs_bucket_id}"
-    buildspec_location          = "backend/buildspec.yml"
-    file_path                   = "backend/ingester-response-reader/*"
-    file_path_common            = "backend/common/*"
-    build_service_role_arn      = "${module.build-common-infrastructure.build_service_role_arn}"
+  process_name            = "ingester-response-reader"
+  project_github_location = var.project_github_location
+  build_logs_bucket_id    = module.build-common-infrastructure.build_logs_bucket_id
+  buildspec_location      = "backend/buildspec.yml"
+  file_path               = "backend/ingester-response-reader/*"
+  file_path_common        = "backend/common/*"
+  build_service_role_arn  = module.build-common-infrastructure.build_service_role_arn
 }
 
 module "puller_flickr" {
-    source = "../modules/puller-flickr"
+  source = "../modules/puller-flickr"
 
-    environment = "${var.environment}"
-    region = "${var.region}"
-    metrics_namespace = "${var.metrics_namespace}"
+  environment       = var.environment
+  region            = var.region
+  metrics_namespace = var.metrics_namespace
 
-    parameter_memcached_location = "${module.memcached.location}"
-    kms_key_id              = "${module.encryption.kms_key_id}"
-    kms_key_arn             = "${module.encryption.kms_key_arn}"
+  parameter_memcached_location = module.memcached.location
+  kms_key_id                   = module.encryption.kms_key_id
+  kms_key_arn                  = module.encryption.kms_key_arn
 
-    memcached_location = "localhost:11211" # Disable cacheing Flickr API responses for now, so we can test performance
-    memcached_ttl = 7200
+  memcached_location = "localhost:11211" # Disable cacheing Flickr API responses for now, so we can test performance
+  memcached_ttl      = 7200
 
-    ecs_cluster_id = "${module.elastic_container_service.cluster_id}"
-    ecs_instances_role_name = "${module.elastic_container_service.instance_role_name}"
-    ecs_instances_desired_count = 150
-    ecs_instances_memory = 64
-    ecs_instances_cpu = 100
-    ecs_instances_log_configuration = "${module.elastic_container_service.cluster_log_configuration}"
-    ecs_days_to_keep_images = 1
+  ecs_cluster_id                  = module.elastic_container_service.cluster_id
+  ecs_instances_role_name         = module.elastic_container_service.instance_role_name
+  ecs_instances_desired_count     = 150
+  ecs_instances_memory            = 64
+  ecs_instances_cpu               = 100
+  ecs_instances_log_configuration = module.elastic_container_service.cluster_log_configuration
+  ecs_days_to_keep_images         = 1
 
-    flickr_api_key = "${var.flickr_api_key}"
-    flickr_secret_key = "${var.flickr_secret_key}"
-    flickr_api_retries = 3
-    flickr_api_favorites_max_per_call = 500
-    flickr_api_favorites_max_to_get = 1000
-    flickr_api_favorites_max_calls_to_make = 1
-    flickr_api_contacts_max_per_call = 1000
+  flickr_api_key                         = var.flickr_api_key
+  flickr_secret_key                      = var.flickr_secret_key
+  flickr_api_retries                     = 3
+  flickr_api_favorites_max_per_call      = 500
+  flickr_api_favorites_max_to_get        = 1000
+  flickr_api_favorites_max_calls_to_make = 1
+  flickr_api_contacts_max_per_call       = 1000
 
-    output_queue_url = "${module.ingester_database.ingester_queue_url}"
-    output_queue_arn = "${module.ingester_database.ingester_queue_arn}"
-    output_queue_batch_size = 10
+  output_queue_url        = module.ingester_database.ingester_queue_url
+  output_queue_arn        = module.ingester_database.ingester_queue_arn
+  output_queue_batch_size = 10
 
-    puller_queue_url = "${module.scheduler.puller_queue_url}"
-    puller_queue_arn = "${module.scheduler.puller_queue_arn}"
-    puller_queue_batch_size = 1 # Each message takes a while to process, so hoarding a bunch of messages in an individual instance means that other instances may be underutilized
-    puller_queue_max_items_to_process = 1000
+  puller_queue_url                  = module.scheduler.puller_queue_url
+  puller_queue_arn                  = module.scheduler.puller_queue_arn
+  puller_queue_batch_size           = 1 # Each message takes a while to process, so hoarding a bunch of messages in an individual instance means that other instances may be underutilized
+  puller_queue_max_items_to_process = 1000
 
-    puller_response_queue_url = "${module.scheduler.puller_response_queue_url}"
-    puller_response_queue_arn = "${module.scheduler.puller_response_queue_arn}"
-    puller_response_queue_batch_size = 10
+  puller_response_queue_url        = module.scheduler.puller_response_queue_url
+  puller_response_queue_arn        = module.scheduler.puller_response_queue_arn
+  puller_response_queue_batch_size = 10
 
-    process_name                = "puller-flickr"
-    project_github_location     = "${var.project_github_location}"
-    build_logs_bucket_id        = "${module.build-common-infrastructure.build_logs_bucket_id}"
-    buildspec_location          = "backend/buildspec.yml"
-    file_path                   = "backend/puller-flickr/*"
-    file_path_common            = "backend/common/*"
-    build_service_role_arn      = "${module.build-common-infrastructure.build_service_role_arn}"
+  process_name            = "puller-flickr"
+  project_github_location = var.project_github_location
+  build_logs_bucket_id    = module.build-common-infrastructure.build_logs_bucket_id
+  buildspec_location      = "backend/buildspec.yml"
+  file_path               = "backend/puller-flickr/*"
+  file_path_common        = "backend/common/*"
+  build_service_role_arn  = module.build-common-infrastructure.build_service_role_arn
 }
 
 module "ingester_database" {
-    source = "../modules/ingester-database"
+  source = "../modules/ingester-database"
 
-    environment             = "${var.environment}"
-    region                  = "${var.region}"
-    metrics_namespace       = "${var.metrics_namespace}"
+  environment       = var.environment
+  region            = var.region
+  metrics_namespace = var.metrics_namespace
 
-    parameter_memcached_location = "${module.memcached.location}"
-    kms_key_id              = "${module.encryption.kms_key_id}"
-    kms_key_arn             = "${module.encryption.kms_key_arn}"
+  parameter_memcached_location = module.memcached.location
+  kms_key_id                   = module.encryption.kms_key_id
+  kms_key_arn                  = module.encryption.kms_key_arn
 
-    ecs_cluster_id          = "${module.elastic_container_service.cluster_id}"
-    ecs_instances_role_name = "${module.elastic_container_service.instance_role_name}"
-    ecs_instances_desired_count = 100
-    ecs_instances_memory    = 64
-    ecs_instances_cpu       = 100
-    ecs_instances_log_configuration = "${module.elastic_container_service.cluster_log_configuration}"
-    ecs_days_to_keep_images = 1
+  ecs_cluster_id                  = module.elastic_container_service.cluster_id
+  ecs_instances_role_name         = module.elastic_container_service.instance_role_name
+  ecs_instances_desired_count     = 100
+  ecs_instances_memory            = 64
+  ecs_instances_cpu               = 100
+  ecs_instances_log_configuration = module.elastic_container_service.cluster_log_configuration
+  ecs_days_to_keep_images         = 1
 
-    mysql_database_host     = "${module.database.database_host}"
-    mysql_database_port     = "${module.database.database_port}"
-    mysql_database_username = "${module.database.database_username}"
-    mysql_database_password = "${var.database_password_prod}"
-    mysql_database_name     = "${module.database.database_name}"
-    mysql_database_min_batch_size = 100 # Counter-intuitively, the best overall system performance is gained by batching these the least. It's so that the process can flush as quickly as possible rather than storing up and flushing while everything else is waiting around
-    mysql_database_maxretries = 3
+  mysql_database_host           = module.database.database_host
+  mysql_database_port           = module.database.database_port
+  mysql_database_username       = module.database.database_username
+  mysql_database_password       = var.database_password_prod
+  mysql_database_name           = module.database.database_name
+  mysql_database_min_batch_size = 100 # Counter-intuitively, the best overall system performance is gained by batching these the least. It's so that the process can flush as quickly as possible rather than storing up and flushing while everything else is waiting around
+  mysql_database_maxretries     = 3
 
-    input_queue_batch_size  = 1 # Each message takes a while to process because it contains many individual items, so only get one at a time so that we're not blocking other instances from picking them up
-    input_queue_max_items_to_process = 10000
-    input_queue_long_polling_seconds = 1 # Don't do long polling for too long: we can only commit after we find no more new messages
+  input_queue_batch_size           = 1 # Each message takes a while to process because it contains many individual items, so only get one at a time so that we're not blocking other instances from picking them up
+  input_queue_max_items_to_process = 10000
+  input_queue_long_polling_seconds = 1 # Don't do long polling for too long: we can only commit after we find no more new messages
 
-    output_queue_long_polling_seconds = 1 # Don't do long polling for too long: the ingester response reader can only write to the API server after finding no more new messages
-    output_queue_batch_size = 10
+  output_queue_long_polling_seconds = 1 # Don't do long polling for too long: the ingester response reader can only write to the API server after finding no more new messages
+  output_queue_batch_size           = 10
 
-    process_name                = "ingester-database"
-    project_github_location     = "${var.project_github_location}"
-    build_logs_bucket_id        = "${module.build-common-infrastructure.build_logs_bucket_id}"
-    buildspec_location          = "backend/buildspec.yml"
-    file_path                   = "backend/ingester-database/*"
-    file_path_common            = "backend/common/*"
-    build_service_role_arn      = "${module.build-common-infrastructure.build_service_role_arn}"
+  process_name            = "ingester-database"
+  project_github_location = var.project_github_location
+  build_logs_bucket_id    = module.build-common-infrastructure.build_logs_bucket_id
+  buildspec_location      = "backend/buildspec.yml"
+  file_path               = "backend/ingester-database/*"
+  file_path_common        = "backend/common/*"
+  build_service_role_arn  = module.build-common-infrastructure.build_service_role_arn
 }
 
 module "api_server" {
-    source = "../modules/api-server"
+  source = "../modules/api-server"
 
-    environment             = "${var.environment}"
-    region                  = "${var.region}"
-    metrics_namespace       = "${var.metrics_namespace}"
+  environment       = var.environment
+  region            = var.region
+  metrics_namespace = var.metrics_namespace
 
-    parameter_memcached_location = "${module.memcached.location}"
-    kms_key_id              = "${module.encryption.kms_key_id}"
-    kms_key_arn             = "${module.encryption.kms_key_arn}"
+  parameter_memcached_location = module.memcached.location
+  kms_key_id                   = module.encryption.kms_key_id
+  kms_key_arn                  = module.encryption.kms_key_arn
 
-    vpc_id                  = "${module.vpc.vpc_id}"
-    vpc_public_subnet_ids   = "${module.vpc.vpc_public_subnet_ids}"
-    vpc_cidr                = "${module.vpc.vpc_cidr_block}"
+  vpc_id                = module.vpc.vpc_id
+  vpc_public_subnet_ids = module.vpc.vpc_public_subnet_ids
+  vpc_cidr              = module.vpc.vpc_cidr_block
 
-    load_balancer_port      = 4444
-    api_server_port         = 4445
+  load_balancer_port = 4444
+  api_server_port    = 4445
 
-    session_encryption_key     = "${var.api_server_session_encryption_key_prod}"
+  session_encryption_key = var.api_server_session_encryption_key_prod
 
-    flickr_api_key = "${var.flickr_api_key}"
-    flickr_secret_key = "${var.flickr_secret_key}"
-    flickr_api_retries = 3
-    flickr_api_memcached_location = "localhost:11211" # Disable cacheing Flickr API responses for now
-    flickr_api_memcached_ttl = 7200
-    flickr_auth_memcached_location = "${module.memcached.location}"
+  flickr_api_key                 = var.flickr_api_key
+  flickr_secret_key              = var.flickr_secret_key
+  flickr_api_retries             = 3
+  flickr_api_memcached_location  = "localhost:11211" # Disable cacheing Flickr API responses for now
+  flickr_api_memcached_ttl       = 7200
+  flickr_auth_memcached_location = module.memcached.location
 
-    retain_load_balancer_access_logs_after_destroy = "false" # For dev, we don't care about retaining these logs after doing a terraform destroy
-    load_balancer_days_to_keep_access_logs = 30
-    load_balancer_access_logs_bucket = "load-balancer-access-logs"
-    load_balancer_access_logs_prefix = "api-server-lb"
-    bucketname_user_string  = "${var.bucketname_user_string}"
+  retain_load_balancer_access_logs_after_destroy = "false" # For dev, we don't care about retaining these logs after doing a terraform destroy
+  load_balancer_days_to_keep_access_logs         = 30
+  load_balancer_access_logs_bucket               = "load-balancer-access-logs"
+  load_balancer_access_logs_prefix               = "api-server-lb"
+  bucketname_user_string                         = var.bucketname_user_string
 
-    local_machine_cidr      = "${var.local_machine_cidr}"
+  local_machine_cidr = var.local_machine_cidr
 
-    mysql_database_host     = "${module.database.database_host}"
-    mysql_database_port     = "${module.database.database_port}"
-    mysql_database_username = "${module.database.database_username}"
-    mysql_database_password = "${var.database_password_prod}"
-    mysql_database_name     = "${module.database.database_name}"
-    mysql_database_fetch_batch_size = 10000
-    mysql_database_connection_pool_size = 20
-    mysql_database_user_data_encryption_key = "${var.database_user_data_encryption_key_prod}"
+  mysql_database_host                     = module.database.database_host
+  mysql_database_port                     = module.database.database_port
+  mysql_database_username                 = module.database.database_username
+  mysql_database_password                 = var.database_password_prod
+  mysql_database_name                     = module.database.database_name
+  mysql_database_fetch_batch_size         = 10000
+  mysql_database_connection_pool_size     = 20
+  mysql_database_user_data_encryption_key = var.database_user_data_encryption_key_prod
 
-    puller_queue_url = "${module.scheduler.puller_queue_url}"
-    puller_queue_arn = "${module.scheduler.puller_queue_arn}"
-    puller_queue_batch_size = 1 # We're always going to make requests one at a time as users add their favorites
+  puller_queue_url        = module.scheduler.puller_queue_url
+  puller_queue_arn        = module.scheduler.puller_queue_arn
+  puller_queue_batch_size = 1 # We're always going to make requests one at a time as users add their favorites
 
-    ecs_cluster_id          = "${module.elastic_container_service.cluster_id}"
-    ecs_instances_role_name = "${module.elastic_container_service.instance_role_name}"
-    ecs_instances_desired_count = 15
-    ecs_instances_memory    = 256
-    ecs_instances_cpu       = 100
-    ecs_instances_log_configuration = "${module.elastic_container_service.cluster_log_configuration}"
-    ecs_days_to_keep_images = 1
+  ecs_cluster_id                  = module.elastic_container_service.cluster_id
+  ecs_instances_role_name         = module.elastic_container_service.instance_role_name
+  ecs_instances_desired_count     = 15
+  ecs_instances_memory            = 256
+  ecs_instances_cpu               = 100
+  ecs_instances_log_configuration = module.elastic_container_service.cluster_log_configuration
+  ecs_days_to_keep_images         = 1
 
-    default_num_photo_recommendations = 10
-    default_num_user_recommendations = 5
-    default_num_photos_from_group = 20
+  default_num_photo_recommendations = 10
+  default_num_user_recommendations  = 5
+  default_num_photos_from_group     = 20
 
-    process_name                = "api-server"
-    project_github_location     = "${var.project_github_location}"
-    build_logs_bucket_id        = "${module.build-common-infrastructure.build_logs_bucket_id}"
-    buildspec_location          = "backend/buildspec.yml"
-    file_path                   = "backend/api-server/*"
-    file_path_common            = "backend/common/*"
-    build_service_role_arn      = "${module.build-common-infrastructure.build_service_role_arn}"
+  process_name            = "api-server"
+  project_github_location = var.project_github_location
+  build_logs_bucket_id    = module.build-common-infrastructure.build_logs_bucket_id
+  buildspec_location      = "backend/buildspec.yml"
+  file_path               = "backend/api-server/*"
+  file_path_common        = "backend/common/*"
+  build_service_role_arn  = module.build-common-infrastructure.build_service_role_arn
 }
 
 module "frontend" {
-    source = "../modules/frontend"
+  source = "../modules/frontend"
 
-    environment             = "${var.environment}"
-    environment_long_name   = "${var.environment_long_name}"
-    region                  = "${var.region}"
+  environment           = var.environment
+  environment_long_name = var.environment_long_name
+  region                = var.region
 
-    bucketname_user_string  = "${var.bucketname_user_string}"
+  bucketname_user_string = var.bucketname_user_string
 
-    application_domain      = "${var.dns_address}"
-    application_name        = "photo-recommender"
+  application_domain = var.dns_address
+  application_name   = "photo-recommender"
 
-    days_to_keep_old_versions = 1
+  days_to_keep_old_versions = 1
 
-    load_balancer_arn       = "${module.api_server.load_balancer_arn}"
-    load_balancer_dns_name  = "${module.api_server.load_balancer_dns_name}"
-    load_balancer_port      = "${module.api_server.load_balancer_port}"
-    load_balancer_zone_id   = "${module.api_server.load_balancer_zone_id}"
+  load_balancer_arn      = module.api_server.load_balancer_arn
+  load_balancer_dns_name = module.api_server.load_balancer_dns_name
+  load_balancer_port     = module.api_server.load_balancer_port
+  load_balancer_zone_id  = module.api_server.load_balancer_zone_id
 
-    frontend_access_logs_bucket = "frontend-access-logs"
-    retain_frontend_access_logs_after_destroy = "false" # For dev, we don't care about retaining these logs after doing a terraform destroy
-    days_to_keep_frontend_access_logs = 30
+  frontend_access_logs_bucket               = "frontend-access-logs"
+  retain_frontend_access_logs_after_destroy = "false" # For dev, we don't care about retaining these logs after doing a terraform destroy
+  days_to_keep_frontend_access_logs         = 30
 
-    use_custom_domain           = "true"
-    ssl_certificate_body        = "${var.ssl_certificate_body}"
-    ssl_certificate_private_key = "${var.ssl_certificate_private_key}"
-    ssl_certificate_chain       = "${var.ssl_certificate_chain}"
+  use_custom_domain           = "true"
+  ssl_certificate_body        = var.ssl_certificate_body
+  ssl_certificate_private_key = var.ssl_certificate_private_key
+  ssl_certificate_chain       = var.ssl_certificate_chain
 
-    project_github_location     = "${var.project_github_location}"
-    build_logs_bucket_id        = "${module.build-common-infrastructure.build_logs_bucket_id}"
-    buildspec_location          = "frontend/buildspec.yml"
-    file_path                   = "frontend/*"
-    build_service_role_arn      = "${module.build-common-infrastructure.build_service_role_arn}"
+  project_github_location = var.project_github_location
+  build_logs_bucket_id    = module.build-common-infrastructure.build_logs_bucket_id
+  buildspec_location      = "frontend/buildspec.yml"
+  file_path               = "frontend/*"
+  build_service_role_arn  = module.build-common-infrastructure.build_service_role_arn
 }
 
 module "dashboard" {
-    source = "../modules/dashboard"
+  source = "../modules/dashboard"
 
-    environment = "${var.environment}"
-    region      = "${var.region}"
-    metrics_namespace = "${var.metrics_namespace}"
+  environment       = var.environment
+  region            = var.region
+  metrics_namespace = var.metrics_namespace
 
-    puller_queue_base_name               = "${module.scheduler.puller_queue_base_name}"
-    puller_queue_full_name               = "${module.scheduler.puller_queue_full_name}"
-    puller_queue_dead_letter_full_name   = "${module.scheduler.puller_queue_dead_letter_full_name}"
+  puller_queue_base_name             = module.scheduler.puller_queue_base_name
+  puller_queue_full_name             = module.scheduler.puller_queue_full_name
+  puller_queue_dead_letter_full_name = module.scheduler.puller_queue_dead_letter_full_name
 
-    puller_response_queue_base_name              = "${module.scheduler.puller_response_queue_base_name}"
-    puller_response_queue_full_name              = "${module.scheduler.puller_response_queue_full_name}"
-    puller_response_queue_dead_letter_full_name  = "${module.scheduler.puller_response_queue_dead_letter_full_name}"
+  puller_response_queue_base_name             = module.scheduler.puller_response_queue_base_name
+  puller_response_queue_full_name             = module.scheduler.puller_response_queue_full_name
+  puller_response_queue_dead_letter_full_name = module.scheduler.puller_response_queue_dead_letter_full_name
 
-    ingester_queue_base_name                = "${module.ingester_database.ingester_queue_base_name}"
-    ingester_queue_full_name                = "${module.ingester_database.ingester_queue_full_name}"
-    ingester_queue_dead_letter_full_name    = "${module.ingester_database.ingester_queue_dead_letter_full_name}"
+  ingester_queue_base_name             = module.ingester_database.ingester_queue_base_name
+  ingester_queue_full_name             = module.ingester_database.ingester_queue_full_name
+  ingester_queue_dead_letter_full_name = module.ingester_database.ingester_queue_dead_letter_full_name
 
-    ingester_response_queue_base_name                = "${module.ingester_database.ingester_response_queue_base_name}"
-    ingester_response_queue_full_name                = "${module.ingester_database.ingester_response_queue_full_name}"
-    ingester_response_queue_dead_letter_full_name    = "${module.ingester_database.ingester_response_queue_dead_letter_full_name}"
+  ingester_response_queue_base_name             = module.ingester_database.ingester_response_queue_base_name
+  ingester_response_queue_full_name             = module.ingester_database.ingester_response_queue_full_name
+  ingester_response_queue_dead_letter_full_name = module.ingester_database.ingester_response_queue_dead_letter_full_name
 
-    database_identifier                     = "${module.database.database_instance_identifier}"
+  database_identifier = module.database.database_instance_identifier
 
-    ecs_autoscaling_group_name              = "${module.elastic_container_service.autoscaling_group_name}"
-    ecs_cluster_name                        = "${module.elastic_container_service.cluster_full_name}"
+  ecs_autoscaling_group_name = module.elastic_container_service.autoscaling_group_name
+  ecs_cluster_name           = module.elastic_container_service.cluster_full_name
 }
 
 module "alarms" {
-    source = "../modules/alarms"
+  source = "../modules/alarms"
 
-    environment     = "${var.environment}"
-    region          = "${var.region}"
+  environment = var.environment
+  region      = var.region
 
-    enable_alarms   = "true"
+  enable_alarms = "true"
 
-    metrics_namespace = "${var.metrics_namespace}"
-    topic_name      = "photo-recommender"
-    alarms_email    = "${var.alarms_email}"
+  metrics_namespace = var.metrics_namespace
+  topic_name        = "photo-recommender"
+  alarms_email      = var.alarms_email
 
-    unhandled_exceptions_threshold = 1
+  unhandled_exceptions_threshold = 1
 
-    queue_names = [ "${module.scheduler.puller_queue_full_name}", "${module.scheduler.puller_response_queue_full_name}", "${module.ingester_database.ingester_queue_full_name}", "${module.ingester_database.ingester_response_queue_full_name}"]
-    queue_item_size_threshold = 235520 # 230kB -- 256kB is the absolute max
-    queue_item_age_threshold = 900 # 15 minutes: it can take a long time to process stuff in dev, with a limited numbers of workers
-    queue_reader_error_threshold = 1
-    queue_writer_error_threshold = 1
+  queue_names                  = [module.scheduler.puller_queue_full_name, module.scheduler.puller_response_queue_full_name, module.ingester_database.ingester_queue_full_name, module.ingester_database.ingester_response_queue_full_name]
+  queue_item_size_threshold    = 235520 # 230kB -- 256kB is the absolute max
+  queue_item_age_threshold     = 900    # 15 minutes: it can take a long time to process stuff in dev, with a limited numbers of workers
+  queue_reader_error_threshold = 1
+  queue_writer_error_threshold = 1
 
-    dead_letter_queue_names = [ "${module.scheduler.puller_queue_dead_letter_full_name}", "${module.scheduler.puller_response_queue_dead_letter_full_name}", "${module.ingester_database.ingester_queue_dead_letter_full_name}", "${module.ingester_database.ingester_response_queue_dead_letter_full_name}"]
-    dead_letter_queue_items_threshold = 1
+  dead_letter_queue_names           = [module.scheduler.puller_queue_dead_letter_full_name, module.scheduler.puller_response_queue_dead_letter_full_name, module.ingester_database.ingester_queue_dead_letter_full_name, module.ingester_database.ingester_response_queue_dead_letter_full_name]
+  dead_letter_queue_items_threshold = 1
 
-    users_store_exception_threshold = 1
+  users_store_exception_threshold = 1
 
-    api_server_favorites_store_exception_threshold = 1
-    api_server_generic_exception_threshold = 1
-    
-    ingester_database_batch_writer_exception_threshold = 1
-    
-    puller_flickr_max_batch_size_exceeded_error_threshold = 1
-    puller_flickr_max_neighbors_exceeded_error_threshold = 1
-    puller_flickr_max_flickr_api_exceptions_threshold = 1
+  api_server_favorites_store_exception_threshold = 1
+  api_server_generic_exception_threshold         = 1
+
+  ingester_database_batch_writer_exception_threshold = 1
+
+  puller_flickr_max_batch_size_exceeded_error_threshold = 1
+  puller_flickr_max_neighbors_exceeded_error_threshold  = 1
+  puller_flickr_max_flickr_api_exceptions_threshold     = 1
 }
+

--- a/terraform/prod/provider.tf
+++ b/terraform/prod/provider.tf
@@ -1,4 +1,5 @@
 provider "aws" {
-    shared_credentials_file = "../aws_credentials"
-    region = "${var.region}"
+  shared_credentials_file = "../aws_credentials"
+  region                  = var.region
 }
+

--- a/terraform/prod/variables.tf
+++ b/terraform/prod/variables.tf
@@ -1,18 +1,58 @@
-variable "region" { default = "us-west-2" }
-variable "environment" { default = "prod" }
-variable "environment_long_name" { default = "production" }
-variable "alarms_email" {}
-variable "metrics_namespace" { default = "Photo Recommender" }
-variable "local_machine_cidr" {}
-variable "local_machine_public_key" {}
-variable "flickr_api_key" {}
-variable "flickr_secret_key" {}
-variable "database_password_prod" {}
-variable "dns_address" {}
-variable "bucketname_user_string" {}
-variable "database_user_data_encryption_key_prod" {}
-variable "api_server_session_encryption_key_prod" {}
-variable "ssl_certificate_body" {}
-variable "ssl_certificate_private_key" {}
-variable "ssl_certificate_chain" {}
-variable "project_github_location" {}
+variable "region" {
+  default = "us-west-2"
+}
+
+variable "environment" {
+  default = "prod"
+}
+
+variable "environment_long_name" {
+  default = "production"
+}
+
+variable "alarms_email" {
+}
+
+variable "metrics_namespace" {
+  default = "Photo Recommender"
+}
+
+variable "local_machine_cidr" {
+}
+
+variable "local_machine_public_key" {
+}
+
+variable "flickr_api_key" {
+}
+
+variable "flickr_secret_key" {
+}
+
+variable "database_password_prod" {
+}
+
+variable "dns_address" {
+}
+
+variable "bucketname_user_string" {
+}
+
+variable "database_user_data_encryption_key_prod" {
+}
+
+variable "api_server_session_encryption_key_prod" {
+}
+
+variable "ssl_certificate_body" {
+}
+
+variable "ssl_certificate_private_key" {
+}
+
+variable "ssl_certificate_chain" {
+}
+
+variable "project_github_location" {
+}
+

--- a/terraform/prod/variables.tf
+++ b/terraform/prod/variables.tf
@@ -29,6 +29,9 @@ variable "flickr_api_key" {
 variable "flickr_secret_key" {
 }
 
+variable "database_password_dev" {
+}
+
 variable "database_password_prod" {
 }
 
@@ -36,6 +39,12 @@ variable "dns_address" {
 }
 
 variable "bucketname_user_string" {
+}
+
+variable "database_user_data_encryption_key_dev" {
+}
+
+variable "api_server_session_encryption_key_dev" {
 }
 
 variable "database_user_data_encryption_key_prod" {

--- a/terraform/prod/versions.tf
+++ b/terraform/prod/versions.tf
@@ -1,0 +1,4 @@
+
+terraform {
+  required_version = ">= 0.12"
+}


### PR DESCRIPTION
Now uses terraform 0.12.26

- Ran the upgrade tool `terraform 0.12upgrade`
- Fixed errors when running `terraform plan`
- Fixed errors when running `terraform apply`
- Renamed buckets due to collision with someone else's
- Added public access blocking for build logs bucket