### PR TITLE
terraform 0.12 cleanup

### DIFF
--- a/terraform/dev/main.tf
+++ b/terraform/dev/main.tf
@@ -35,7 +35,7 @@ module "build-common-infrastructure" {
 
   build_logs_bucket               = "photo-recommender-build-logs"
   bucketname_user_string          = var.bucketname_user_string
-  retain_build_logs_after_destroy = "false" # For dev, we don't care about retaining these logs after doing a terraform destroy
+  retain_build_logs_after_destroy = false # For dev, we don't care about retaining these logs after doing a terraform destroy
   days_to_keep_build_logs         = 1
 }
 
@@ -343,7 +343,7 @@ module "api_server" {
   flickr_api_memcached_ttl       = 7200
   flickr_auth_memcached_location = module.memcached.location
 
-  retain_load_balancer_access_logs_after_destroy = "false" # For dev, we don't care about retaining these logs after doing a terraform destroy
+  retain_load_balancer_access_logs_after_destroy = false # For dev, we don't care about retaining these logs after doing a terraform destroy
   load_balancer_days_to_keep_access_logs         = 1
   load_balancer_access_logs_bucket               = "photo-recommender-load-balancer-access-logs"
   load_balancer_access_logs_prefix               = "api-server-lb"
@@ -405,10 +405,10 @@ module "frontend" {
   load_balancer_zone_id  = module.api_server.load_balancer_zone_id
 
   frontend_access_logs_bucket               = "photo-recommender-frontend-access-logs"
-  retain_frontend_access_logs_after_destroy = "false" # For dev, we don't care about retaining these logs after doing a terraform destroy
+  retain_frontend_access_logs_after_destroy = false # For dev, we don't care about retaining these logs after doing a terraform destroy
   days_to_keep_frontend_access_logs         = 1
 
-  use_custom_domain           = "false"
+  use_custom_domain           = false
   ssl_certificate_body        = var.ssl_certificate_body
   ssl_certificate_private_key = var.ssl_certificate_private_key
   ssl_certificate_chain       = var.ssl_certificate_chain
@@ -455,7 +455,7 @@ module "alarms" {
   environment = var.environment
   region      = var.region
 
-  enable_alarms = "true"
+  enable_alarms = true
 
   metrics_namespace = var.metrics_namespace
   topic_name        = "photo-recommender"

--- a/terraform/dev/main.tf
+++ b/terraform/dev/main.tf
@@ -1,7 +1,7 @@
 module "vpc" {
   source = "../modules/vpc"
 
-  vpc_name    = "photo-recommender"
+  vpc_name    = var.application_name
   environment = var.environment
 
   cidr_block = "10.10.0.0/16"
@@ -33,7 +33,7 @@ module "build-common-infrastructure" {
   project_github_location  = var.project_github_location
   s3_deployment_bucket_arn = module.frontend.s3_deployment_bucket_arn
 
-  build_logs_bucket               = "photo-recommender-build-logs"
+  build_logs_bucket               = "${var.application_name}-build-logs"
   bucketname_user_string          = var.bucketname_user_string
   retain_build_logs_after_destroy = false # For dev, we don't care about retaining these logs after doing a terraform destroy
   days_to_keep_build_logs         = 1
@@ -44,7 +44,7 @@ module "elastic_container_service" {
 
   environment  = var.environment
   region       = var.region
-  cluster_name = "photo-recommender"
+  cluster_name = var.application_name
 
   vpc_id                = module.vpc.vpc_id
   vpc_public_subnet_ids = module.vpc.vpc_public_subnet_ids
@@ -72,7 +72,7 @@ module "database" {
   vpc_cidr              = module.vpc.vpc_cidr_block
   local_machine_cidr    = var.local_machine_cidr
 
-  mysql_database_name                = "photorecommender"
+  mysql_database_name                = var.application_name_no_hyphens
   mysql_instance_type                = "db.t2.micro" #"db.m5.large"#"db.t2.micro" 
   mysql_storage_encrypted            = false         # db.t2.micro doesn't support encryption at rest -- needs to be at least db.t2.small
   mysql_storage_type                 = "gp2"         # General purpose SSD
@@ -345,7 +345,7 @@ module "api_server" {
 
   retain_load_balancer_access_logs_after_destroy = false # For dev, we don't care about retaining these logs after doing a terraform destroy
   load_balancer_days_to_keep_access_logs         = 1
-  load_balancer_access_logs_bucket               = "photo-recommender-load-balancer-access-logs"
+  load_balancer_access_logs_bucket               = "${var.application_name}-load-balancer-access-logs"
   load_balancer_access_logs_prefix               = "api-server-lb"
   bucketname_user_string                         = var.bucketname_user_string
 
@@ -395,7 +395,7 @@ module "frontend" {
   bucketname_user_string = var.bucketname_user_string
 
   application_domain = "dev.${var.dns_address}"
-  application_name   = "photo-recommender"
+  application_name   = var.application_name
 
   days_to_keep_old_versions = 1
 
@@ -404,7 +404,7 @@ module "frontend" {
   load_balancer_port     = module.api_server.load_balancer_port
   load_balancer_zone_id  = module.api_server.load_balancer_zone_id
 
-  frontend_access_logs_bucket               = "photo-recommender-frontend-access-logs"
+  frontend_access_logs_bucket               = "${var.application_name}-frontend-access-logs"
   retain_frontend_access_logs_after_destroy = false # For dev, we don't care about retaining these logs after doing a terraform destroy
   days_to_keep_frontend_access_logs         = 1
 
@@ -458,7 +458,7 @@ module "alarms" {
   enable_alarms = true
 
   metrics_namespace = var.metrics_namespace
-  topic_name        = "photo-recommender"
+  topic_name        = var.application_name
   alarms_email      = var.alarms_email
 
   unhandled_exceptions_threshold = 1

--- a/terraform/dev/variables.tf
+++ b/terraform/dev/variables.tf
@@ -13,6 +13,14 @@ variable "environment_long_name" {
 variable "alarms_email" {
 }
 
+variable "application_name" {
+  default = "photo-recommender"
+}
+
+variable "application_name_no_hyphens" {
+  default = "photorecommender"
+}
+
 variable "metrics_namespace" {
   default = "Photo Recommender"
 }

--- a/terraform/modules/alarms/exceptions.tf
+++ b/terraform/modules/alarms/exceptions.tf
@@ -1,5 +1,5 @@
 resource "aws_cloudwatch_metric_alarm" "unhandled_exceptions" {
-  count = var.enable_alarms == "true" ? length(var.process_names) : 0 # Don't create this if we turn off alarms (e.g. for dev)
+  count = var.enable_alarms ? length(var.process_names) : 0 # Don't create this if we turn off alarms (e.g. for dev)
 
   alarm_name                = "Unhandled exceptions in ${element(var.process_names, count.index)} ${var.environment}" # Need to have a different name for each one, or else we only see one in the UI
   comparison_operator       = "GreaterThanOrEqualToThreshold"
@@ -22,7 +22,7 @@ resource "aws_cloudwatch_metric_alarm" "unhandled_exceptions" {
 }
 
 resource "aws_cloudwatch_metric_alarm" "queue_reader_error" {
-  count = var.enable_alarms == "true" ? length(var.process_names_that_read_from_queues) : 0 # Don't create this if we turn off alarms (e.g. for dev)
+  count = var.enable_alarms ? length(var.process_names_that_read_from_queues) : 0 # Don't create this if we turn off alarms (e.g. for dev)
 
   alarm_name                = "QueueReaderError in ${element(var.process_names_that_read_from_queues, count.index)} ${var.environment}" # Need to have a different name for each one, or else we only see one in the UI
   comparison_operator       = "GreaterThanOrEqualToThreshold"
@@ -45,7 +45,7 @@ resource "aws_cloudwatch_metric_alarm" "queue_reader_error" {
 }
 
 resource "aws_cloudwatch_metric_alarm" "queue_writer_error" {
-  count = var.enable_alarms == "true" ? length(var.process_names_that_write_to_queues) : 0 # Don't create this if we turn off alarms (e.g. for dev)
+  count = var.enable_alarms ? length(var.process_names_that_write_to_queues) : 0 # Don't create this if we turn off alarms (e.g. for dev)
 
   alarm_name                = "QueueWriterError in ${element(var.process_names_that_write_to_queues, count.index)} ${var.environment}" # Need to have a different name for each one, or else we only see one in the UI
   comparison_operator       = "GreaterThanOrEqualToThreshold"
@@ -68,7 +68,7 @@ resource "aws_cloudwatch_metric_alarm" "queue_writer_error" {
 }
 
 resource "aws_cloudwatch_metric_alarm" "users_store_exception" {
-  count = var.enable_alarms == "true" ? length(var.process_names_that_use_api_server) : 0 # Don't create this if we turn off alarms (e.g. for dev)
+  count = var.enable_alarms ? length(var.process_names_that_use_api_server) : 0 # Don't create this if we turn off alarms (e.g. for dev)
 
   alarm_name                = "UsersStoreException in ${element(var.process_names_that_use_api_server, count.index)} ${var.environment}" # Need to have a different name for each one, or else we only see one in the UI
   comparison_operator       = "GreaterThanOrEqualToThreshold"
@@ -91,7 +91,7 @@ resource "aws_cloudwatch_metric_alarm" "users_store_exception" {
 }
 
 resource "aws_cloudwatch_metric_alarm" "favorites_store_exception" {
-  count = var.enable_alarms == "true" ? 1 : 0 # Don't create this if we turn off alarms (e.g. for dev)
+  count = var.enable_alarms ? 1 : 0 # Don't create this if we turn off alarms (e.g. for dev)
 
   alarm_name                = "API server encountered FavoritesStoreException ${var.environment}"
   comparison_operator       = "GreaterThanOrEqualToThreshold"
@@ -114,7 +114,7 @@ resource "aws_cloudwatch_metric_alarm" "favorites_store_exception" {
 }
 
 resource "aws_cloudwatch_metric_alarm" "api_server_exception" {
-  count = var.enable_alarms == "true" ? 1 : 0 # Don't create this if we turn off alarms (e.g. for dev)
+  count = var.enable_alarms ? 1 : 0 # Don't create this if we turn off alarms (e.g. for dev)
 
   alarm_name                = "API server encountered a generic Exception ${var.environment}"
   comparison_operator       = "GreaterThanOrEqualToThreshold"
@@ -137,7 +137,7 @@ resource "aws_cloudwatch_metric_alarm" "api_server_exception" {
 }
 
 resource "aws_cloudwatch_metric_alarm" "database_batch_writer_exception" {
-  count = var.enable_alarms == "true" ? 1 : 0 # Don't create this if we turn off alarms (e.g. for dev)
+  count = var.enable_alarms ? 1 : 0 # Don't create this if we turn off alarms (e.g. for dev)
 
   alarm_name                = "ingester-database encountered a DatabaseBatchWriterException ${var.environment}"
   comparison_operator       = "GreaterThanOrEqualToThreshold"
@@ -160,7 +160,7 @@ resource "aws_cloudwatch_metric_alarm" "database_batch_writer_exception" {
 }
 
 resource "aws_cloudwatch_metric_alarm" "puller_flickr_max_batch_size_exceeded" {
-  count = var.enable_alarms == "true" ? 1 : 0 # Don't create this if we turn off alarms (e.g. for dev)
+  count = var.enable_alarms ? 1 : 0 # Don't create this if we turn off alarms (e.g. for dev)
 
   alarm_name                = "puller-flickr encountered a MaxBatchSizeExceeded error ${var.environment}"
   comparison_operator       = "GreaterThanOrEqualToThreshold"
@@ -183,7 +183,7 @@ resource "aws_cloudwatch_metric_alarm" "puller_flickr_max_batch_size_exceeded" {
 }
 
 resource "aws_cloudwatch_metric_alarm" "puller_flickr_max_neighbors_exceeded" {
-  count = var.enable_alarms == "true" ? 1 : 0 # Don't create this if we turn off alarms (e.g. for dev)
+  count = var.enable_alarms ? 1 : 0 # Don't create this if we turn off alarms (e.g. for dev)
 
   alarm_name                = "puller-flickr encountered a MaxNeighborsExceeded error ${var.environment}"
   comparison_operator       = "GreaterThanOrEqualToThreshold"
@@ -206,7 +206,7 @@ resource "aws_cloudwatch_metric_alarm" "puller_flickr_max_neighbors_exceeded" {
 }
 
 resource "aws_cloudwatch_metric_alarm" "puller_flickr_max_flickr_api_exceptions_exceeded" {
-  count = var.enable_alarms == "true" ? 1 : 0 # Don't create this if we turn off alarms (e.g. for dev)
+  count = var.enable_alarms ? 1 : 0 # Don't create this if we turn off alarms (e.g. for dev)
 
   alarm_name                = "puller-flickr encountered a FlickrApiException error ${var.environment}"
   comparison_operator       = "GreaterThanOrEqualToThreshold"

--- a/terraform/modules/alarms/queues.tf
+++ b/terraform/modules/alarms/queues.tf
@@ -1,5 +1,5 @@
 resource "aws_cloudwatch_metric_alarm" "dead_letter_queue_items" {
-  count = var.enable_alarms == "true" ? length(var.dead_letter_queue_names) : 0 # Don't create this if we turn off alarms (e.g. for dev)
+  count = var.enable_alarms ? length(var.dead_letter_queue_names) : 0 # Don't create this if we turn off alarms (e.g. for dev)
 
   alarm_name                = "${element(var.dead_letter_queue_names, count.index)} items" # Need to have a different name for each one, or else we only see one in the UI
   comparison_operator       = "GreaterThanOrEqualToThreshold"
@@ -21,7 +21,7 @@ resource "aws_cloudwatch_metric_alarm" "dead_letter_queue_items" {
 }
 
 resource "aws_cloudwatch_metric_alarm" "queue_item_size" {
-  count = var.enable_alarms == "true" ? length(var.queue_names) : 0 # Don't create this if we turn off alarms (e.g. for dev)
+  count = var.enable_alarms ? length(var.queue_names) : 0 # Don't create this if we turn off alarms (e.g. for dev)
 
   alarm_name                = "${element(var.queue_names, count.index)} item size" # Need to have a different name for each one, or else we only see one in the UI
   comparison_operator       = "GreaterThanOrEqualToThreshold"
@@ -43,7 +43,7 @@ resource "aws_cloudwatch_metric_alarm" "queue_item_size" {
 }
 
 resource "aws_cloudwatch_metric_alarm" "queue_item_age" {
-  count = var.enable_alarms == "true" ? length(var.queue_names) : 0 # Don't create this if we turn off alarms (e.g. for dev)
+  count = var.enable_alarms ? length(var.queue_names) : 0 # Don't create this if we turn off alarms (e.g. for dev)
 
   alarm_name                = "${element(var.queue_names, count.index)} item age" # Need to have a different name for each one, or else we only see one in the UI
   comparison_operator       = "GreaterThanOrEqualToThreshold"

--- a/terraform/modules/alarms/variables.tf
+++ b/terraform/modules/alarms/variables.tf
@@ -14,6 +14,7 @@ variable "alarms_email" {
 }
 
 variable "enable_alarms" {
+  type = bool
 }
 
 variable "unhandled_exceptions_threshold" {

--- a/terraform/modules/api-server/variables.tf
+++ b/terraform/modules/api-server/variables.tf
@@ -90,6 +90,7 @@ variable "bucketname_user_string" {
 }
 
 variable "retain_load_balancer_access_logs_after_destroy" {
+  type = bool
 }
 
 variable "default_num_photo_recommendations" {

--- a/terraform/modules/build-common-infrastructure/variables.tf
+++ b/terraform/modules/build-common-infrastructure/variables.tf
@@ -17,6 +17,7 @@ variable "bucketname_user_string" {
 }
 
 variable "retain_build_logs_after_destroy" {
+  type = bool
 }
 
 variable "days_to_keep_build_logs" {

--- a/terraform/modules/frontend/variables.tf
+++ b/terraform/modules/frontend/variables.tf
@@ -32,6 +32,7 @@ variable "frontend_access_logs_bucket" {
 }
 
 variable "retain_frontend_access_logs_after_destroy" {
+  type = bool
 }
 
 variable "days_to_keep_frontend_access_logs" {
@@ -41,6 +42,7 @@ variable "bucketname_user_string" {
 }
 
 variable "use_custom_domain" {
+  type = bool
 }
 
 variable "ssl_certificate_body" {

--- a/terraform/modules/memcached/outputs.tf
+++ b/terraform/modules/memcached/outputs.tf
@@ -1,9 +1,13 @@
 output "location" {
   # Ugly syntax here for referencing a resource that may not exist. See https://github.com/hashicorp/terraform/issues/16726
+  # With terraform 0.12 we could use their new short-circuiting conditional logic to simplify this expression, since we wouldn't 
+  # run into an issue anymore of having the conditional reference a resource that wasn't created. However, that would mean putting the test
+  # that determines whether the resource is created or not in two places. So this method seems more rebust even though it's harder to read.
+  #
   # Puts "localhost:11211" in this attribute if the memcached cluster wasn't created. The script will attempt to connect to there, fail, and continue in that case
-  # Also note that all variables are internally stored as strings, so having the port as an int results in a strange error message: https://github.com/hashicorp/terraform/issues/17033
+  
   value = format(
-    "%s:%s",
+    "%s:%d",
     element(
       concat(
         aws_elasticache_cluster.memcached.*.cluster_address,
@@ -12,7 +16,7 @@ output "location" {
       0,
     ),
     element(
-      concat(aws_elasticache_cluster.memcached.*.port, ["11211"]),
+      concat(aws_elasticache_cluster.memcached.*.port, [11211]),
       0,
     ),
   )

--- a/terraform/modules/mysql/mysql.tf
+++ b/terraform/modules/mysql/mysql.tf
@@ -17,7 +17,7 @@ resource "aws_db_instance" "mysql_database" {
   storage_type      = var.storage_type
 
   storage_encrypted = var.storage_encrypted
-  kms_key_id        = var.storage_encrypted ? var.kms_key_arn : "" # Luckily we're able to use "" here to denote an empty field. Support for a null value is coming in terraform 0.12: https://github.com/hashicorp/terraform/issues/14037
+  kms_key_id        = var.storage_encrypted ? var.kms_key_arn : null
 
   engine               = "mysql"
   engine_version       = "8.0"

--- a/terraform/modules/task-definition/task-definition.tf
+++ b/terraform/modules/task-definition/task-definition.tf
@@ -44,30 +44,7 @@ resource "aws_iam_role_policy_attachment" "attach-extra-policy" {
   policy_arn = var.instances_extra_policy_arn
 }
 
-# terraform 0.11 doesn't have support for dynamic blocks yet, and we need to use a block to describe our optional load balancer.
-# So instead we'll have to copy & paste our resource and use the count field to pick one or the other to be created.
-# Dynamic blocks are coming in terraform 0.12: https://github.com/hashicorp/terraform/issues/7034
-
-resource "aws_ecs_service" "ecs_service_no_load_balancer" {
-  count = var.has_load_balancer ? 0 : 1
-
-  name    = var.name
-  cluster = var.cluster_id
-  task_definition = "${aws_ecs_task_definition.task_definition.family}:${max(
-    aws_ecs_task_definition.task_definition.revision,
-    data.aws_ecs_task_definition.task_definition.revision,
-  )}"
-  desired_count = var.instances_desired_count
-  # Consider putting this in if we see this stuff getting rebuilt every run when we don't want to. 
-  # Note then that there will be an extra step when we change the task definition: https://github.com/terraform-providers/terraform-provider-aws/issues/1274
-  #lifecycle {
-  #    ignore_changes = ["task_definition"] # the same here, do nothing if it was already installed
-  #}
-}
-
-resource "aws_ecs_service" "ecs_service_with_load_balancer" {
-  count = var.has_load_balancer ? 1 : 0
-
+resource "aws_ecs_service" "ecs_service" {
   name    = var.name
   cluster = var.cluster_id
   task_definition = "${aws_ecs_task_definition.task_definition.family}:${max(
@@ -76,10 +53,13 @@ resource "aws_ecs_service" "ecs_service_with_load_balancer" {
   )}"
   desired_count = var.instances_desired_count
 
-  load_balancer {
-    target_group_arn = var.load_balancer_target_group_arn
-    container_name   = var.name
-    container_port   = var.load_balancer_container_port
+  dynamic "load_balancer" {
+    for_each = var.has_load_balancer ? [1] : []
+    content {
+      target_group_arn = var.load_balancer_target_group_arn
+      container_name   = var.name
+      container_port   = var.load_balancer_container_port
+    }
   }
   # Consider putting this in if we see this stuff getting rebuilt every run when we don't want to. 
   # Note then that there will be an extra step when we change the task definition: https://github.com/terraform-providers/terraform-provider-aws/issues/1274

--- a/terraform/prod/main.tf
+++ b/terraform/prod/main.tf
@@ -1,7 +1,7 @@
 module "vpc" {
   source = "../modules/vpc"
 
-  vpc_name    = "photo-recommender"
+  vpc_name    = var.application_name
   environment = var.environment
 
   cidr_block = "10.10.0.0/16"
@@ -33,7 +33,7 @@ module "build-common-infrastructure" {
   project_github_location  = var.project_github_location
   s3_deployment_bucket_arn = module.frontend.s3_deployment_bucket_arn
 
-  build_logs_bucket               = "photo-recommender-build-logs"
+  build_logs_bucket               = "${var.application_name}-build-logs"
   bucketname_user_string          = var.bucketname_user_string
   retain_build_logs_after_destroy = false # For dev, we don't care about retaining these logs after doing a terraform destroy
   days_to_keep_build_logs         = 90
@@ -44,7 +44,7 @@ module "elastic_container_service" {
 
   environment  = var.environment
   region       = var.region
-  cluster_name = "photo-recommender"
+  cluster_name = var.application_name
 
   vpc_id                = module.vpc.vpc_id
   vpc_public_subnet_ids = module.vpc.vpc_public_subnet_ids
@@ -72,7 +72,7 @@ module "database" {
   vpc_cidr              = module.vpc.vpc_cidr_block
   local_machine_cidr    = var.local_machine_cidr
 
-  mysql_database_name                = "photorecommender"
+  mysql_database_name                = var.application_name_no_hyphens
   mysql_instance_type                = "db.m5.large" #"db.t2.micro" 
   mysql_storage_encrypted            = false         # db.t2.micro doesn't support encryption at rest -- needs to be at least db.t2.small
   mysql_storage_type                 = "gp2"         # General purpose SSD
@@ -345,7 +345,7 @@ module "api_server" {
 
   retain_load_balancer_access_logs_after_destroy = false # For dev, we don't care about retaining these logs after doing a terraform destroy
   load_balancer_days_to_keep_access_logs         = 30
-  load_balancer_access_logs_bucket               = "photo-recommender-load-balancer-access-logs"
+  load_balancer_access_logs_bucket               = "${var.application_name}-load-balancer-access-logs"
   load_balancer_access_logs_prefix               = "api-server-lb"
   bucketname_user_string                         = var.bucketname_user_string
 
@@ -395,7 +395,7 @@ module "frontend" {
   bucketname_user_string = var.bucketname_user_string
 
   application_domain = var.dns_address
-  application_name   = "photo-recommender"
+  application_name   = var.application_name
 
   days_to_keep_old_versions = 1
 
@@ -404,7 +404,7 @@ module "frontend" {
   load_balancer_port     = module.api_server.load_balancer_port
   load_balancer_zone_id  = module.api_server.load_balancer_zone_id
 
-  frontend_access_logs_bucket               = "photo-recommender-frontend-access-logs"
+  frontend_access_logs_bucket               = "${var.application_name}-frontend-access-logs"
   retain_frontend_access_logs_after_destroy = false # For dev, we don't care about retaining these logs after doing a terraform destroy
   days_to_keep_frontend_access_logs         = 30
 
@@ -458,7 +458,7 @@ module "alarms" {
   enable_alarms = true
 
   metrics_namespace = var.metrics_namespace
-  topic_name        = "photo-recommender"
+  topic_name        = var.application_name
   alarms_email      = var.alarms_email
 
   unhandled_exceptions_threshold = 1

--- a/terraform/prod/main.tf
+++ b/terraform/prod/main.tf
@@ -35,7 +35,7 @@ module "build-common-infrastructure" {
 
   build_logs_bucket               = "photo-recommender-build-logs"
   bucketname_user_string          = var.bucketname_user_string
-  retain_build_logs_after_destroy = "false" # For dev, we don't care about retaining these logs after doing a terraform destroy
+  retain_build_logs_after_destroy = false # For dev, we don't care about retaining these logs after doing a terraform destroy
   days_to_keep_build_logs         = 90
 }
 
@@ -343,7 +343,7 @@ module "api_server" {
   flickr_api_memcached_ttl       = 7200
   flickr_auth_memcached_location = module.memcached.location
 
-  retain_load_balancer_access_logs_after_destroy = "false" # For dev, we don't care about retaining these logs after doing a terraform destroy
+  retain_load_balancer_access_logs_after_destroy = false # For dev, we don't care about retaining these logs after doing a terraform destroy
   load_balancer_days_to_keep_access_logs         = 30
   load_balancer_access_logs_bucket               = "photo-recommender-load-balancer-access-logs"
   load_balancer_access_logs_prefix               = "api-server-lb"
@@ -405,10 +405,10 @@ module "frontend" {
   load_balancer_zone_id  = module.api_server.load_balancer_zone_id
 
   frontend_access_logs_bucket               = "photo-recommender-frontend-access-logs"
-  retain_frontend_access_logs_after_destroy = "false" # For dev, we don't care about retaining these logs after doing a terraform destroy
+  retain_frontend_access_logs_after_destroy = false # For dev, we don't care about retaining these logs after doing a terraform destroy
   days_to_keep_frontend_access_logs         = 30
 
-  use_custom_domain           = "true"
+  use_custom_domain           = true
   ssl_certificate_body        = var.ssl_certificate_body
   ssl_certificate_private_key = var.ssl_certificate_private_key
   ssl_certificate_chain       = var.ssl_certificate_chain
@@ -455,7 +455,7 @@ module "alarms" {
   environment = var.environment
   region      = var.region
 
-  enable_alarms = "true"
+  enable_alarms = true
 
   metrics_namespace = var.metrics_namespace
   topic_name        = "photo-recommender"

--- a/terraform/prod/variables.tf
+++ b/terraform/prod/variables.tf
@@ -13,6 +13,14 @@ variable "environment_long_name" {
 variable "alarms_email" {
 }
 
+variable "application_name" {
+  default = "photo-recommender"
+}
+
+variable "application_name_no_hyphens" {
+  default = "photorecommender"
+}
+
 variable "metrics_namespace" {
   default = "Photo Recommender"
 }


### PR DESCRIPTION
- Change string "booleans" to actual booleans
- Use new dynamic blocks to simplify ECS task resources
- Cleanup memcached location specification a little
- Refactor application name into its own variable so it's not repeated