### PR TITLE
Moved the prod domain and cert generation into AWS

### DIFF
--- a/README.md
+++ b/README.md
@@ -92,7 +92,7 @@ Copy the file `terraform/terraform.tfvars.example` to `terraform/terraform.tfvar
 - Enter the github address of your fork of this project
 - Fill in your Flickr API key and secret: https://www.flickr.com/services/apps/create/apply
 - Fill in a master password for the various databases
-- If you're going to make a prod instance with a real domain, create an SSL certificate and fill in the details. There's good instructions here: https://itnext.io/using-letsencrypt-ssl-certificates-in-aws-certificate-manager-c2bc3c6ae10
+- If you're going to make a prod instance with a real domain, register that domain using AWS's Route53 manually and fill in the domain name in this file.
 - Fill in a 256-bit AES encryption key, used to encrypt user session data. Can be obtained from https://www.allkeysgenerator.com/Random/Security-Encryption-Key-Generator.aspx for example
 - Fill in a 256-bit AES encryption key, used to encrypt user access tokens in the database. Can be obtained from the same place as the above
 
@@ -239,7 +239,6 @@ Point your browser there and enjoy!
 - Consider normalizing the `favorites` table by splitting it into a table that just has the photos, and another table of who's favorited them
   - What is the impact on write throughput of this change?
 - Highlight new recommendations by moving them to the top of the list. Maybe have a "first recommended on" field per user, and use that to boost score?
-- Move the domain into route53 and the SSL certificate into the AWS certificate manager
 - Investigate why puller-flickr often has such a long max time to process a single user
 - Remove already-favorited images from the AddFavorites screen
 - Add logout to the navigation bar

--- a/terraform/dev/main.tf
+++ b/terraform/dev/main.tf
@@ -409,9 +409,6 @@ module "frontend" {
   days_to_keep_frontend_access_logs         = 1
 
   use_custom_domain           = false
-  ssl_certificate_body        = var.ssl_certificate_body
-  ssl_certificate_private_key = var.ssl_certificate_private_key
-  ssl_certificate_chain       = var.ssl_certificate_chain
 
   project_github_location = var.project_github_location
   build_logs_bucket_id    = module.build-common-infrastructure.build_logs_bucket_id

--- a/terraform/dev/variables.tf
+++ b/terraform/dev/variables.tf
@@ -61,15 +61,6 @@ variable "database_user_data_encryption_key_prod" {
 variable "api_server_session_encryption_key_prod" {
 }
 
-variable "ssl_certificate_body" {
-}
-
-variable "ssl_certificate_private_key" {
-}
-
-variable "ssl_certificate_chain" {
-}
-
 variable "project_github_location" {
 }
 

--- a/terraform/modules/frontend/dns.tf
+++ b/terraform/modules/frontend/dns.tf
@@ -1,17 +1,42 @@
+provider "aws" {
+  # Certificates need to be in us-east-1
+  # https://github.com/hashicorp/terraform/issues/10957
+  region = "us-east-1"
+  alias  = "use1"
+}
+
+resource "aws_acm_certificate" "cert" {
+  provider          = aws.use1
+  count             = var.use_custom_domain ? 1 : 0
+  domain_name       = var.application_domain
+  validation_method = "DNS"
+
+  options {
+    certificate_transparency_logging_preference = "ENABLED"
+  }
+}
+
 resource "aws_route53_zone" "primary" {
   name          = var.application_domain
   force_destroy = true
 }
 
-resource "aws_route53_record" "cloudfront" {
+resource "aws_route53_record" "cert_validation" {
+  count   = var.use_custom_domain ? 1 : 0
   zone_id = aws_route53_zone.primary.zone_id
-  name    = var.application_domain
-  type    = "A"
-
-  alias {
-    name                   = aws_cloudfront_distribution.application.domain_name
-    zone_id                = aws_cloudfront_distribution.application.hosted_zone_id
-    evaluate_target_health = true
-  }
+  name    = aws_acm_certificate.cert[count.index].domain_validation_options.0.resource_record_name
+  type    = aws_acm_certificate.cert[count.index].domain_validation_options.0.resource_record_type
+  records = [aws_acm_certificate.cert[count.index].domain_validation_options.0.resource_record_value]
+  ttl     = 60
 }
 
+resource "aws_acm_certificate_validation" "cert" {
+  provider                = aws.use1
+  count                   = var.use_custom_domain ? 1 : 0
+  certificate_arn         = aws_acm_certificate.cert[count.index].arn
+  validation_record_fqdns = [aws_route53_record.cert_validation[count.index].fqdn]
+
+  timeouts {
+    create = "24h" # Validation can take hours: https://aws.amazon.com/blogs/security/easier-certificate-validation-using-dns-with-aws-certificate-manager/
+  }
+}

--- a/terraform/modules/frontend/variables.tf
+++ b/terraform/modules/frontend/variables.tf
@@ -45,15 +45,6 @@ variable "use_custom_domain" {
   type = bool
 }
 
-variable "ssl_certificate_body" {
-}
-
-variable "ssl_certificate_private_key" {
-}
-
-variable "ssl_certificate_chain" {
-}
-
 variable "project_github_location" {
 }
 

--- a/terraform/prod/main.tf
+++ b/terraform/prod/main.tf
@@ -54,10 +54,10 @@ module "elastic_container_service" {
 
   extra_security_groups = [module.api_server.security_group_id]
 
-  instance_type                = "c5.large" #"t2.micro"
-  cluster_desired_size         = 20         #0#2#20
+  instance_type                = "t2.micro" #"c5.large" #"t2.micro"
+  cluster_desired_size         = 2#20         #0#2#20
   cluster_min_size             = 0
-  cluster_max_size             = 20 #0#2#20
+  cluster_max_size             = 2#20 #0#2#20
   instances_log_retention_days = 1
 }
 
@@ -134,7 +134,7 @@ module "scheduler" {
   puller_response_queue_long_polling_seconds = 1  # Don't do long polling for too long: we can only write out our batches to the API server after we find no more new messages
 
   max_iterations_before_exit  = 1000
-  sleep_ms_between_iterations = 500
+  min_sleep_ms_between_iterations = 500
 
   duration_to_request_lock_seconds = 10
 
@@ -409,9 +409,6 @@ module "frontend" {
   days_to_keep_frontend_access_logs         = 30
 
   use_custom_domain           = true
-  ssl_certificate_body        = var.ssl_certificate_body
-  ssl_certificate_private_key = var.ssl_certificate_private_key
-  ssl_certificate_chain       = var.ssl_certificate_chain
 
   project_github_location = var.project_github_location
   build_logs_bucket_id    = module.build-common-infrastructure.build_logs_bucket_id

--- a/terraform/prod/variables.tf
+++ b/terraform/prod/variables.tf
@@ -61,15 +61,6 @@ variable "database_user_data_encryption_key_prod" {
 variable "api_server_session_encryption_key_prod" {
 }
 
-variable "ssl_certificate_body" {
-}
-
-variable "ssl_certificate_private_key" {
-}
-
-variable "ssl_certificate_chain" {
-}
-
 variable "project_github_location" {
 }
 

--- a/terraform/terraform.tfvars.example
+++ b/terraform/terraform.tfvars.example
@@ -31,13 +31,3 @@ api_server_session_encryption_key_prod = ""
 
 # The domain under which instances (dev, prod) of the application will run as subdomains
 dns_address = "abc123.com"
-
-# ssl certificate. Good instructions on getting one from LetsEncrypt here: https://itnext.io/using-letsencrypt-ssl-certificates-in-aws-certificate-manager-c2bc3c6ae10
-ssl_certificate_body = <<EOF
-EOF
-
-ssl_certificate_private_key = <<EOF
-EOF
-
-ssl_certificate_chain = <<EOF
-EOF


### PR DESCRIPTION
Previously, I had made the domain in GoDaddy (not knowing I could do it in AWS), and then the cert with Let's Encrypt. After 90 days I was able to transfer the domain to AWS

- Moved domain into Route53
- Rather than add a cert to `terraform.tfvars`, have the cert be generated by terraform
- Added certificate validation to the terraform
- Refactored the frontend terraform a little to have the DNS stuff in one spot
- Small terraform fix
